### PR TITLE
Add Antigravity/Z.ai limits, pane defaults, and Japanese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 ![herdr 0.7+](https://img.shields.io/badge/herdr-0.7%2B-6E56CF)
 ![platforms: linux | macOS](https://img.shields.io/badge/platforms-linux%20%7C%20macOS-lightgrey)
 
+**English** | [日本語](README_JP.md)
+
 Monitor context usage and provider rate limits for agents running in [Herdr](https://herdr.dev).
 
 ![Agent Usage pane showing provider limits and per-pane activity shares](docs/assets/agent-usage-pane.png)
 
-- **Per-pane context meters** — every agent pane's sidebar label shows how much of its context window the session is using (`⛁ 13% (130k)` = 130k tokens, 13% of the window), updated after each completed turn.
-- **Account rate-limit windows at a glance** — one live pane shows how much 5h / 7d / 30d allowance is left for Claude, Codex, OpenCode Go, and Grok, with reset countdowns and which open pane is burning it.
+- **Per-pane context meters** — every supported agent pane's sidebar label shows how much of its context window the session is using (`⛁ 13% (130k)` = 130k tokens, 13% of the window), updated after each completed turn. Codex and Grok labels show their most constrained account allowance; Antigravity/`agy` shows its 5-hour allowance.
+- **Account rate-limit windows at a glance** — one live pane shows how much 5h / 7d / 30d allowance is left for Codex, Antigravity, Z.ai, and Grok, with reset countdowns and which open pane is burning it. Claude and OpenCode collectors remain available but are hidden from the plugin pane by default.
 - **Low-allowance warnings** — optional toasts fire when a window drops below your thresholds (default 50 / 20 / 10 / 5 % left), before you hit the wall mid-task.
 
 ## Requirements
@@ -56,7 +58,7 @@ The agent can install the plugin and guide you through the remaining setup.
 
 1. Install the plugin and run **setup** (above).
 2. Open a workspace with at least one agent pane.
-3. After an agent turn completes (or you focus the pane), the sidebar custom status shows context usage.
+3. After an agent turn completes (or you focus the pane), the sidebar custom status shows context usage. Account allowance is included in supported agent labels, for example `codex 7%`, `grok 94%`, or `agy 100%`.
 4. Open the limits pane:
 
 ```bash
@@ -100,6 +102,7 @@ herdr plugin action invoke usagebar.setup
 
 | Surface | What it shows |
 | --- | --- |
+| **Sidebar agent label** | Account allowance: most constrained window for Codex/Grok, 5-hour window for Antigravity/`agy` |
 | **Sidebar custom status** | Per-pane context usage: `⛁ 13% (130k)` when the window size is known, or the token count alone |
 | **Agent Usage pane** | Provider plan, usage windows (5h / 7d / 30d), remaining % bars, reset countdown, open-pane token share |
 | **Toasts** (optional) | Remaining-limit warnings at configured thresholds (default 50 / 20 / 10 / 5 % left) |
@@ -108,16 +111,39 @@ herdr plugin action invoke usagebar.setup
 
 | Agent | Sidebar context | Limits pane | Notes |
 | --- | --- | --- | --- |
-| Claude Code | Yes | Yes | Rate windows from `~/.claude.json` / statusLine cache |
+| Claude Code | Yes | Hidden by default | Rate windows from `~/.claude.json` / statusLine cache |
 | Codex | Yes | Yes | Context + rate windows from local rollouts |
-| OpenCode Go | Yes | Yes | Prefer official web usage when `OPENCODE_GO_COOKIE` is set; else local SQLite |
-| Grok | Yes | Yes | Context from `signals.json`; credits from grok.com when auth is present |
+| Antigravity | Label only | Yes | `agy` label uses the 5-hour allowance; local quota API requires a running process and `lsof` |
+| Z.ai | No | Yes | Coding-plan quota API; set `Z_AI_API_KEY` |
+| OpenCode Go | Yes | Hidden by default | Prefer official web usage when `OPENCODE_GO_COOKIE` is set; else local SQLite |
+| Grok | Yes | Yes | Label uses the most constrained allowance; context comes from `signals.json` |
 
 Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
+
+### Z.ai setup
+
+Set `Z_AI_API_KEY` in the environment that starts Herdr. Optional settings mirror CodexBar:
+
+- `Z_AI_API_REGION=bigmodel-cn` selects `open.bigmodel.cn`; the default is `api.z.ai`.
+- `Z_AI_API_HOST` overrides the API host, and `Z_AI_QUOTA_URL` overrides the full quota URL. Credential-bearing overrides must use HTTPS.
+- Team usage requires `Z_AI_USAGE_SCOPE=team`, `Z_AI_BIGMODEL_ORGANIZATION`, and `Z_AI_BIGMODEL_PROJECT`.
+
+Antigravity needs no external credentials. The collector probes only `127.0.0.1` and accepts the local server's self-signed TLS certificate. Start the Antigravity app, IDE, or authenticated `agy` process before refreshing limits.
 
 ## Agent Usage pane
 
 - Auto-refreshes every **15s**. Press **`r`** to refresh, **`q`** to quit.
+- The plugin pane shows every supported provider except Claude and OpenCode, including providers without a matching open Herdr agent pane.
+- Claude and OpenCode support code is not removed. The default exclusions are launch arguments in [`bin/run-limits-pane.sh`](bin/run-limits-pane.sh).
+- Direct CLI users can show every collector by omitting exclusions, or hide providers by repeating `--exclude-provider <id>`:
+
+```bash
+bin/usagebar limits --once --all
+bin/usagebar limits --once --all \
+  --exclude-provider claude \
+  --exclude-provider opencode
+```
+
 - OpenCode Go may show three windows (**5h / 7d / 30d**). Other providers show whichever usage windows their data sources make available.
 - Open pane **token share** is local activity share within the shortest window (including a **closed / other** bucket for usage outside open panes). It is not account quota attribution.
 - Sidebar context meters update after the agent has **settled** (not while `working`), so the label matches the last completed turn. If the session cannot be resolved, the custom status is cleared rather than showing another session’s numbers.
@@ -127,6 +153,18 @@ herdr plugin action invoke usagebar.open-limits
 ```
 
 ## Configuration
+
+### Provider visibility
+
+The Herdr plugin pane runs with these defaults:
+
+```bash
+usagebar limits --all \
+  --exclude-provider claude \
+  --exclude-provider opencode
+```
+
+`--all` collects providers even when they have no matching open Herdr agent pane. `--exclude-provider` only filters rendering; it does not delete or disable the collector.
 
 ### Plugin config
 
@@ -208,12 +246,14 @@ lint, and vulnerability checks before it creates a GitHub Release.
 
 ## Data handling
 
-Everything is computed from files that the agents already keep on your machine:
+Context usage is computed from files that the agents already keep on your machine. Provider limits may also come from authenticated or loopback-only APIs:
 
 | Provider | Local sources read |
 | --- | --- |
 | Claude Code | `~/.claude.json`, statusLine cache under `~/.claude/herdr-usagebar/` |
 | Codex | rollout files under `~/.codex/sessions/` |
+| Antigravity | Running Antigravity/`agy` process flags and its `127.0.0.1` quota API |
+| Z.ai | `Z_AI_API_KEY` and optional region/team environment variables; no local usage file |
 | OpenCode Go | `~/.local/share/opencode/opencode.db` |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch) |
 
@@ -221,13 +261,15 @@ Network requests happen in the following cases:
 
 - `opencode.ai` — only when you set `OPENCODE_GO_COOKIE`
 - `grok.com` — only when `~/.grok/auth.json` exists (you ran `grok login`)
+- `api.z.ai` or `open.bigmodel.cn` — only when `Z_AI_API_KEY` is set; credential-bearing endpoint overrides must use HTTPS
+- `127.0.0.1` — Antigravity/`agy` local quota probing; self-signed TLS is accepted only for this fixed loopback target
 - `api.github.com` — on the first pane focus and then at most once every 24 hours, to check this plugin's latest public release. The request has no credentials and sends no usage or session data.
 
 No telemetry, no analytics, or usage/session data is sent. State written by the plugin (config, notification state, update-check state, usage history) stays under `~/.config/herdr/plugins/config/usagebar/` and `~/.claude/herdr-usagebar/`.
 
 ## Limitations
 
-- **Not a billing dashboard.** Local transcripts / rollouts / signals (and optional OpenCode web / Grok.com credits) can differ from official consoles (other machines, server-side windows).
+- **Not a billing dashboard.** Local transcripts / rollouts / signals and provider quota APIs can differ from official consoles (other machines, server-side windows, or API changes).
 - **Herdr core config is not rewritten on install.** Use `usagebar.setup` / `usagebar.enable-toast` or edit by hand.
 - **macOS / Linux** only.
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,0 +1,276 @@
+# Agent Usage
+
+[![CI](https://github.com/senna-lang/herdr-agent-usage/actions/workflows/ci.yml/badge.svg)](https://github.com/senna-lang/herdr-agent-usage/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)
+![herdr 0.7+](https://img.shields.io/badge/herdr-0.7%2B-6E56CF)
+![platforms: linux | macOS](https://img.shields.io/badge/platforms-linux%20%7C%20macOS-lightgrey)
+
+[English](README.md) | **日本語**
+
+[Herdr](https://herdr.dev) 上で動くエージェントのコンテキスト使用量と、プロバイダーのレート制限を監視します。
+
+![プロバイダー制限とペインごとの活動シェアを表示する Agent Usage ペイン](docs/assets/agent-usage-pane.png)
+
+- **ペインごとのコンテキストメーター** — 対応エージェントのサイドバーラベルに、セッションがコンテキストウィンドウの何割を使っているかを表示します（`⛁ 13% (130k)` = 130k トークン、ウィンドウの 13%）。各ターン完了後に更新されます。Codex / Grok のラベルは最も制約の厳しいアカウント枠、Antigravity/`agy` は 5 時間枠を表示します。
+- **アカウントのレート制限ウィンドウを一覧** — 1 つのライブペインで、Codex / Antigravity / Z.ai / Grok の 5h / 7d / 30d 残量、リセットまでのカウントダウン、どのオープンペインが消費しているかを表示します。Claude と OpenCode のコレクターは利用可能ですが、プラグインペインではデフォルトで非表示です。
+- **残量低下の警告** — 任意のトースト通知で、閾値を下回ったときに知らせます（デフォルトは残り 50 / 20 / 10 / 5 %）。タスクの途中で壁に当たる前に気づけます。
+
+## 要件
+
+- **Herdr ≥ 0.7.0**
+- **macOS または Linux**
+- セッション照合を安定させるためのエージェント連携（推奨）:
+
+```bash
+herdr integration install codex
+herdr integration install opencode
+# Claude ペインを使う場合は Claude Code 連携も推奨
+```
+
+## インストール
+
+```bash
+herdr plugin install senna-lang/herdr-agent-usage
+# 非対話シェル（CI、コーディングエージェント）では --yes が必要
+```
+
+プラグインのインストールだけでは `~/.config/herdr/config.toml`（トースト配信、キーバインド）は書き換えられません。インストール後にセットアップを実行してください:
+
+```bash
+herdr plugin action invoke usagebar.setup
+# 任意: 未設定ならトースト配信を追記
+herdr plugin action invoke usagebar.enable-toast
+herdr server reload-config
+```
+
+`usagebar.setup` は初回実行時に `usagebar` バイナリを自動解決します。ローカルに Go ツールチェーン（≥ 1.25）があればビルドし、なければ [GitHub Releases](https://github.com/senna-lang/herdr-agent-usage/releases) からプリビルドバイナリをダウンロードします（macOS / Linux、arm64 / amd64）。手動ビルドする場合は、プラグインルートで `make build` を実行してください。
+
+## LLM にセットアップさせる
+
+[docs/LLM-SETUP.md](docs/LLM-SETUP.md) のプロンプトを LLM コーディングエージェントに貼り付けてください。
+エージェントがプラグインをインストールし、残りのセットアップを案内します。
+
+- **トースト:** トースト通知を有効にする前に、エージェントは必ず承認を求めてください。
+- **キーバインド:** 推奨ショートカットは、制限ペインを開く `ctrl+shift+u` と、メーターを更新する `ctrl+shift+m` です（単一コード、Herdr プレフィックスなし）。どちらかが既に使われている場合、エージェントは代わりのショートカットを確認してください。
+
+## クイックスタート
+
+1. プラグインをインストールし、上記の **setup** を実行します。
+2. エージェントペインを 1 つ以上含むワークスペースを開きます。
+3. エージェントのターンが完了する（またはペインにフォーカスする）と、サイドバーのカスタムステータスにコンテキスト使用量が表示されます。対応エージェントのラベルにはアカウント枠も含まれます（例: `codex 7%`、`grok 94%`、`agy 100%`）。
+4. 制限ペインを開きます:
+
+```bash
+herdr plugin action invoke usagebar.open-limits
+```
+
+5. 任意のキーバインドを **自分の** `~/.config/herdr/config.toml` に追加します:
+
+```toml
+[[keys.command]]
+key = "ctrl+shift+u"
+type = "plugin_action"
+command = "usagebar.open-limits"
+description = "Agent Usage: open limits pane"
+
+[[keys.command]]
+key = "ctrl+shift+m"
+type = "plugin_action"
+command = "usagebar.refresh"
+description = "Agent Usage: refresh sidebar meters"
+```
+
+Mac では **Control+Shift+U** / **Control+Shift+M** です（Command ではありません）。その後 `herdr server reload-config` を実行します。
+
+## アクション
+
+| アクション | コマンド | 内容 |
+| --- | --- | --- |
+| 制限ペインを開く | `usagebar.open-limits` | プロバイダーウィンドウ付きの分割ペインを開く |
+| メーターを更新 | `usagebar.refresh` | 対象ペインのサイドバーカスタムステータスを再計算 |
+| セットアップ | `usagebar.setup` | プラグイン設定を初期化し、トースト/キーのスニペットを表示、Herdr トースト状態を報告 |
+| トーストを有効化 | `usagebar.enable-toast` | `[ui.toast]` が無いときだけ追記（上書きしない） |
+| 更新を確認 | `usagebar.check-updates` | GitHub Releases を今すぐ確認し、リリース/更新手順を表示 |
+
+```bash
+herdr plugin action list --plugin usagebar
+herdr plugin action invoke usagebar.setup
+```
+
+## 得られるもの
+
+| 表示面 | 内容 |
+| --- | --- |
+| **サイドバーのエージェントラベル** | アカウント枠: Codex/Grok は最も制約の厳しいウィンドウ、Antigravity/`agy` は 5 時間ウィンドウ |
+| **サイドバーのカスタムステータス** | ペインごとのコンテキスト使用量: ウィンドウサイズが分かる場合は `⛁ 13% (130k)`、分からない場合はトークン数のみ |
+| **Agent Usage ペイン** | プロバイダープラン、使用ウィンドウ（5h / 7d / 30d）、残量 % バー、リセットカウントダウン、オープンペインのトークンシェア |
+| **トースト**（任意） | 設定した閾値での残量警告（デフォルトは残り 50 / 20 / 10 / 5 %） |
+
+### 対応エージェント
+
+| エージェント | サイドバーコンテキスト | 制限ペイン | 備考 |
+| --- | --- | --- | --- |
+| Claude Code | あり | デフォルト非表示 | レートウィンドウは `~/.claude.json` / statusLine キャッシュ |
+| Codex | あり | あり | コンテキストとレートウィンドウはローカルの rollout から |
+| Antigravity | ラベルのみ | あり | `agy` ラベルは 5 時間枠。ローカルクォータ API には起動中プロセスと `lsof` が必要 |
+| Z.ai | なし | あり | Coding-plan のクォータ API。`Z_AI_API_KEY` を設定 |
+| OpenCode Go | あり | デフォルト非表示 | `OPENCODE_GO_COOKIE` がある場合は公式 Web 使用量を優先、なければローカル SQLite |
+| Grok | あり | あり | ラベルは最も制約の厳しい枠。コンテキストは `signals.json` から |
+
+制限ペインのパーセンテージは **残量**（`% left`）です。高いほど安全です。
+
+### Z.ai の設定
+
+Herdr を起動する環境に `Z_AI_API_KEY` を設定します。任意設定は CodexBar と同様です:
+
+- `Z_AI_API_REGION=bigmodel-cn` で `open.bigmodel.cn` を選択（デフォルトは `api.z.ai`）。
+- `Z_AI_API_HOST` で API ホストを上書き、`Z_AI_QUOTA_URL` でクォータ URL 全体を上書き。認証情報を含む上書きは HTTPS 必須です。
+- チーム利用には `Z_AI_USAGE_SCOPE=team`、`Z_AI_BIGMODEL_ORGANIZATION`、`Z_AI_BIGMODEL_PROJECT` が必要です。
+
+Antigravity に外部クレデンシャルは不要です。コレクターは `127.0.0.1` のみをプローブし、ローカルサーバーの自己署名 TLS 証明書を受け入れます。制限を更新する前に、Antigravity アプリ、IDE、または認証済み `agy` プロセスを起動してください。
+
+## Agent Usage ペイン
+
+- **15 秒**ごとに自動更新。**`r`** で手動更新、**`q`** で終了。
+- プラグインペインは Claude と OpenCode 以外の対応プロバイダーを表示します。対応する Herdr エージェントペインが開いていなくても表示されます。
+- Claude / OpenCode のサポートコードは削除されていません。デフォルト除外は [`bin/run-limits-pane.sh`](bin/run-limits-pane.sh) の起動引数です。
+- CLI を直接使う場合は、除外を付けなければ全コレクターを表示できます。非表示にするには `--exclude-provider <id>` を繰り返します:
+
+```bash
+bin/usagebar limits --once --all
+bin/usagebar limits --once --all \
+  --exclude-provider claude \
+  --exclude-provider opencode
+```
+
+- OpenCode Go は 3 つのウィンドウ（**5h / 7d / 30d**）を表示することがあります。他のプロバイダーは、データソースが提供する使用ウィンドウを表示します。
+- オープンペインの **トークンシェア** は、最短ウィンドウ内でのローカル活動シェアです（オープンペイン外の使用を表す **closed / other** バケットを含む）。アカウントクォータの按分ではありません。
+- サイドバーのコンテキストメーターは、エージェントが **settled** になった後（`working` 中ではない）に更新されるため、ラベルは最後に完了したターンと一致します。セッションを解決できない場合は、別セッションの数値を出さずカスタムステータスをクリアします。
+
+```bash
+herdr plugin action invoke usagebar.open-limits
+```
+
+## 設定
+
+### プロバイダーの表示
+
+Herdr プラグインペインは次のデフォルトで起動します:
+
+```bash
+usagebar limits --all \
+  --exclude-provider claude \
+  --exclude-provider opencode
+```
+
+`--all` は対応する Herdr エージェントペインが無くてもプロバイダーを収集します。`--exclude-provider` は表示のフィルタのみで、コレクターの削除や無効化はしません。
+
+### プラグイン設定
+
+```bash
+herdr plugin config-dir usagebar
+# → ~/.config/herdr/plugins/config/usagebar/config.toml
+```
+
+初回の `usagebar.setup`（または未作成時）で生成されます:
+
+```toml
+[notify]
+enabled = true
+remaining_thresholds = [50, 20, 10, 5]
+```
+
+### Herdr トースト配信
+
+画面上に通知を出すには必要です:
+
+```bash
+herdr plugin action invoke usagebar.enable-toast
+herdr server reload-config
+```
+
+または `~/.config/herdr/config.toml` に手動で貼り付けます:
+
+```toml
+[ui.toast]
+delivery = "herdr" # または "system" / "terminal"
+
+[ui.toast.herdr]
+position = "bottom-left"
+```
+
+`usagebar.enable-toast` は **`[ui.toast]` が無いときだけ追記**します。既存のトースト設定は変更しません。
+
+### OpenCode Go の公式使用量（任意）
+
+OpenCode コンソール由来の数値を使いたい場合は、Cookie リクエストヘッダーを設定します:
+
+```bash
+export OPENCODE_GO_COOKIE='auth=…'
+```
+
+未設定の場合、使用量はローカルの `~/.local/share/opencode/opencode.db` から推定されます（5h ローリング、UTC 週、カレンダー月）。
+
+### Claude statusLine（任意）
+
+Claude の 5h / 7d ウィンドウとトースト用に、status line をこのプラグイン経由にします。既存コマンドを置き換えず、チェーンしてください。
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash /path/to/herdr-agent-usage/bin/run-statusline.sh"
+  }
+}
+```
+
+インストール後、パスは `herdr plugin list` で解決できます（Herdr 設定下のプラグインルート）。`HERDR_PLUGIN_ROOT` が利用可能なら、`usagebar.setup` が貼り付け用コマンドを表示します。
+
+## レート制限アラート
+
+設定した残量レベル（デフォルト **残り 50% / 20% / 10% / 5%**）で、ウィンドウごとに 1 回ずつ発火します。
+
+1. トースト配信を有効化（`usagebar.enable-toast` または手動スニペット）。
+2. **Claude** — 上記の statusLine が利用率をキャッシュして通知します。
+3. **Codex / OpenCode / Grok** — エージェントターンが settled になった後、Claude status line なしでも最短の利用可能ウィンドウに基づいてトーストを出せます。
+
+## リリース（メンテナー向け）
+
+1. `herdr-plugin.toml` の `version` を更新し、コミットして `main` に push します。
+2. クリーンで最新の `main` チェックアウトから `scripts/release.sh vX.Y.Z` を実行します。
+
+スクリプトは、そのコミットの CI 完了を待ってからタグを作成・push します。タグ起動の Release ワークフローは、GitHub Release 作成前に vet / build / test / format / lint / vulnerability チェックを再度実行します。
+
+## データの扱い
+
+コンテキスト使用量は、エージェントが既にマシン上に保持しているファイルから計算します。プロバイダー制限は、認証付き API または loopback のみの API からも取得します:
+
+| プロバイダー | 読み取るローカルソース |
+| --- | --- |
+| Claude Code | `~/.claude.json`、`~/.claude/herdr-usagebar/` 配下の statusLine キャッシュ |
+| Codex | `~/.codex/sessions/` 配下の rollout ファイル |
+| Antigravity | 起動中の Antigravity/`agy` プロセスフラグと `127.0.0.1` のクォータ API |
+| Z.ai | `Z_AI_API_KEY` と任意の region/team 環境変数。ローカル使用量ファイルは無し |
+| OpenCode Go | `~/.local/share/opencode/opencode.db` |
+| Grok | `~/.grok/sessions/**/signals.json`、`~/.grok/auth.json`（クレジット取得用クレデンシャル） |
+
+ネットワークリクエストが発生するケース:
+
+- `opencode.ai` — `OPENCODE_GO_COOKIE` を設定した場合のみ
+- `grok.com` — `~/.grok/auth.json` がある場合のみ（`grok login` 済み）
+- `api.z.ai` または `open.bigmodel.cn` — `Z_AI_API_KEY` を設定した場合のみ。認証情報を含むエンドポイント上書きは HTTPS 必須
+- `127.0.0.1` — Antigravity/`agy` のローカルクォータプローブ。自己署名 TLS はこの固定 loopback 対象のみ許可
+- `api.github.com` — 初回のペインフォーカス時、およびその後最大 24 時間に 1 回、このプラグインの最新公開リリースを確認。認証情報は付けず、使用量やセッションデータも送りません
+
+テレメトリ、分析、使用量/セッションデータの送信はありません。プラグインが書き込む状態（設定、通知状態、更新確認状態、使用履歴）は `~/.config/herdr/plugins/config/usagebar/` と `~/.claude/herdr-usagebar/` にのみ置かれます。
+
+## 制限事項
+
+- **課金ダッシュボードではありません。** ローカルの transcript / rollout / signals とプロバイダーのクォータ API は、公式コンソールと一致しないことがあります（他マシン、サーバー側ウィンドウ、API 変更など）。
+- **インストール時に Herdr 本体の設定は書き換えません。** `usagebar.setup` / `usagebar.enable-toast` を使うか、手で編集してください。
+- **macOS / Linux** のみ。
+
+## ライセンス
+
+[MIT](LICENSE)

--- a/bin/run-limits-pane.sh
+++ b/bin/run-limits-pane.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/run-usagebar.sh" limits "$@"
+exec "$SCRIPT_DIR/run-usagebar.sh" limits --all \
+  --exclude-provider claude \
+  --exclude-provider opencode \
+  "$@"

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -74,9 +74,10 @@ func printUsage(w *os.File) {
 
 Usage:
   usagebar status|update [--force]   Update sidebar custom_status for HERDR_PANE_ID
-  usagebar limits|panel              Interactive limits panel (q quit, r refresh)
+usagebar limits|panel              Interactive limits panel (q quit, r refresh)
                                      Shows providers with an open agent pane;
-                                     --all shows every provider
+                                     --all shows every provider;
+                                     --exclude-provider ID hides one provider
   usagebar limits --once [--all]     Print panel once to stdout
   usagebar notify                    Check non-Claude primary rate-limit toasts
   usagebar check-update --current-version X.Y.Z [--force] [--quiet]
@@ -136,6 +137,33 @@ func flagValue(args []string, flag string) string {
 		}
 	}
 	return ""
+}
+
+func flagValues(args []string, flag string) map[string]bool {
+	values := make(map[string]bool)
+	for i, arg := range args {
+		if arg != flag || i+1 >= len(args) {
+			continue
+		}
+		value := strings.ToLower(strings.TrimSpace(args[i+1]))
+		if value != "" {
+			values[value] = true
+		}
+	}
+	return values
+}
+
+func excludeProviders(providers []limits.ProviderLimits, excluded map[string]bool) []limits.ProviderLimits {
+	if len(excluded) == 0 {
+		return providers
+	}
+	filtered := make([]limits.ProviderLimits, 0, len(providers))
+	for _, provider := range providers {
+		if !excluded[strings.ToLower(provider.ProviderID)] {
+			filtered = append(filtered, provider)
+		}
+	}
+	return filtered
 }
 
 func environment() map[string]string {
@@ -264,6 +292,7 @@ func paintFrame(text string) {
 
 func runLimitsPane(args []string) error {
 	once := hasFlag(args, "--once")
+	excluded := flagValues(args, "--exclude-provider")
 	// Default: show only providers with an open agent pane; --all shows every provider.
 	activeOnly := !hasFlag(args, "--all")
 	layoutFor := func() limits.PanelLayout {
@@ -275,7 +304,7 @@ func runLimitsPane(args []string) error {
 	}
 	if once || !term.IsTerminal(int(os.Stdout.Fd())) {
 		nowMs := time.Now().UnixMilli()
-		providers := collectProviders(nowMs, activeOnly)
+		providers := excludeProviders(collectProviders(nowMs, activeOnly), excluded)
 		text := limits.FormatLimitsPanel(providers, nowMs, layoutFor())
 		fmt.Print(text)
 		if !strings.HasSuffix(text, "\n") {
@@ -311,7 +340,7 @@ func runLimitsPane(args []string) error {
 
 	renderFull := func() {
 		nowMs := time.Now().UnixMilli()
-		cachedProviders = collectProviders(nowMs, activeOnly)
+		cachedProviders = excludeProviders(collectProviders(nowMs, activeOnly), excluded)
 		cachedNowMs = nowMs
 		paintFrame(limits.FormatLimitsPanel(cachedProviders, nowMs, layoutFor()))
 	}

--- a/cmd/usagebar/main_test.go
+++ b/cmd/usagebar/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+)
+
+func TestFlagValuesCollectsRepeatedProviderExclusions(t *testing.T) {
+	got := flagValues([]string{
+		"--all",
+		"--exclude-provider", "Claude",
+		"--exclude-provider", "zai",
+	}, "--exclude-provider")
+	if len(got) != 2 || !got["claude"] || !got["zai"] {
+		t.Fatalf("got=%v", got)
+	}
+}
+
+func TestExcludeProviders(t *testing.T) {
+	providers := []limits.ProviderLimits{
+		{ProviderID: "claude"},
+		{ProviderID: "codex"},
+		{ProviderID: "zai"},
+	}
+	got := excludeProviders(providers, map[string]bool{"claude": true})
+	if len(got) != 2 || got[0].ProviderID != "codex" || got[1].ProviderID != "zai" {
+		t.Fatalf("got=%v", got)
+	}
+}

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,7 +3,7 @@ name = "Agent Usage"
 version = "0.1.3"
 # Plugin host (events/actions/HERDR_PLUGIN_*) landed in Herdr 0.7.0.
 min_herdr_version = "0.7.0"
-description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, and Grok"
+description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, Antigravity, Z.ai, OpenCode Go, and Grok"
 platforms = ["macos", "linux"]
 
 [[events]]

--- a/internal/herdrcli/herdr.go
+++ b/internal/herdrcli/herdr.go
@@ -214,6 +214,17 @@ func ClearCustomStatus(paneID, source string) {
 	spawnHerdr("pane", "report-metadata", paneID, "--source", source, "--clear-custom-status")
 }
 
+// SetDisplayAgent replaces the sidebar's rendered agent label without changing
+// the canonical agent id used for provider resolution.
+func SetDisplayAgent(paneID, source, text string) {
+	spawnHerdr("pane", "report-metadata", paneID, "--source", source, "--display-agent", text)
+}
+
+// ClearDisplayAgent removes this plugin's rendered agent-label override.
+func ClearDisplayAgent(paneID, source string) {
+	spawnHerdr("pane", "report-metadata", paneID, "--source", source, "--clear-display-agent")
+}
+
 // ShowNotification runs herdr notification show; returns whether shown.
 func ShowNotification(title, body string) bool {
 	stdout, ok := spawnHerdr("notification", "show", title, "--body", body)

--- a/internal/limits/activeproviders_test.go
+++ b/internal/limits/activeproviders_test.go
@@ -73,3 +73,13 @@ func TestActiveProviderSet_CaseInsensitiveAgentIDs(t *testing.T) {
 		t.Fatalf("got %v, want {claude, opencode}", got)
 	}
 }
+
+func TestActiveProviderSet_AntigravityAndZaiAliases(t *testing.T) {
+	got := ActiveProviderSet([]OpenPaneSnapshot{
+		{Agent: "AGY"},
+		{Agent: "z.ai"},
+	})
+	if len(got) != 2 || !got["antigravity"] || !got["zai"] {
+		t.Fatalf("got %v, want antigravity and zai", got)
+	}
+}

--- a/internal/limits/antigravitylimits.go
+++ b/internal/limits/antigravitylimits.go
@@ -1,0 +1,548 @@
+/**
+ * Antigravity quota collection from the local language-server API.
+ *
+ * The probe only talks to 127.0.0.1. It discovers Antigravity/agy processes,
+ * obtains their listening ports, and calls the same internal endpoints used by
+ * CodexBar. Self-signed TLS is accepted only for this fixed loopback target.
+ */
+package limits
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	antigravityQuotaSummaryPath = "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary"
+	antigravityUserStatusPath   = "/exa.language_server_pb.LanguageServerService/GetUserStatus"
+	antigravityModelConfigPath  = "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs"
+)
+
+// AntigravityProcess is a local process that may expose quota endpoints.
+type AntigravityProcess struct {
+	PID                      int
+	CSRFToken                string
+	RequiresCSRF             bool
+	ExtensionPort            int
+	ExtensionServerCSRFToken string
+}
+
+// CollectAntigravityLimitsOptions injects process and network dependencies.
+type CollectAntigravityLimitsOptions struct {
+	ProcessList    func() (string, error)
+	ListeningPorts func(pid int) ([]int, error)
+	HTTPClient     *http.Client
+}
+
+// CollectAntigravityLimits probes a running Antigravity app, IDE, or agy CLI.
+func CollectAntigravityLimits(_ *string, nowMs int64, opts CollectAntigravityLimitsOptions) ProviderLimits {
+	result := ProviderLimits{
+		ProviderID:  "antigravity",
+		Label:       "Antigravity",
+		Source:      "Antigravity local API",
+		FetchedAtMs: nowMs,
+	}
+	processList := opts.ProcessList
+	if processList == nil {
+		processList = antigravityProcessList
+	}
+	output, err := processList()
+	if err != nil {
+		result.Note = strPtr("Antigravity process detection failed: " + err.Error())
+		return result
+	}
+	processes := parseAntigravityProcesses(output)
+	if len(processes) == 0 {
+		result.Note = strPtr("start Antigravity or agy to fetch local limits")
+		return result
+	}
+	listeningPorts := opts.ListeningPorts
+	if listeningPorts == nil {
+		listeningPorts = antigravityListeningPorts
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = antigravityHTTPClient()
+	}
+
+	var lastErr error
+	for _, process := range processes {
+		ports, portErr := listeningPorts(process.PID)
+		if portErr != nil || len(ports) == 0 {
+			if portErr != nil {
+				lastErr = portErr
+			}
+			continue
+		}
+		parsed, fetchErr := fetchAntigravityQuota(client, antigravityEndpoints(process, ports))
+		if fetchErr != nil {
+			lastErr = fetchErr
+			continue
+		}
+		result.Primary = parsed.primary
+		result.Secondary = parsed.secondary
+		result.Tertiary = parsed.tertiary
+		result.PlanType = parsed.plan
+		result.Note = parsed.note
+		return result
+	}
+	if lastErr != nil {
+		result.Note = strPtr("Antigravity local quota unavailable: " + lastErr.Error())
+	} else {
+		result.Note = strPtr("Antigravity is running but exposes no listening quota port")
+	}
+	return result
+}
+
+func antigravityProcessList() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "ps", "-ax", "-o", "pid=,command=").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+var antigravityFlagPattern = regexp.MustCompile(`(?i)(--[a-z_]+)(?:=|\s+)([^\s]+)`)
+
+func parseAntigravityProcesses(output string) []AntigravityProcess {
+	var processes []AntigravityProcess
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		command := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), fields[0]))
+		lower := strings.ToLower(command)
+		isCLI := antigravityCLICommand(lower)
+		isServer := antigravityLanguageServerCommand(lower)
+		if !isCLI && !isServer {
+			continue
+		}
+		flags := make(map[string]string)
+		for _, match := range antigravityFlagPattern.FindAllStringSubmatch(command, -1) {
+			flags[strings.ToLower(match[1])] = match[2]
+		}
+		csrf := flags["--csrf_token"]
+		if isServer && csrf == "" {
+			continue
+		}
+		extensionPort, _ := strconv.Atoi(flags["--extension_server_port"])
+		processes = append(processes, AntigravityProcess{
+			PID:                      pid,
+			CSRFToken:                csrf,
+			RequiresCSRF:             !isCLI,
+			ExtensionPort:            extensionPort,
+			ExtensionServerCSRFToken: flags["--extension_server_csrf_token"],
+		})
+	}
+	return processes
+}
+
+func antigravityCLICommand(lower string) bool {
+	for _, marker := range []string{"/agy ", "/agy", " antigravity-cli", "/antigravity-cli", " antigravity_cli", "/antigravity_cli"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return strings.HasPrefix(lower, "agy ") || lower == "agy"
+}
+
+func antigravityLanguageServerCommand(lower string) bool {
+	server := strings.Contains(lower, "language_server") || strings.Contains(lower, "language-server")
+	marker := strings.Contains(lower, "antigravity")
+	return server && marker
+}
+
+var antigravityListenPortPattern = regexp.MustCompile(`:(\d+)\s+\(LISTEN\)`)
+
+func antigravityListeningPorts(pid int) ([]int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(
+		ctx,
+		"lsof",
+		"-nP",
+		"-iTCP",
+		"-sTCP:LISTEN",
+		"-a",
+		"-p",
+		strconv.Itoa(pid),
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("lsof pid %d: %w", pid, err)
+	}
+	seen := make(map[int]bool)
+	var ports []int
+	for _, match := range antigravityListenPortPattern.FindAllStringSubmatch(string(output), -1) {
+		port, err := strconv.Atoi(match[1])
+		if err == nil && !seen[port] {
+			seen[port] = true
+			ports = append(ports, port)
+		}
+	}
+	sort.Ints(ports)
+	return ports, nil
+}
+
+type antigravityEndpoint struct {
+	Scheme    string
+	Port      int
+	CSRFToken string
+	UseCSRF   bool
+}
+
+func antigravityEndpoints(process AntigravityProcess, ports []int) []antigravityEndpoint {
+	var endpoints []antigravityEndpoint
+	seen := make(map[string]bool)
+	appendEndpoint := func(endpoint antigravityEndpoint) {
+		key := fmt.Sprintf("%s:%d:%t:%s", endpoint.Scheme, endpoint.Port, endpoint.UseCSRF, endpoint.CSRFToken)
+		if !seen[key] {
+			seen[key] = true
+			endpoints = append(endpoints, endpoint)
+		}
+	}
+	for _, port := range ports {
+		appendEndpoint(antigravityEndpoint{"https", port, process.CSRFToken, process.RequiresCSRF})
+		appendEndpoint(antigravityEndpoint{"http", port, process.CSRFToken, process.RequiresCSRF})
+	}
+	if process.ExtensionPort > 0 {
+		token := process.ExtensionServerCSRFToken
+		if token == "" {
+			token = process.CSRFToken
+		}
+		appendEndpoint(antigravityEndpoint{"http", process.ExtensionPort, token, true})
+	}
+	return endpoints
+}
+
+func antigravityHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} // #nosec G402 -- fixed 127.0.0.1 target only
+	return &http.Client{Transport: transport, Timeout: 5 * time.Second}
+}
+
+type parsedAntigravityQuota struct {
+	primary   *LimitWindow
+	secondary *LimitWindow
+	tertiary  *LimitWindow
+	plan      *string
+	note      *string
+}
+
+func fetchAntigravityQuota(client *http.Client, endpoints []antigravityEndpoint) (*parsedAntigravityQuota, error) {
+	var lastErr error
+	for _, endpoint := range endpoints {
+		body, err := antigravityRequest(client, endpoint, antigravityQuotaSummaryPath, map[string]any{"forceRefresh": true})
+		if err == nil {
+			parsed, parseErr := parseAntigravityQuotaSummary(body)
+			if parseErr == nil && parsed.primary != nil {
+				identityBody, identityErr := antigravityRequest(client, endpoint, antigravityUserStatusPath, antigravityMetadataBody())
+				if identityErr == nil {
+					applyAntigravityIdentity(parsed, identityBody)
+				}
+				return parsed, nil
+			}
+			lastErr = parseErr
+		} else {
+			lastErr = err
+		}
+		for _, fallback := range []struct {
+			path string
+			body map[string]any
+		}{
+			{antigravityUserStatusPath, antigravityMetadataBody()},
+			{antigravityModelConfigPath, antigravityMetadataBody()},
+		} {
+			body, err = antigravityRequest(client, endpoint, fallback.path, fallback.body)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			parsed, parseErr := parseAntigravityLegacyQuota(body)
+			if parseErr == nil && parsed.primary != nil {
+				return parsed, nil
+			}
+			lastErr = parseErr
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no local endpoints")
+	}
+	return nil, lastErr
+}
+
+func antigravityRequest(client *http.Client, endpoint antigravityEndpoint, path string, payload map[string]any) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	requestURL := fmt.Sprintf("%s://127.0.0.1:%d%s", endpoint.Scheme, endpoint.Port, path)
+	req, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connect-Protocol-Version", "1")
+	if endpoint.UseCSRF {
+		req.Header.Set("X-Codeium-Csrf-Token", endpoint.CSRFToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return responseBody, nil
+}
+
+func antigravityMetadataBody() map[string]any {
+	return map[string]any{"metadata": map[string]any{
+		"ideName": "antigravity", "extensionName": "antigravity", "ideVersion": "unknown", "locale": "en",
+	}}
+}
+
+type antigravityQuotaSummaryResponse struct {
+	Code     any                      `json:"code"`
+	Response *antigravityQuotaPayload `json:"response"`
+	Summary  *antigravityQuotaPayload `json:"summary"`
+	Groups   []antigravityQuotaGroup  `json:"groups"`
+}
+
+type antigravityQuotaPayload struct {
+	Groups []antigravityQuotaGroup `json:"groups"`
+}
+
+type antigravityQuotaGroup struct {
+	DisplayName string                   `json:"displayName"`
+	Buckets     []antigravityQuotaBucket `json:"buckets"`
+}
+
+type antigravityQuotaBucket struct {
+	BucketID          string   `json:"bucketId"`
+	DisplayName       string   `json:"displayName"`
+	Description       string   `json:"description"`
+	RemainingFraction *float64 `json:"remainingFraction"`
+	Remaining         *struct {
+		RemainingFraction *float64 `json:"remainingFraction"`
+		Case              string   `json:"case"`
+		Value             *float64 `json:"value"`
+	} `json:"remaining"`
+	ResetTime string `json:"resetTime"`
+	Disabled  bool   `json:"disabled"`
+}
+
+func parseAntigravityQuotaSummary(data []byte) (*parsedAntigravityQuota, error) {
+	var response antigravityQuotaSummaryResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("parse quota summary: %w", err)
+	}
+	payload := response.Response
+	if payload == nil {
+		payload = response.Summary
+	}
+	groups := response.Groups
+	if payload != nil {
+		groups = payload.Groups
+	}
+	best := make(map[int]*LimitWindow)
+	for _, group := range groups {
+		for _, bucket := range group.Buckets {
+			remaining := bucket.RemainingFraction
+			if remaining == nil && bucket.Remaining != nil {
+				remaining = bucket.Remaining.RemainingFraction
+				if remaining == nil && bucket.Remaining.Case == "remainingFraction" {
+					remaining = bucket.Remaining.Value
+				}
+			}
+			if bucket.Disabled || remaining == nil {
+				continue
+			}
+			minutes := antigravityWindowMinutes(bucket.BucketID + " " + bucket.DisplayName + " " + bucket.Description)
+			if minutes == 0 {
+				continue
+			}
+			used := 100 - (*remaining * 100)
+			if used < 0 {
+				used = 0
+			}
+			if used > 100 {
+				used = 100
+			}
+			window := &LimitWindow{UsedPercentage: used, WindowMinutes: &minutes, ResetsAt: parseAntigravityReset(bucket.ResetTime)}
+			if current := best[minutes]; current == nil || window.UsedPercentage > current.UsedPercentage {
+				best[minutes] = window
+			}
+		}
+	}
+	minutes := make([]int, 0, len(best))
+	for value := range best {
+		minutes = append(minutes, value)
+	}
+	sort.Ints(minutes)
+	parsed := &parsedAntigravityQuota{}
+	ordered := []*LimitWindow{nil, nil, nil}
+	for i, value := range minutes {
+		if i == len(ordered) {
+			break
+		}
+		ordered[i] = best[value]
+	}
+	parsed.primary, parsed.secondary, parsed.tertiary = ordered[0], ordered[1], ordered[2]
+	if parsed.primary == nil {
+		return nil, fmt.Errorf("quota summary has no supported buckets")
+	}
+	parsed.note = strPtr("most constrained quota across Gemini and Claude + GPT")
+	return parsed, nil
+}
+
+func antigravityWindowMinutes(text string) int {
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "week") || strings.Contains(lower, "7d") || strings.Contains(lower, "weekly") {
+		return 7 * 24 * 60
+	}
+	if strings.Contains(lower, "5h") || strings.Contains(lower, "5 h") || strings.Contains(lower, "5-hour") || strings.Contains(lower, "5 hour") || strings.Contains(lower, "session") {
+		return 5 * 60
+	}
+	if strings.Contains(lower, "month") || strings.Contains(lower, "30d") {
+		return 30 * 24 * 60
+	}
+	return 0
+}
+
+func parseAntigravityReset(raw string) *int64 {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return nil
+	}
+	if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if number > 10_000_000_000 {
+			number /= 1000
+		}
+		return &number
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			seconds := parsed.Unix()
+			return &seconds
+		}
+	}
+	return nil
+}
+
+type antigravityLegacyResponse struct {
+	UserStatus *struct {
+		Email    *string `json:"email"`
+		UserTier *struct {
+			Name *string `json:"name"`
+		} `json:"userTier"`
+		PlanStatus *struct {
+			PlanInfo *struct {
+				PlanName        *string `json:"planName"`
+				PlanDisplayName *string `json:"planDisplayName"`
+				DisplayName     *string `json:"displayName"`
+			} `json:"planInfo"`
+		} `json:"planStatus"`
+		CascadeModelConfigData *struct {
+			ClientModelConfigs []antigravityModelConfig `json:"clientModelConfigs"`
+		} `json:"cascadeModelConfigData"`
+	} `json:"userStatus"`
+	ClientModelConfigs []antigravityModelConfig `json:"clientModelConfigs"`
+}
+
+type antigravityModelConfig struct {
+	Label        string `json:"label"`
+	ModelOrAlias struct {
+		Model string `json:"model"`
+	} `json:"modelOrAlias"`
+	QuotaInfo *struct {
+		RemainingFraction *float64 `json:"remainingFraction"`
+		ResetTime         string   `json:"resetTime"`
+	} `json:"quotaInfo"`
+}
+
+func parseAntigravityLegacyQuota(data []byte) (*parsedAntigravityQuota, error) {
+	var response antigravityLegacyResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("parse legacy quota: %w", err)
+	}
+	models := response.ClientModelConfigs
+	parsed := antigravityIdentity(response)
+	if response.UserStatus != nil {
+		if response.UserStatus.CascadeModelConfigData != nil {
+			models = response.UserStatus.CascadeModelConfigData.ClientModelConfigs
+		}
+	}
+	var best *LimitWindow
+	for _, model := range models {
+		if model.QuotaInfo == nil || model.QuotaInfo.RemainingFraction == nil {
+			continue
+		}
+		minutes := 5 * 60
+		used := 100 - (*model.QuotaInfo.RemainingFraction * 100)
+		window := &LimitWindow{UsedPercentage: used, WindowMinutes: &minutes, ResetsAt: parseAntigravityReset(model.QuotaInfo.ResetTime)}
+		if best == nil || window.UsedPercentage > best.UsedPercentage {
+			best = window
+		}
+	}
+	parsed.primary = best
+	if best == nil {
+		return nil, fmt.Errorf("legacy response has no usable model quota")
+	}
+	if parsed.note == nil {
+		parsed.note = strPtr("most constrained local model quota")
+	}
+	return parsed, nil
+}
+
+func applyAntigravityIdentity(parsed *parsedAntigravityQuota, data []byte) {
+	var response antigravityLegacyResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return
+	}
+	identity := antigravityIdentity(response)
+	parsed.plan = identity.plan
+	if identity.note != nil {
+		parsed.note = identity.note
+	}
+}
+
+func antigravityIdentity(response antigravityLegacyResponse) *parsedAntigravityQuota {
+	parsed := &parsedAntigravityQuota{}
+	if response.UserStatus == nil {
+		return parsed
+	}
+	if response.UserStatus.UserTier != nil {
+		parsed.plan = firstNonEmpty(response.UserStatus.UserTier.Name)
+	}
+	if parsed.plan == nil && response.UserStatus.PlanStatus != nil && response.UserStatus.PlanStatus.PlanInfo != nil {
+		info := response.UserStatus.PlanStatus.PlanInfo
+		parsed.plan = firstNonEmpty(info.PlanDisplayName, info.DisplayName, info.PlanName)
+	}
+	if response.UserStatus.Email != nil && strings.TrimSpace(*response.UserStatus.Email) != "" {
+		parsed.note = strPtr("account " + strings.TrimSpace(*response.UserStatus.Email))
+	}
+	return parsed
+}

--- a/internal/limits/antigravitylimits_test.go
+++ b/internal/limits/antigravitylimits_test.go
@@ -1,0 +1,110 @@
+package limits
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestParseAntigravityProcesses(t *testing.T) {
+	output := `
+  101 /opt/Antigravity/language_server --app_data_dir antigravity --csrf_token abc --extension_server_port=9191 --extension_server_csrf_token ext
+  202 /home/test/.local/bin/agy
+  303 /other/language_server --csrf_token wrong
+`
+	got := parseAntigravityProcesses(output)
+	if len(got) != 2 {
+		t.Fatalf("len=%d got=%+v", len(got), got)
+	}
+	if got[0].PID != 101 || got[0].CSRFToken != "abc" || got[0].ExtensionPort != 9191 || got[0].ExtensionServerCSRFToken != "ext" {
+		t.Fatalf("app=%+v", got[0])
+	}
+	if got[1].PID != 202 || got[1].RequiresCSRF {
+		t.Fatalf("cli=%+v", got[1])
+	}
+}
+
+func TestParseAntigravityQuotaSummaryChoosesMostConstrainedPerWindow(t *testing.T) {
+	data := []byte(`{
+  "response": {"groups": [
+    {"displayName":"Gemini Models","buckets":[
+      {"bucketId":"gemini-session","displayName":"5 hour limit","remaining":{"remainingFraction":0.8},"resetTime":"2030-01-01T00:00:00Z"},
+      {"bucketId":"gemini-weekly","displayName":"Weekly limit","remaining":{"remainingFraction":0.6}}
+    ]},
+    {"displayName":"Claude and GPT models","buckets":[
+      {"bucketId":"claude-session","displayName":"5-hour limit","remainingFraction":0.3},
+      {"bucketId":"claude-weekly","displayName":"Weekly limit","remainingFraction":0.9}
+    ]}
+  ]}
+}`)
+	got, err := parseAntigravityQuotaSummary(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.primary == nil || got.primary.UsedPercentage != 70 || got.primary.WindowMinutes == nil || *got.primary.WindowMinutes != 300 {
+		t.Fatalf("primary=%+v", got.primary)
+	}
+	if got.secondary == nil || got.secondary.UsedPercentage != 40 || got.secondary.WindowMinutes == nil || *got.secondary.WindowMinutes != 10080 {
+		t.Fatalf("secondary=%+v", got.secondary)
+	}
+}
+
+func TestCollectAntigravityLimitsUsesLoopbackAPIAndCSRF(t *testing.T) {
+	var quotaCSRF string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case antigravityQuotaSummaryPath:
+			quotaCSRF = r.Header.Get("X-Codeium-Csrf-Token")
+			return jsonResponse(`{"response":{"groups":[{"displayName":"Gemini Models","buckets":[{"bucketId":"gemini-session","displayName":"5 hour limit","remaining":{"remainingFraction":0.25}}]}]}}`), nil
+		case antigravityUserStatusPath:
+			var body strings.Builder
+			_ = json.NewEncoder(&body).Encode(map[string]any{"userStatus": map[string]any{
+				"email":    "dev@example.com",
+				"userTier": map[string]any{"name": "Pro"},
+			}})
+			return jsonResponse(body.String()), nil
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("not found")),
+			}, nil
+		}
+	})}
+
+	got := CollectAntigravityLimits(nil, 99, CollectAntigravityLimitsOptions{
+		ProcessList: func() (string, error) {
+			return "123 /opt/antigravity/language_server --csrf_token csrf-123 --app_data_dir antigravity", nil
+		},
+		ListeningPorts: func(pid int) ([]int, error) {
+			if pid != 123 {
+				t.Fatalf("pid=%d", pid)
+			}
+			return []int{8443}, nil
+		},
+		HTTPClient: client,
+	})
+	if quotaCSRF != "csrf-123" {
+		t.Fatalf("csrf=%q", quotaCSRF)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 75 {
+		t.Fatalf("got=%+v", got)
+	}
+	if got.PlanType == nil || *got.PlanType != "Pro" {
+		t.Fatalf("plan=%v", got.PlanType)
+	}
+	if got.Note == nil || !strings.Contains(*got.Note, "dev@example.com") {
+		t.Fatalf("note=%v", got.Note)
+	}
+}
+
+func TestCollectAntigravityLimitsWhenNotRunning(t *testing.T) {
+	got := CollectAntigravityLimits(nil, 1, CollectAntigravityLimitsOptions{
+		ProcessList: func() (string, error) { return "1 /sbin/init", nil },
+	})
+	if got.Note == nil || !strings.Contains(*got.Note, "start Antigravity") {
+		t.Fatalf("note=%v", got.Note)
+	}
+}

--- a/internal/limits/attachactivity.go
+++ b/internal/limits/attachactivity.go
@@ -4,6 +4,8 @@
  */
 package limits
 
+import "strings"
+
 // OpenPaneSnapshot is one open agent pane used for share aggregation.
 type OpenPaneSnapshot struct {
 	PaneID    string
@@ -15,10 +17,14 @@ type OpenPaneSnapshot struct {
 
 // agent id -> ProviderLimits.providerId
 var agentToProvider = map[string]string{
-	"claude":   "claude",
-	"codex":    "codex",
-	"opencode": "opencode",
-	"grok":     "grok",
+	"claude":      "claude",
+	"codex":       "codex",
+	"antigravity": "antigravity",
+	"agy":         "antigravity",
+	"zai":         "zai",
+	"z.ai":        "zai",
+	"opencode":    "opencode",
+	"grok":        "grok",
 }
 
 // PaneActivityDeps injects token collectors for tests and I/O adapters.
@@ -38,20 +44,9 @@ func AttachPaneActivity(
 	out := make([]ProviderLimits, len(providers))
 	for i, p := range providers {
 		out[i] = p
-		var agentID string
-		for a, providerID := range agentToProvider {
-			if providerID == p.ProviderID {
-				agentID = a
-				break
-			}
-		}
-		if agentID == "" {
-			continue
-		}
-
 		var panesForProvider []OpenPaneSnapshot
 		for _, pane := range openPanes {
-			if pane.Agent == agentID {
+			if agentToProvider[strings.ToLower(pane.Agent)] == p.ProviderID {
 				panesForProvider = append(panesForProvider, pane)
 			}
 		}

--- a/internal/limits/collect.go
+++ b/internal/limits/collect.go
@@ -10,10 +10,12 @@ type LimitsCollector func(cwd *string, nowMs int64) ProviderLimits
 
 // CollectOptions configures CollectAllProviderLimits.
 type CollectOptions struct {
-	Claude   LimitsCollector
-	Codex    LimitsCollector
-	OpenCode LimitsCollector
-	Grok     LimitsCollector
+	Claude      LimitsCollector
+	Codex       LimitsCollector
+	Antigravity LimitsCollector
+	Zai         LimitsCollector
+	OpenCode    LimitsCollector
+	Grok        LimitsCollector
 	// Attach activity after collection (injectable for tests).
 	Attach func(providers []ProviderLimits, nowMs int64) []ProviderLimits
 	// Only restricts collection to these provider ids (nil = all providers).
@@ -28,6 +30,12 @@ func DefaultCollectOptions() CollectOptions {
 			return CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{})
 		},
 		Codex: CollectCodexLimits,
+		Antigravity: func(_ *string, nowMs int64) ProviderLimits {
+			return CollectAntigravityLimits(nil, nowMs, CollectAntigravityLimitsOptions{})
+		},
+		Zai: func(_ *string, nowMs int64) ProviderLimits {
+			return CollectZaiLimits(nil, nowMs, CollectZaiLimitsOptions{})
+		},
 		OpenCode: func(_ *string, nowMs int64) ProviderLimits {
 			return CollectOpenCodeLimits(nowMs, "")
 		},
@@ -38,7 +46,8 @@ func DefaultCollectOptions() CollectOptions {
 }
 
 // CollectAllProviderLimits runs collectors in display order:
-// Claude -> Codex -> OpenCode -> Grok, then attaches pane activity when configured.
+// Claude -> Codex -> Antigravity -> Z.ai -> OpenCode -> Grok, then attaches
+// pane activity when configured.
 // Providers excluded by opts.Only are skipped (collectors never run).
 // Pass DefaultCollectOptions() for production local collectors.
 func CollectAllProviderLimits(cwd *string, nowMs int64, opts CollectOptions) []ProviderLimits {
@@ -60,6 +69,8 @@ func CollectAllProviderLimits(cwd *string, nowMs int64, opts CollectOptions) []P
 	}{
 		{opts.Claude, "claude", "Claude"},
 		{opts.Codex, "codex", "Codex"},
+		{opts.Antigravity, "antigravity", "Antigravity"},
+		{opts.Zai, "zai", "Z.ai"},
 		{opts.OpenCode, "opencode", "OpenCode"},
 		{opts.Grok, "grok", "Grok"},
 	}

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -7,10 +7,10 @@ import "testing"
 
 func TestCollectAllProviderLimits_OrderAndStubs(t *testing.T) {
 	got := CollectAllProviderLimits(nil, 100, CollectOptions{})
-	if len(got) != 4 {
+	if len(got) != 6 {
 		t.Fatalf("len=%d", len(got))
 	}
-	wantIDs := []string{"claude", "codex", "opencode", "grok"}
+	wantIDs := []string{"claude", "codex", "antigravity", "zai", "opencode", "grok"}
 	for i, id := range wantIDs {
 		if got[i].ProviderID != id {
 			t.Fatalf("[%d] id=%q want %q", i, got[i].ProviderID, id)
@@ -34,7 +34,7 @@ func TestCollectAllProviderLimits_WithCollectorsAndAttach(t *testing.T) {
 			return ProviderLimits{ProviderID: "codex", Label: "Codex", Source: "test", FetchedAtMs: now}
 		},
 		Attach: func(providers []ProviderLimits, nowMs int64) []ProviderLimits {
-			if nowMs != 200 || len(providers) != 4 {
+			if nowMs != 200 || len(providers) != 6 {
 				t.Fatalf("attach args")
 			}
 			providers[0].PaneActivity = &ProviderPaneActivity{WindowMinutes: 300, TotalTokens: 1}

--- a/internal/limits/remaining.go
+++ b/internal/limits/remaining.go
@@ -1,0 +1,37 @@
+package limits
+
+import "math"
+
+// WindowRemaining returns one window's remaining percentage, clamped to 0-100.
+func WindowRemaining(window *LimitWindow) (int, bool) {
+	if window == nil {
+		return 0, false
+	}
+	value := int(math.Round(100 - window.UsedPercentage))
+	if value < 0 {
+		value = 0
+	}
+	if value > 100 {
+		value = 100
+	}
+	return value, true
+}
+
+// MostConstrainedRemaining returns the lowest remaining percentage among a
+// provider's known windows. This is the safest compact account-level summary.
+func MostConstrainedRemaining(provider ProviderLimits) (int, bool) {
+	windows := []*LimitWindow{provider.Primary, provider.Secondary, provider.Tertiary}
+	remaining := 101
+	found := false
+	for _, window := range windows {
+		value, ok := WindowRemaining(window)
+		if !ok {
+			continue
+		}
+		if !found || value < remaining {
+			remaining = value
+			found = true
+		}
+	}
+	return remaining, found
+}

--- a/internal/limits/remaining_test.go
+++ b/internal/limits/remaining_test.go
@@ -1,0 +1,31 @@
+package limits
+
+import "testing"
+
+func TestMostConstrainedRemaining(t *testing.T) {
+	provider := ProviderLimits{
+		Primary:   &LimitWindow{UsedPercentage: 10},
+		Secondary: &LimitWindow{UsedPercentage: 89.4},
+		Tertiary:  &LimitWindow{UsedPercentage: 40},
+	}
+	got, ok := MostConstrainedRemaining(provider)
+	if !ok || got != 11 {
+		t.Fatalf("got=%d ok=%v, want 11 true", got, ok)
+	}
+}
+
+func TestMostConstrainedRemainingNoWindows(t *testing.T) {
+	if got, ok := MostConstrainedRemaining(ProviderLimits{}); ok || got != 101 {
+		t.Fatalf("got=%d ok=%v, want no value", got, ok)
+	}
+}
+
+func TestWindowRemaining(t *testing.T) {
+	got, ok := WindowRemaining(&LimitWindow{UsedPercentage: 0.4})
+	if !ok || got != 100 {
+		t.Fatalf("got=%d ok=%v, want 100 true", got, ok)
+	}
+	if _, ok := WindowRemaining(nil); ok {
+		t.Fatal("nil window unexpectedly returned a value")
+	}
+}

--- a/internal/limits/zailimits.go
+++ b/internal/limits/zailimits.go
@@ -1,0 +1,309 @@
+/**
+ * z.ai coding-plan quota collection.
+ *
+ * Authentication and endpoint selection mirror CodexBar's provider:
+ * Z_AI_API_KEY supplies the bearer token, Z_AI_QUOTA_URL overrides the full
+ * endpoint, and Z_AI_API_HOST overrides only the API host. Credential-bearing
+ * requests are sent only to HTTPS endpoints.
+ */
+package limits
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	zaiGlobalHost = "https://api.z.ai"
+	zaiChinaHost  = "https://open.bigmodel.cn"
+	zaiQuotaPath  = "/api/monitor/usage/quota/limit"
+)
+
+// CollectZaiLimitsOptions injects environment and HTTP dependencies for tests.
+type CollectZaiLimitsOptions struct {
+	Environment map[string]string
+	HTTPClient  *http.Client
+}
+
+type zaiQuotaResponse struct {
+	Code    int           `json:"code"`
+	Message *string       `json:"msg"`
+	Data    *zaiQuotaData `json:"data"`
+	Success bool          `json:"success"`
+}
+
+type zaiQuotaData struct {
+	Limits      []zaiLimitRaw `json:"limits"`
+	PlanName    *string       `json:"planName"`
+	Plan        *string       `json:"plan"`
+	PlanType    *string       `json:"plan_type"`
+	PackageName *string       `json:"packageName"`
+}
+
+type zaiLimitRaw struct {
+	Type          string   `json:"type"`
+	Unit          int      `json:"unit"`
+	Number        int      `json:"number"`
+	Usage         *float64 `json:"usage"`
+	CurrentValue  *float64 `json:"currentValue"`
+	Remaining     *float64 `json:"remaining"`
+	Percentage    float64  `json:"percentage"`
+	NextResetTime *int64   `json:"nextResetTime"`
+}
+
+// CollectZaiLimits fetches personal or team coding-plan quota windows.
+func CollectZaiLimits(_ *string, nowMs int64, opts CollectZaiLimitsOptions) ProviderLimits {
+	result := ProviderLimits{
+		ProviderID:  "zai",
+		Label:       "Z.ai",
+		Source:      "z.ai quota API",
+		FetchedAtMs: nowMs,
+	}
+	env := opts.Environment
+	if env == nil {
+		env = environmentMap()
+	}
+	apiKey := strings.TrimSpace(env["Z_AI_API_KEY"])
+	if apiKey == "" {
+		result.Note = strPtr("set Z_AI_API_KEY to fetch coding-plan limits")
+		return result
+	}
+
+	endpoint, err := resolveZaiQuotaURL(env)
+	if err != nil {
+		result.Note = strPtr(err.Error())
+		return result
+	}
+	if strings.EqualFold(strings.TrimSpace(env["Z_AI_USAGE_SCOPE"]), "team") {
+		org := strings.TrimSpace(env["Z_AI_BIGMODEL_ORGANIZATION"])
+		project := strings.TrimSpace(env["Z_AI_BIGMODEL_PROJECT"])
+		if org == "" || project == "" {
+			result.Note = strPtr("team usage requires Z_AI_BIGMODEL_ORGANIZATION and Z_AI_BIGMODEL_PROJECT")
+			return result
+		}
+		query := endpoint.Query()
+		query.Set("type", "2")
+		endpoint.RawQuery = query.Encode()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		result.Note = strPtr("z.ai request: " + err.Error())
+		return result
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	if strings.EqualFold(strings.TrimSpace(env["Z_AI_USAGE_SCOPE"]), "team") {
+		req.Header.Set("Bigmodel-Organization", strings.TrimSpace(env["Z_AI_BIGMODEL_ORGANIZATION"]))
+		req.Header.Set("Bigmodel-Project", strings.TrimSpace(env["Z_AI_BIGMODEL_PROJECT"]))
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 12 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		result.Note = strPtr("z.ai quota request failed: " + err.Error())
+		return result
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		result.Note = strPtr("z.ai quota response: " + err.Error())
+		return result
+	}
+	if resp.StatusCode != http.StatusOK {
+		result.Note = strPtr(fmt.Sprintf("z.ai quota API HTTP %d", resp.StatusCode))
+		return result
+	}
+	parsed, err := parseZaiQuota(body)
+	if err != nil {
+		result.Note = strPtr(err.Error())
+		return result
+	}
+	result.Primary, result.Secondary, result.Tertiary = parsed.windows[0], parsed.windows[1], parsed.windows[2]
+	result.PlanType = parsed.plan
+	if result.Primary == nil {
+		result.Note = strPtr("z.ai quota API returned no supported limits")
+	}
+	return result
+}
+
+type parsedZaiQuota struct {
+	windows [3]*LimitWindow
+	plan    *string
+}
+
+func parseZaiQuota(data []byte) (*parsedZaiQuota, error) {
+	var response zaiQuotaResponse
+	if len(data) == 0 {
+		return nil, fmt.Errorf("z.ai quota API returned an empty response")
+	}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("parse z.ai quota response: %w", err)
+	}
+	if !response.Success || response.Code != http.StatusOK {
+		message := fmt.Sprintf("z.ai quota API returned code %d", response.Code)
+		if response.Message != nil && strings.TrimSpace(*response.Message) != "" {
+			message = strings.TrimSpace(*response.Message)
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+	if response.Data == nil {
+		return nil, fmt.Errorf("z.ai quota API response is missing data")
+	}
+
+	var windows []*LimitWindow
+	for _, raw := range response.Data.Limits {
+		window := zaiWindow(raw)
+		if window != nil {
+			windows = append(windows, window)
+		}
+	}
+	sort.SliceStable(windows, func(i, j int) bool {
+		return windowMinutesForSort(windows[i]) < windowMinutesForSort(windows[j])
+	})
+	if len(windows) > 3 {
+		windows = windows[:3]
+	}
+	parsed := &parsedZaiQuota{plan: firstNonEmpty(
+		response.Data.PlanName,
+		response.Data.Plan,
+		response.Data.PlanType,
+		response.Data.PackageName,
+	)}
+	copy(parsed.windows[:], windows)
+	return parsed, nil
+}
+
+func zaiWindow(raw zaiLimitRaw) *LimitWindow {
+	if raw.Type != "TOKENS_LIMIT" && raw.Type != "TIME_LIMIT" {
+		return nil
+	}
+	minutes := zaiWindowMinutes(raw)
+	if minutes == 0 {
+		return nil
+	}
+	used := raw.Percentage
+	if raw.Usage != nil && *raw.Usage > 0 {
+		var usedRaw *float64
+		if raw.Remaining != nil {
+			value := *raw.Usage - *raw.Remaining
+			if raw.CurrentValue != nil && *raw.CurrentValue > value {
+				value = *raw.CurrentValue
+			}
+			usedRaw = &value
+		} else if raw.CurrentValue != nil {
+			usedRaw = raw.CurrentValue
+		}
+		if usedRaw != nil {
+			used = (*usedRaw / *raw.Usage) * 100
+		}
+	}
+	if used < 0 {
+		used = 0
+	}
+	if used > 100 {
+		used = 100
+	}
+	window := &LimitWindow{UsedPercentage: used, WindowMinutes: &minutes}
+	if raw.NextResetTime != nil {
+		seconds := *raw.NextResetTime
+		if seconds > 10_000_000_000 {
+			seconds /= 1000
+		}
+		window.ResetsAt = &seconds
+	}
+	return window
+}
+
+func zaiWindowMinutes(raw zaiLimitRaw) int {
+	// z.ai reports the MCP monthly allowance as TIME_LIMIT/1 minute.
+	if raw.Type == "TIME_LIMIT" && raw.Unit == 5 && raw.Number == 1 {
+		return 30 * 24 * 60
+	}
+	if raw.Number <= 0 {
+		return 0
+	}
+	switch raw.Unit {
+	case 1:
+		return raw.Number * 24 * 60
+	case 3:
+		return raw.Number * 60
+	case 5:
+		return raw.Number
+	case 6:
+		return raw.Number * 7 * 24 * 60
+	default:
+		return 0
+	}
+}
+
+func windowMinutesForSort(window *LimitWindow) int {
+	if window == nil || window.WindowMinutes == nil {
+		return int(^uint(0) >> 1)
+	}
+	return *window.WindowMinutes
+}
+
+func firstNonEmpty(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && strings.TrimSpace(*value) != "" {
+			cleaned := strings.TrimSpace(*value)
+			return &cleaned
+		}
+	}
+	return nil
+}
+
+func resolveZaiQuotaURL(env map[string]string) (*url.URL, error) {
+	raw := strings.TrimSpace(env["Z_AI_QUOTA_URL"])
+	if raw == "" {
+		host := strings.TrimSpace(env["Z_AI_API_HOST"])
+		if host == "" {
+			if strings.EqualFold(strings.TrimSpace(env["Z_AI_API_REGION"]), "bigmodel-cn") {
+				host = zaiChinaHost
+			} else {
+				host = zaiGlobalHost
+			}
+		}
+		raw = strings.TrimRight(host, "/")
+		if !strings.Contains(raw, "://") {
+			raw = "https://" + raw
+		}
+		parsed, err := url.Parse(raw)
+		if err != nil || parsed.Host == "" || parsed.Scheme != "https" {
+			return nil, fmt.Errorf("Z_AI_API_HOST must be an HTTPS URL or bare host")
+		}
+		if parsed.Path == "" || parsed.Path == "/" {
+			parsed.Path = zaiQuotaPath
+		}
+		return parsed, nil
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || parsed.Scheme != "https" {
+		return nil, fmt.Errorf("Z_AI_QUOTA_URL must be an HTTPS URL or bare host")
+	}
+	return parsed, nil
+}
+
+func environmentMap() map[string]string {
+	env := make(map[string]string)
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	return env
+}

--- a/internal/limits/zailimits_test.go
+++ b/internal/limits/zailimits_test.go
@@ -1,0 +1,110 @@
+package limits
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestCollectZaiLimitsFetchesAndOrdersWindows(t *testing.T) {
+	var authorization string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		authorization = r.Header.Get("Authorization")
+		return jsonResponse(`{
+  "code": 200,
+  "success": true,
+  "data": {
+    "planName": "Coding Pro",
+    "limits": [
+      {"type":"TOKENS_LIMIT","unit":6,"number":1,"usage":1000,"currentValue":200,"remaining":800,"percentage":99,"nextResetTime":2000000000000},
+      {"type":"TIME_LIMIT","unit":5,"number":1,"usage":100,"currentValue":40,"remaining":60,"percentage":40},
+      {"type":"TOKENS_LIMIT","unit":3,"number":5,"usage":200,"currentValue":100,"remaining":100,"percentage":50}
+    ]
+  }
+}`), nil
+	})}
+
+	got := CollectZaiLimits(nil, 123, CollectZaiLimitsOptions{
+		Environment: map[string]string{
+			"Z_AI_API_KEY":   "secret-token",
+			"Z_AI_QUOTA_URL": "https://quota.test/quota",
+		},
+		HTTPClient: client,
+	})
+	if authorization != "Bearer secret-token" {
+		t.Fatalf("authorization=%q", authorization)
+	}
+	if got.Primary == nil || got.Primary.WindowMinutes == nil || *got.Primary.WindowMinutes != 300 {
+		t.Fatalf("primary=%+v", got.Primary)
+	}
+	if got.Primary.UsedPercentage != 50 {
+		t.Fatalf("primary used=%v want 50", got.Primary.UsedPercentage)
+	}
+	if got.Secondary == nil || got.Secondary.WindowMinutes == nil || *got.Secondary.WindowMinutes != 10080 {
+		t.Fatalf("secondary=%+v", got.Secondary)
+	}
+	if got.Secondary.UsedPercentage != 20 {
+		t.Fatalf("secondary used=%v want 20", got.Secondary.UsedPercentage)
+	}
+	if got.Tertiary == nil || got.Tertiary.WindowMinutes == nil || *got.Tertiary.WindowMinutes != 43200 {
+		t.Fatalf("tertiary=%+v", got.Tertiary)
+	}
+	if got.PlanType == nil || *got.PlanType != "Coding Pro" {
+		t.Fatalf("plan=%v", got.PlanType)
+	}
+}
+
+func TestCollectZaiLimitsTeamHeaders(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Query().Get("type") != "2" {
+			t.Errorf("type=%q", r.URL.Query().Get("type"))
+		}
+		if r.Header.Get("Bigmodel-Organization") != "org-1" || r.Header.Get("Bigmodel-Project") != "project-1" {
+			t.Errorf("team headers=%q/%q", r.Header.Get("Bigmodel-Organization"), r.Header.Get("Bigmodel-Project"))
+		}
+		return jsonResponse(`{"code":200,"success":true,"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":10}]}}`), nil
+	})}
+
+	got := CollectZaiLimits(nil, 1, CollectZaiLimitsOptions{
+		Environment: map[string]string{
+			"Z_AI_API_KEY":               "token",
+			"Z_AI_QUOTA_URL":             "https://quota.test/quota",
+			"Z_AI_USAGE_SCOPE":           "team",
+			"Z_AI_BIGMODEL_ORGANIZATION": "org-1",
+			"Z_AI_BIGMODEL_PROJECT":      "project-1",
+		},
+		HTTPClient: client,
+	})
+	if got.Primary == nil {
+		t.Fatalf("got=%+v", got)
+	}
+}
+
+func TestResolveZaiQuotaURLRejectsHTTPOverride(t *testing.T) {
+	_, err := resolveZaiQuotaURL(map[string]string{"Z_AI_QUOTA_URL": "http://attacker.test/quota"})
+	if err == nil {
+		t.Fatal("expected insecure endpoint error")
+	}
+}
+
+func TestCollectZaiLimitsRequiresToken(t *testing.T) {
+	got := CollectZaiLimits(nil, 1, CollectZaiLimitsOptions{Environment: map[string]string{}})
+	if got.Note == nil || !containsStr(*got.Note, "Z_AI_API_KEY") {
+		t.Fatalf("note=%v", got.Note)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -5,16 +5,68 @@
 package update
 
 import (
+	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers"
 )
 
 func isSettledStatus(status string) bool {
 	return status != "working"
+}
+
+func accountLimitProviderID(agent string) string {
+	switch strings.ToLower(agent) {
+	case "codex":
+		return "codex"
+	case "grok":
+		return "grok"
+	case "agy", "antigravity":
+		return "antigravity"
+	default:
+		return ""
+	}
+}
+
+func accountLabelRemaining(providerID string, providerLimits limits.ProviderLimits) (int, bool) {
+	if providerID == "antigravity" {
+		// Antigravity collectors order the short 5-hour/session window first.
+		// The sidebar should show that immediately actionable allowance instead
+		// of the more constrained weekly window.
+		if remaining, ok := limits.WindowRemaining(providerLimits.Primary); ok {
+			return remaining, true
+		}
+	}
+	return limits.MostConstrainedRemaining(providerLimits)
+}
+
+func updateAccountLimitLabel(paneID, agent string, cwd *string) {
+	providerID := accountLimitProviderID(agent)
+	if providerID == "" {
+		return
+	}
+	nowMs := time.Now().UnixMilli()
+	var providerLimits limits.ProviderLimits
+	switch providerID {
+	case "codex":
+		providerLimits = limits.CollectCodexLimits(cwd, nowMs)
+	case "grok":
+		providerLimits = limits.CollectGrokLimits(nowMs, limits.CollectGrokLimitsOptions{})
+	case "antigravity":
+		providerLimits = limits.CollectAntigravityLimits(cwd, nowMs, limits.CollectAntigravityLimitsOptions{})
+	}
+	remaining, ok := accountLabelRemaining(providerID, providerLimits)
+	if !ok {
+		herdrcli.ClearDisplayAgent(paneID, herdrcli.Source)
+		return
+	}
+	herdrcli.SetDisplayAgent(paneID, herdrcli.Source, fmt.Sprintf("%s %d%%", agent, remaining))
 }
 
 // RunUpdate resolves usage for HERDR_PANE_ID and updates custom_status.
@@ -30,11 +82,6 @@ func RunUpdate(force bool) {
 		return
 	}
 
-	p := providers.FindProvider(*pane.Agent)
-	if p == nil {
-		return
-	}
-
 	if pane.AgentStatus != nil && !isSettledStatus(*pane.AgentStatus) && !force {
 		return
 	}
@@ -42,6 +89,12 @@ func RunUpdate(force bool) {
 	cwd := pane.ForegroundCwd
 	if cwd == nil {
 		cwd = pane.Cwd
+	}
+	updateAccountLimitLabel(paneID, *pane.Agent, cwd)
+
+	p := providers.FindProvider(*pane.Agent)
+	if p == nil {
+		return
 	}
 	usage := p.ResolveUsage(provider.UsageResolveInput{
 		Session: pane.AgentSession,

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,38 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+)
+
+func TestAccountLimitProviderID(t *testing.T) {
+	tests := map[string]string{
+		"codex":       "codex",
+		"GROK":        "grok",
+		"agy":         "antigravity",
+		"Antigravity": "antigravity",
+		"opencode":    "",
+	}
+	for agent, want := range tests {
+		if got := accountLimitProviderID(agent); got != want {
+			t.Errorf("agent=%q got=%q want=%q", agent, got, want)
+		}
+	}
+}
+
+func TestAccountLabelRemainingUsesAntigravityFiveHourWindow(t *testing.T) {
+	provider := limits.ProviderLimits{
+		Primary:   &limits.LimitWindow{UsedPercentage: 0},
+		Secondary: &limits.LimitWindow{UsedPercentage: 6},
+	}
+	got, ok := accountLabelRemaining("antigravity", provider)
+	if !ok || got != 100 {
+		t.Fatalf("got=%d ok=%v, want 100 true", got, ok)
+	}
+
+	got, ok = accountLabelRemaining("codex", provider)
+	if !ok || got != 94 {
+		t.Fatalf("codex got=%d ok=%v, want 94 true", got, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- Add Antigravity and Z.ai provider limit collectors (local Antigravity/`agy` quota API and Z.ai coding-plan quota API).
- Default the plugin limits pane to show all providers except Claude and OpenCode (`--all` with exclusions); collectors remain available via CLI.
- Harden binary update resolution and related tests.
- Add `README_JP.md` (Japanese docs) and EN/JP language links in `README.md`.

## Test plan
- [x] `go test ./...`
- [ ] `herdr plugin action invoke usagebar.setup` on a clean install path
- [ ] Open limits pane and confirm Codex / Antigravity / Z.ai / Grok visibility defaults
- [ ] Confirm Claude / OpenCode appear when exclusions are removed
- [ ] With `Z_AI_API_KEY` set, refresh Z.ai windows
- [ ] With Antigravity/`agy` running, refresh local 5h allowance
- [ ] Spot-check `README_JP.md` against English README for section parity