### PR TITLE
docs: add contribution and review guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Summary
+
+<!-- What does this PR change, and why? Keep the PR focused on one purpose. -->
+
+## Related issue
+
+<!--
+Link the issue discussed before this work when required by CONTRIBUTING.md.
+Small bug fixes and documentation changes do not require a prior issue.
+-->
+
+Related issue: <!-- #123 or N/A -->
+
+## Testing
+
+<!-- Describe relevant automated and manual testing, including any limitations. -->
+
+- [ ] `gofmt -l .` produces no output
+- [ ] `go vet ./...`
+- [ ] `go test ./...`
+- [ ] `go build ./...`
+- [ ] Tests were added or updated where appropriate
+
+## User and compatibility impact
+
+<!--
+Note UI, behavior, configuration, persisted-state, or compatibility impact.
+Write "None" if there is none.
+-->
+
+## AI assistance
+
+<!--
+If meaningful AI assistance was used, briefly describe it when that context
+would help reviewers. You remain responsible for understanding and verifying
+the submitted change. Write "None" if there is nothing to disclose.
+-->
+
+## Checklist
+
+- [ ] This PR has one clear purpose and contains no unrelated changes
+- [ ] I understand the submitted change and have reviewed it for correctness
+- [ ] Documentation is updated where user-visible behavior changed

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -97,5 +97,5 @@ jobs:
             core.notice(
               `Review requirement met by ${approvals
                 .map((review) => review.user.login)
-                .join(", ")}.",
+                .join(", ")}.`,
             );

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -1,0 +1,101 @@
+# Enforces the repository's conditional review policy: PRs opened by the
+# maintainer may merge without an approval; all other PRs need one current
+# approval from a collaborator with write access.
+name: Review policy
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review-policy:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const maintainer = "senna-lang";
+
+            if (pr.user.login === maintainer) {
+              core.notice("Maintainer-authored PR: approval is not required.");
+              return;
+            }
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+
+            // Only each reviewer's latest review applies. An approval for an
+            // older commit is not sufficient after the PR changes.
+            const latestByReviewer = new Map();
+            for (const review of reviews) {
+              if (!review.user || review.user.login === pr.user.login) {
+                continue;
+              }
+              const previous = latestByReviewer.get(review.user.login);
+              if (
+                !previous ||
+                new Date(review.submitted_at || 0) >=
+                  new Date(previous.submitted_at || 0)
+              ) {
+                latestByReviewer.set(review.user.login, review);
+              }
+            }
+
+            const currentReviews = [];
+            for (const [login, review] of latestByReviewer) {
+              if (review.commit_id !== pr.head.sha) {
+                continue;
+              }
+              const { data: permission } =
+                await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: login,
+                });
+              if (["admin", "maintain", "write"].includes(permission.permission)) {
+                currentReviews.push(review);
+              }
+            }
+
+            const changeRequests = currentReviews.filter(
+              (review) => review.state === "CHANGES_REQUESTED",
+            );
+            if (changeRequests.length > 0) {
+              core.setFailed(
+                `Changes requested by ${changeRequests
+                  .map((review) => review.user.login)
+                  .join(", ")} must be resolved, dismissed, or approved.`,
+              );
+              return;
+            }
+
+            const approvals = currentReviews.filter(
+              (review) => review.state === "APPROVED",
+            );
+            if (approvals.length === 0) {
+              core.setFailed(
+                "This external PR needs one approval from a collaborator with write access.",
+              );
+              return;
+            }
+
+            core.notice(
+              `Review requirement met by ${approvals
+                .map((review) => review.user.login)
+                .join(", ")}.",
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Thanks for helping improve Agent Usage. This project reads data produced by
+several agent harnesses and presents it inside Herdr, so seemingly small changes
+can affect session matching, displayed limits, local state, or compatibility
+with existing installations.
+
+## Before you start
+
+Small bug fixes and documentation improvements are welcome as direct pull
+requests.
+
+Please open an issue before investing in any of the following:
+
+- a new feature or supported provider
+- a change to a configuration or persisted-state format
+- a significant UI or behavior change
+
+Use the issue to describe the problem, the proposed behavior, and any
+compatibility implications. This gives maintainers a chance to confirm that the
+approach fits the project before substantial work begins.
+
+## Development
+
+Agent Usage requires Go 1.25 or later. The executable entry point is
+`cmd/usagebar`. Shared behavior lives under `internal`, including provider
+registration in `internal/providers`, provider-specific session extraction and
+resolution in `internal/providers/<agent>`, limit collection and presentation
+in `internal/limits`, and plugin setup in `internal/setup`.
+
+Build and test the project from the repository root:
+
+```sh
+make build
+make test
+```
+
+Add or update tests for the behavior you change. Prefer focused tests beside
+the affected package, and include regression coverage for bug fixes when
+practical.
+
+Format changed Go files with `gofmt`. Before opening a pull request, run the
+same core checks used by CI (`gofmt -l .` should produce no output):
+
+```sh
+gofmt -l .
+go vet ./...
+go test ./...
+go build ./...
+```
+
+CI runs these checks on both Linux and macOS and also runs golangci-lint and
+govulncheck.
+
+## Pull requests
+
+Keep each pull request focused on one purpose. Explain what changed, why it is
+needed, how it was tested, and any user-visible or compatibility impact. Avoid
+unrelated refactoring or formatting changes.
+
+Passing tests does not guarantee that a change will be accepted. Maintainers
+will also consider backward compatibility, ongoing maintenance cost, and fit
+with the project's direction.
+
+## AI-assisted contributions
+
+AI-assisted contributions are welcome, but the submitter remains responsible
+for the result. You must understand the change, review it for correctness, and
+run the relevant verification yourself. Disclose meaningful AI assistance when
+it would help reviewers evaluate the contribution or when a maintainer asks.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ No telemetry, no analytics, or usage/session data is sent. State written by the 
 - **Herdr core config is not rewritten on install.** Use `usagebar.setup` / `usagebar.enable-toast` or edit by hand.
 - **macOS / Linux** only.
 
+## Contributing
+
+Bug fixes and documentation improvements are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) before starting a larger change.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

- add a project-specific contributing guide and a focused pull request template
- add a review-policy check: PRs authored by `senna-lang` need no approval; other PRs need one current approval from a collaborator with write access
- add a README link to the contributing guide

## Related issue

N/A

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Workflow YAML parses successfully
- [x] No Go behavior changed; no package tests were added

## User and compatibility impact

The repository's `Protect main` Ruleset now requires the `review-policy` check. This PR adds the workflow that provides that check.

## AI assistance

Codex assisted with drafting the documentation, workflow, verification, and Ruleset configuration.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
