### PR TITLE
feat: Add OMP and Pi coding agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Monitor context usage and provider rate limits for agents running in [Herdr](htt
 - **Provider limit row** — a separate sidebar row shows the shortest account-limit window (`5h 72%`) without crowding the context meter.
 - **Account rate-limit windows at a glance** — one live pane shows how much 5h / 7d / 30d allowance is left for Claude, Codex, OpenCode Go, and Grok, with reset countdowns and which open pane is burning it.
 - **Low-allowance warnings** — optional toasts fire when a window drops below your thresholds (default 50 / 20 / 10 / 5 % left), before you hit the wall mid-task.
-- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across all four harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), and Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`). The sidebar then names the backend and totals what that pane spent on it (e.g. `deepseek` with `Σ 425k $0.04`), and the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode today); otherwise the block is token-only.
+- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across supported harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`), and OMP / Pi assistant `message.provider`. The sidebar then names the backend and totals what that pane spent on it (e.g. `deepseek` with `Σ 425k $0.04`), and the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode, OMP, and Pi today); otherwise the block is token-only.
 
 ## Requirements
 
@@ -25,6 +25,8 @@ Monitor context usage and provider rate limits for agents running in [Herdr](htt
 ```bash
 herdr integration install codex
 herdr integration install opencode
+herdr integration install omp
+herdr integration install pi
 # Claude Code integration recommended when you use Claude panes
 ```
 
@@ -117,6 +119,8 @@ herdr plugin action invoke usagebar.setup
 | Codex | Yes | Yes | Context + rate windows from local rollouts; custom `model_provider` panes are pay-as-you-go |
 | OpenCode Go | Yes | Yes | Prefer official web usage when `OPENCODE_GO_COOKIE` is set; else local SQLite. Non-`opencode-go` backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
 | Grok | Yes | Yes | Context from `signals.json`; SuperGrok credits when auth is present. Custom models (`~/.grok/config.toml` `[model.*]` with `base_url`) are pay-as-you-go and labelled from the endpoint host (openai, ollama, …) |
+| OMP (Oh My Pi) | Yes | Yes | Session jsonl under `~/.omp/agent/sessions/`; always pay-as-you-go. Sidebar burn + pane API blocks use assistant `usage.totalTokens` / `usage.cost.total`, grouped by `message.provider` |
+| Pi coding agent | Yes | Yes | Session jsonl under `~/.pi/agent/sessions/`; same pay-as-you-go path as OMP (shared extractors) |
 
 Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 
@@ -243,11 +247,13 @@ Everything is computed from files that the agents already keep on your machine:
 | Codex | rollout files under `~/.codex/sessions/` |
 | OpenCode Go | `~/.local/share/opencode/opencode.db` |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch), `~/.grok/config.toml` (custom-model base URLs) |
+| OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup) |
+| Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present |
 
 Pay-as-you-go detection is not tied to any one harness: it reads the same
 per-harness files above (the backend a session used is already recorded there —
 OpenCode's `providerID`, Codex's `model_provider`, Claude's deployment env,
-Grok's `config.toml`). No extra data sources, no network calls.
+Grok's `config.toml`, OMP/Pi `message.provider`). No extra data sources, no network calls.
 
 Network requests happen in the following cases:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Monitor context usage and provider rate limits for agents running in [Herdr](htt
 - **Provider limit row** — a separate sidebar row shows the shortest account-limit window (`5h 72%`) without crowding the context meter.
 - **Account rate-limit windows at a glance** — one live pane shows how much 5h / 7d / 30d allowance is left for Claude, Codex, OpenCode Go, and Grok, with reset countdowns and which open pane is burning it.
 - **Low-allowance warnings** — optional toasts fire when a window drops below your thresholds (default 50 / 20 / 10 / 5 % left), before you hit the wall mid-task.
-- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across supported harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`), and OMP / Pi assistant `message.provider`. The sidebar then names the backend and totals what that pane spent on it (e.g. `deepseek` with `Σ 425k $0.04`), and the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode, OMP, and Pi today); otherwise the block is token-only.
+- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across supported harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`), and OMP / Pi assistant `message.provider`. The sidebar totals what that pane spent (e.g. `Σ 425k $0.04`); on most pay-as-you-go panes `$provider` names the backend (`deepseek`), while OMP / Pi keep the harness name, and the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode, OMP, and Pi today); otherwise the block is token-only.
 
 ## Requirements
 
@@ -107,7 +107,7 @@ herdr plugin action invoke usagebar.setup
 | --- | --- |
 | **Sidebar `$context` row** | Per-pane context usage: `⛁ 13% (130k)` when the window size is known, or the token count alone |
 | **Sidebar `$limit` row** | Shortest provider limit window (`5h 72%` remaining), or — on a pay-as-you-go pane — what that pane spent on its backend (`Σ 425k $0.04`, scoped to the pane's session and backend) |
-| **Sidebar `$provider` row** | Harness name (`opencode`), or the backend it's actually billing on a pay-as-you-go pane (`deepseek`) |
+| **Sidebar `$provider` row** | Harness name (`opencode`), or the backend it's actually billing on a pay-as-you-go pane (`deepseek`). OMP / Pi keep the harness name — their backends are in-pane model routing, and the burn total spans the whole session |
 | **Agent Usage pane** | Subscription providers: plan, usage windows (5h / 7d / 30d), remaining % bars, reset countdown, open-pane token share. Pay-as-you-go backends: the provider's rolling 24h / 7d / 30d totals (all sessions, not just this pane), per-model breakdown, and open-pane spend share |
 | **Toasts** (optional) | Remaining-limit warnings at configured thresholds (default 50 / 20 / 10 / 5 % left) |
 
@@ -119,8 +119,8 @@ herdr plugin action invoke usagebar.setup
 | Codex | Yes | Yes | Context + rate windows from local rollouts; custom `model_provider` panes are pay-as-you-go |
 | OpenCode Go | Yes | Yes | Prefer official web usage when `OPENCODE_GO_COOKIE` is set; else local SQLite. Non-`opencode-go` backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
 | Grok | Yes | Yes | Context from `signals.json`; SuperGrok credits when auth is present. Custom models (`~/.grok/config.toml` `[model.*]` with `base_url`) are pay-as-you-go and labelled from the endpoint host (openai, ollama, …) |
-| OMP (Oh My Pi) | Yes | Yes | Session jsonl under `~/.omp/agent/sessions/`; always pay-as-you-go. Sidebar burn + pane API blocks use assistant `usage.totalTokens` / `usage.cost.total`, grouped by `message.provider` |
-| Pi coding agent | Yes | Yes | Session jsonl under `~/.pi/agent/sessions/`; same pay-as-you-go path as OMP (shared extractors) |
+| OMP (Oh My Pi) | Yes | Yes | Session jsonl under `~/.omp/agent/sessions/`; always pay-as-you-go. Sidebar keeps harness name on `$provider` and shows session burn on `$limit`; Agent Usage pane groups API blocks by `message.provider` and shows USD when recorded |
+| Pi coding agent | Yes | Yes | Session jsonl under `~/.pi/agent/sessions/`; same pay-as-you-go path as OMP (shared extractors), including harness-name `$provider` |
 
 Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,7 +3,7 @@ name = "Agent Usage"
 version = "0.3.0"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
-description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, and Grok"
+description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"
 platforms = ["macos", "linux"]
 
 [[events]]

--- a/internal/limits/apiusage_files_io.go
+++ b/internal/limits/apiusage_files_io.go
@@ -20,13 +20,14 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
 )
 
 // collectFileHarnessAPIUsage builds blocks for every file-backed harness that
 // has an open pay-as-you-go pane.
 func collectFileHarnessAPIUsage(openPanes []OpenPaneSnapshot, nowMs int64) []APIProviderUsage {
 	var out []APIProviderUsage
-	for _, harnessID := range []string{"claude", "codex", "grok"} {
+	for _, harnessID := range []string{"claude", "codex", "grok", "omp", "pi"} {
 		active := activeAPIPaneBackends(openPanes, harnessID)
 		if len(active) == 0 {
 			continue
@@ -69,7 +70,7 @@ func buildFileHarnessBlocks(harnessID string, active []paneBackend, nowMs int64)
 			Label:     backendDisplayLabel(backendID),
 			Windows:   windows,
 			Models:    SumAPIModels(rows, nowMs, APIShareWindowMinutes),
-			HasCost:   false,
+			HasCost:   AnyAPICost(windows),
 		}
 		if activity := fileHarnessPaneActivity(harnessID, backendID, panesByBackend[backendID], rows, nowMs); activity != nil {
 			block.PaneActivity = activity
@@ -104,6 +105,10 @@ func scanHarnessRows(harnessID string, startMs, nowMs int64) map[string][]apiUsa
 		return scanGrokRowsByBackend(startMs)
 	case "codex":
 		return scanCodexRows(startMs)
+	case "omp":
+		return scanOMPPiRowsByBackend(omp.ListAllOMPSessionFiles(), startMs)
+	case "pi":
+		return scanOMPPiRowsByBackend(omp.ListAllPiSessionFiles(), startMs)
 	default:
 		return nil
 	}
@@ -193,6 +198,26 @@ func scanCodexRows(startMs int64) map[string][]apiUsageRow {
 	return out
 }
 
+// scanOMPPiRowsByBackend reads OMP / Pi session jsonl files touched in the
+// window and groups assistant usage by message provider id.
+func scanOMPPiRowsByBackend(paths []string, startMs int64) map[string][]apiUsageRow {
+	out := make(map[string][]apiUsageRow)
+	for _, path := range paths {
+		lines := readIfTouchedInWindow(path, startMs)
+		if lines == nil {
+			continue
+		}
+		byBackend := OMPPiUsageRowsByBackendFromLines(lines)
+		for backendID, rows := range byBackend {
+			out[backendID] = append(out[backendID], rows...)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // fileHarnessPaneActivity scales each open pane's own session tokens against
 // the backend total, matching how the other blocks compute their share row.
 func fileHarnessPaneActivity(
@@ -226,6 +251,9 @@ func fileHarnessPaneActivity(
 				continue
 			}
 			rows = CodexUsageRowsFromLines(lines, "")
+		case "omp", "pi":
+			byBackend := OMPPiUsageRowsByBackendFromLines(lines)
+			rows = byBackend[backendID]
 		}
 		var tokens float64
 		for _, r := range rows {
@@ -281,6 +309,10 @@ func paneSessionLines(harnessID string, pane OpenPaneSnapshot) []string {
 			return nil
 		}
 		path = strings.Replace(signals, "signals.json", "updates.jsonl", 1)
+	case "omp":
+		path = ompSessionPath(pane)
+	case "pi":
+		path = piSessionPath(pane)
 	}
 	if path == "" {
 		return nil

--- a/internal/limits/apiusage_harness.go
+++ b/internal/limits/apiusage_harness.go
@@ -237,3 +237,107 @@ func GrokUsageRowsFromLines(lines []string) []apiUsageRow {
 	}
 	return out
 }
+
+// OMPPiUsageRowsFromLines converts an OMP / stock Pi session jsonl into
+// usage rows. Each assistant turn carries its own provider/model/cost, so
+// the panel can show backend spend with USD when the harness recorded it.
+// Timestamps are unix milliseconds on the message.
+func OMPPiUsageRowsFromLines(lines []string) []apiUsageRow {
+	var out []apiUsageRow
+	for _, line := range lines {
+		raw := strings.TrimSpace(line)
+		if raw == "" || !strings.Contains(raw, `"role"`) {
+			continue
+		}
+		var parsed struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Role      string `json:"role"`
+				Provider  string `json:"provider"`
+				Model     string `json:"model"`
+				Timestamp int64  `json:"timestamp"`
+				Usage     *struct {
+					TotalTokens *float64 `json:"totalTokens"`
+					Cost        *struct {
+						Total *float64 `json:"total"`
+					} `json:"cost"`
+				} `json:"usage"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			continue
+		}
+		if parsed.Message == nil || parsed.Message.Role != "assistant" || parsed.Message.Usage == nil {
+			continue
+		}
+		tokens := nonNeg(parsed.Message.Usage.TotalTokens)
+		if tokens <= 0 {
+			continue
+		}
+		cost := 0.0
+		if parsed.Message.Usage.Cost != nil {
+			cost = nonNeg(parsed.Message.Usage.Cost.Total)
+		}
+		out = append(out, apiUsageRow{
+			CreatedMs: parsed.Message.Timestamp,
+			ModelID:   parsed.Message.Model,
+			Tokens:    tokens,
+			CostUSD:   cost,
+		})
+	}
+	return out
+}
+
+// OMPPiUsageRowsByBackendFromLines is like OMPPiUsageRowsFromLines, but
+// groups rows by the assistant message's provider id ("deepseek", "cursor").
+func OMPPiUsageRowsByBackendFromLines(lines []string) map[string][]apiUsageRow {
+	out := make(map[string][]apiUsageRow)
+	for _, line := range lines {
+		raw := strings.TrimSpace(line)
+		if raw == "" || !strings.Contains(raw, `"role"`) {
+			continue
+		}
+		var parsed struct {
+			Message *struct {
+				Role      string `json:"role"`
+				Provider  string `json:"provider"`
+				Model     string `json:"model"`
+				Timestamp int64  `json:"timestamp"`
+				Usage     *struct {
+					TotalTokens *float64 `json:"totalTokens"`
+					Cost        *struct {
+						Total *float64 `json:"total"`
+					} `json:"cost"`
+				} `json:"usage"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			continue
+		}
+		if parsed.Message == nil || parsed.Message.Role != "assistant" || parsed.Message.Usage == nil {
+			continue
+		}
+		backendID := strings.TrimSpace(parsed.Message.Provider)
+		if backendID == "" {
+			continue
+		}
+		tokens := nonNeg(parsed.Message.Usage.TotalTokens)
+		if tokens <= 0 {
+			continue
+		}
+		cost := 0.0
+		if parsed.Message.Usage.Cost != nil {
+			cost = nonNeg(parsed.Message.Usage.Cost.Total)
+		}
+		out[backendID] = append(out[backendID], apiUsageRow{
+			CreatedMs: parsed.Message.Timestamp,
+			ModelID:   parsed.Message.Model,
+			Tokens:    tokens,
+			CostUSD:   cost,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/limits/apiusage_harness.go
+++ b/internal/limits/apiusage_harness.go
@@ -270,6 +270,9 @@ func OMPPiUsageRowsFromLines(lines []string) []apiUsageRow {
 		if parsed.Message == nil || parsed.Message.Role != "assistant" || parsed.Message.Usage == nil {
 			continue
 		}
+		if parsed.Message.Timestamp <= 0 {
+			continue
+		}
 		tokens := nonNeg(parsed.Message.Usage.TotalTokens)
 		if tokens <= 0 {
 			continue
@@ -315,6 +318,9 @@ func OMPPiUsageRowsByBackendFromLines(lines []string) map[string][]apiUsageRow {
 			continue
 		}
 		if parsed.Message == nil || parsed.Message.Role != "assistant" || parsed.Message.Usage == nil {
+			continue
+		}
+		if parsed.Message.Timestamp <= 0 {
 			continue
 		}
 		backendID := strings.TrimSpace(parsed.Message.Provider)

--- a/internal/limits/apiusage_harness.go
+++ b/internal/limits/apiusage_harness.go
@@ -12,8 +12,10 @@
  *            fallback label is anthropic
  *   grok   — session modelId joined with ~/.grok/config.toml [model.*]
  *            base_url (openai, ollama, anthropic, …); fallback is xai
+ *   omp/pi — assistant message.provider ("deepseek", "cursor", …)
  *
- * None of these harnesses record cost, so their blocks are token-only.
+ * Claude / Codex / Grok blocks are token-only. OMP / Pi often record
+ * usage.cost.total, so their HasCost follows AnyAPICost(windows).
  */
 package limits
 
@@ -238,61 +240,10 @@ func GrokUsageRowsFromLines(lines []string) []apiUsageRow {
 	return out
 }
 
-// OMPPiUsageRowsFromLines converts an OMP / stock Pi session jsonl into
-// usage rows. Each assistant turn carries its own provider/model/cost, so
-// the panel can show backend spend with USD when the harness recorded it.
-// Timestamps are unix milliseconds on the message.
-func OMPPiUsageRowsFromLines(lines []string) []apiUsageRow {
-	var out []apiUsageRow
-	for _, line := range lines {
-		raw := strings.TrimSpace(line)
-		if raw == "" || !strings.Contains(raw, `"role"`) {
-			continue
-		}
-		var parsed struct {
-			Type    string `json:"type"`
-			Message *struct {
-				Role      string `json:"role"`
-				Provider  string `json:"provider"`
-				Model     string `json:"model"`
-				Timestamp int64  `json:"timestamp"`
-				Usage     *struct {
-					TotalTokens *float64 `json:"totalTokens"`
-					Cost        *struct {
-						Total *float64 `json:"total"`
-					} `json:"cost"`
-				} `json:"usage"`
-			} `json:"message"`
-		}
-		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-			continue
-		}
-		if parsed.Message == nil || parsed.Message.Role != "assistant" || parsed.Message.Usage == nil {
-			continue
-		}
-		if parsed.Message.Timestamp <= 0 {
-			continue
-		}
-		tokens := nonNeg(parsed.Message.Usage.TotalTokens)
-		if tokens <= 0 {
-			continue
-		}
-		cost := 0.0
-		if parsed.Message.Usage.Cost != nil {
-			cost = nonNeg(parsed.Message.Usage.Cost.Total)
-		}
-		out = append(out, apiUsageRow{
-			CreatedMs: parsed.Message.Timestamp,
-			ModelID:   parsed.Message.Model,
-			Tokens:    tokens,
-			CostUSD:   cost,
-		})
-	}
-	return out
-}
-
-// OMPPiUsageRowsByBackendFromLines is like OMPPiUsageRowsFromLines, but
-// groups rows by the assistant message's provider id ("deepseek", "cursor").
+// OMPPiUsageRowsByBackendFromLines converts an OMP / stock Pi session jsonl
+// into usage rows grouped by the assistant message's provider id
+// ("deepseek", "cursor"). Timestamps are unix milliseconds; rows with a
+// missing/non-positive timestamp are skipped so rolling windows stay honest.
 func OMPPiUsageRowsByBackendFromLines(lines []string) map[string][]apiUsageRow {
 	out := make(map[string][]apiUsageRow)
 	for _, line := range lines {

--- a/internal/limits/apiusage_io.go
+++ b/internal/limits/apiusage_io.go
@@ -52,8 +52,9 @@ func activeAPIPaneBackends(openPanes []OpenPaneSnapshot, harnessID string) []pan
 // CollectAPIProviderUsage builds one block per pay-as-you-go backend running
 // in an open pane across every harness, richest first.
 //
-// Only OpenCode records a per-message cost, so blocks from the other
-// harnesses are token-only; the formatter drops the cost column for them.
+// OpenCode and OMP/Pi can record a per-message cost; Claude/Codex/Grok are
+// token-only. Each block's HasCost follows AnyAPICost(windows) so the
+// formatter only shows the cost column when a harness actually recorded USD.
 func CollectAPIProviderUsage(openPanes []OpenPaneSnapshot, nowMs int64) []APIProviderUsage {
 	out := collectOpenCodeAPIUsage(openPanes, nowMs)
 	out = append(out, collectFileHarnessAPIUsage(openPanes, nowMs)...)

--- a/internal/limits/apiusage_omppi_test.go
+++ b/internal/limits/apiusage_omppi_test.go
@@ -7,25 +7,17 @@ func TestOMPPiUsageRowsByBackendFromLines(t *testing.T) {
 		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":1000,"usage":{"totalTokens":100,"cost":{"total":0.01}}}}`,
 		`{"type":"message","message":{"role":"assistant","provider":"cursor","model":"grok","timestamp":2000,"usage":{"totalTokens":50,"cost":{"total":0}}}}`,
 		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":0,"usage":{"totalTokens":999,"cost":{"total":1}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","usage":{"totalTokens":999,"cost":{"total":1}}}}`,
 		`{"type":"message","message":{"role":"user","content":"hi"}}`,
 	}
 	got := OMPPiUsageRowsByBackendFromLines(lines)
-	if len(got["deepseek"]) != 1 || got["deepseek"][0].Tokens != 100 || got["deepseek"][0].CostUSD != 0.01 {
+	if len(got["deepseek"]) != 1 || got["deepseek"][0].Tokens != 100 || got["deepseek"][0].CostUSD != 0.01 || got["deepseek"][0].CreatedMs != 1000 {
 		t.Fatalf("deepseek=%#v", got["deepseek"])
 	}
 	if len(got["cursor"]) != 1 || got["cursor"][0].Tokens != 50 {
 		t.Fatalf("cursor=%#v", got["cursor"])
 	}
-}
-
-func TestOMPPiUsageRowsFromLinesSkipsNonPositiveTimestamp(t *testing.T) {
-	lines := []string{
-		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":1000,"usage":{"totalTokens":100,"cost":{"total":0.01}}}}`,
-		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","usage":{"totalTokens":999,"cost":{"total":1}}}}`,
-		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":0,"usage":{"totalTokens":999,"cost":{"total":1}}}}`,
-	}
-	got := OMPPiUsageRowsFromLines(lines)
-	if len(got) != 1 || got[0].CreatedMs != 1000 || got[0].Tokens != 100 {
-		t.Fatalf("got %#v", got)
+	if _, ok := got[""]; ok {
+		t.Fatalf("unexpected empty backend: %#v", got)
 	}
 }

--- a/internal/limits/apiusage_omppi_test.go
+++ b/internal/limits/apiusage_omppi_test.go
@@ -6,6 +6,7 @@ func TestOMPPiUsageRowsByBackendFromLines(t *testing.T) {
 	lines := []string{
 		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":1000,"usage":{"totalTokens":100,"cost":{"total":0.01}}}}`,
 		`{"type":"message","message":{"role":"assistant","provider":"cursor","model":"grok","timestamp":2000,"usage":{"totalTokens":50,"cost":{"total":0}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":0,"usage":{"totalTokens":999,"cost":{"total":1}}}}`,
 		`{"type":"message","message":{"role":"user","content":"hi"}}`,
 	}
 	got := OMPPiUsageRowsByBackendFromLines(lines)
@@ -14,5 +15,17 @@ func TestOMPPiUsageRowsByBackendFromLines(t *testing.T) {
 	}
 	if len(got["cursor"]) != 1 || got["cursor"][0].Tokens != 50 {
 		t.Fatalf("cursor=%#v", got["cursor"])
+	}
+}
+
+func TestOMPPiUsageRowsFromLinesSkipsNonPositiveTimestamp(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":1000,"usage":{"totalTokens":100,"cost":{"total":0.01}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","usage":{"totalTokens":999,"cost":{"total":1}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":0,"usage":{"totalTokens":999,"cost":{"total":1}}}}`,
+	}
+	got := OMPPiUsageRowsFromLines(lines)
+	if len(got) != 1 || got[0].CreatedMs != 1000 || got[0].Tokens != 100 {
+		t.Fatalf("got %#v", got)
 	}
 }

--- a/internal/limits/apiusage_omppi_test.go
+++ b/internal/limits/apiusage_omppi_test.go
@@ -1,0 +1,18 @@
+package limits
+
+import "testing"
+
+func TestOMPPiUsageRowsByBackendFromLines(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","timestamp":1000,"usage":{"totalTokens":100,"cost":{"total":0.01}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"cursor","model":"grok","timestamp":2000,"usage":{"totalTokens":50,"cost":{"total":0}}}}`,
+		`{"type":"message","message":{"role":"user","content":"hi"}}`,
+	}
+	got := OMPPiUsageRowsByBackendFromLines(lines)
+	if len(got["deepseek"]) != 1 || got["deepseek"][0].Tokens != 100 || got["deepseek"][0].CostUSD != 0.01 {
+		t.Fatalf("deepseek=%#v", got["deepseek"])
+	}
+	if len(got["cursor"]) != 1 || got["cursor"][0].Tokens != 50 {
+		t.Fatalf("cursor=%#v", got["cursor"])
+	}
+}

--- a/internal/limits/attachactivity.go
+++ b/internal/limits/attachactivity.go
@@ -18,6 +18,8 @@ var agentToProvider = map[string]string{
 	"claude":   "claude",
 	"codex":    "codex",
 	"opencode": "opencode",
+	"omp":      "omp",
+	"pi":       "pi",
 	"grok":     "grok",
 }
 

--- a/internal/limits/billingmode_io.go
+++ b/internal/limits/billingmode_io.go
@@ -16,6 +16,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/fsutil"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
 	_ "modernc.org/sqlite"
 )
 
@@ -35,6 +36,9 @@ func paneBillingModeDefault(providerID string, pane OpenPaneSnapshot) BillingMod
 	switch providerID {
 	case "opencode":
 		return opencodePaneBillingMode(pane)
+	case "omp", "pi":
+		// OMP / stock Pi sessions are API-key / Cursor-backed; no subscription quota windows.
+		return BillingPayAsYouGo
 	case "codex":
 		return codexPaneBillingMode(pane)
 	case "claude":
@@ -90,6 +94,10 @@ func payAsYouGoBackendID(providerID string, pane OpenPaneSnapshot) string {
 			return ""
 		}
 		return backendID
+	case "omp":
+		return ompPaneBackendID(pane)
+	case "pi":
+		return piPaneBackendID(pane)
 	case "codex":
 		return codexPaneBackendID(pane)
 	case "claude":
@@ -394,4 +402,50 @@ func grokAccountBillingMode() BillingMode {
 		return BillingUnknown
 	}
 	return GrokBillingModeFromAuthMode(auth.AuthMode)
+}
+
+// ompPaneBackendID returns the latest assistant provider id from the OMP
+// session jsonl path carried on the pane snapshot.
+func ompPaneBackendID(pane OpenPaneSnapshot) string {
+	path := ompSessionPath(pane)
+	if path == "" {
+		return ""
+	}
+	return omp.BackendIDForPath(path)
+}
+
+// ompSessionPath resolves the OMP jsonl path from SessionID, else newest cwd session.
+func ompSessionPath(pane OpenPaneSnapshot) string {
+	if pane.SessionID != nil {
+		if path := omp.SessionPathFromSnapshotValue(*pane.SessionID); path != "" {
+			return path
+		}
+	}
+	if pane.Cwd != nil {
+		return omp.FindLatestOMPSessionForCwd(*pane.Cwd)
+	}
+	return ""
+}
+
+// piSessionPath resolves the stock Pi jsonl path from SessionID, else newest cwd session.
+func piSessionPath(pane OpenPaneSnapshot) string {
+	if pane.SessionID != nil {
+		if path := omp.SessionPathFromSnapshotValue(*pane.SessionID); path != "" {
+			return path
+		}
+	}
+	if pane.Cwd != nil {
+		return omp.FindLatestPiSessionForCwd(*pane.Cwd)
+	}
+	return ""
+}
+
+// piPaneBackendID returns the latest assistant provider id from the Pi
+// session jsonl path carried on the pane snapshot.
+func piPaneBackendID(pane OpenPaneSnapshot) string {
+	path := piSessionPath(pane)
+	if path == "" {
+		return ""
+	}
+	return omp.BackendIDForPath(path)
 }

--- a/internal/limits/panetokens_io.go
+++ b/internal/limits/panetokens_io.go
@@ -13,6 +13,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
 	_ "modernc.org/sqlite"
 )
 
@@ -35,6 +36,12 @@ func TokensForPaneDefault(providerID string, pane OpenPaneSnapshot, startMs, end
 		return codexTokensForPane(pane, startMs, endMs)
 	case "opencode":
 		return opencodeTokensForPane(pane, "opencode-go", startMs, endMs)
+	case "omp":
+		tokens, _ := ompActivityForPane(pane, startMs, endMs)
+		return tokens
+	case "pi":
+		tokens, _ := piActivityForPane(pane, startMs, endMs)
+		return tokens
 	case "grok":
 		return grokTokensForPane(pane, startMs, endMs)
 	default:
@@ -58,6 +65,12 @@ func PaneTotalUsage(providerID string, pane OpenPaneSnapshot, nowMs int64) (toke
 	if providerID == "opencode" {
 		backendID := payAsYouGoBackendID(providerID, pane)
 		return opencodeActivityForPane(pane, backendID, 0, nowMs)
+	}
+	if providerID == "omp" {
+		return ompActivityForPane(pane, 0, nowMs)
+	}
+	if providerID == "pi" {
+		return piActivityForPane(pane, 0, nowMs)
 	}
 	return TokensForPaneAnyBackend(providerID, pane, 0, nowMs), 0
 }
@@ -347,4 +360,20 @@ func grokTotal(startMs, endMs int64) float64 {
 // CollectAndAttachPaneActivity attaches activity using DefaultPaneActivityDeps.
 func CollectAndAttachPaneActivity(providers []ProviderLimits, openPanes []OpenPaneSnapshot, nowMs int64) []ProviderLimits {
 	return AttachPaneActivity(providers, openPanes, nowMs, DefaultPaneActivityDeps())
+}
+
+func ompActivityForPane(pane OpenPaneSnapshot, startMs, endMs int64) (tokens float64, costUSD float64) {
+	path := ompSessionPath(pane)
+	if path == "" {
+		return 0, 0
+	}
+	return omp.ActivityForPath(path, startMs, endMs)
+}
+
+func piActivityForPane(pane OpenPaneSnapshot, startMs, endMs int64) (tokens float64, costUSD float64) {
+	path := piSessionPath(pane)
+	if path == "" {
+		return 0, 0
+	}
+	return omp.ActivityForPath(path, startMs, endMs)
 }

--- a/internal/providers/omp/extract.go
+++ b/internal/providers/omp/extract.go
@@ -1,0 +1,141 @@
+/**
+ * Pure extractors for OMP session jsonl lines.
+ */
+package omp
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type assistantLine struct {
+	Type    string `json:"type"`
+	Message *struct {
+		Role      string `json:"role"`
+		Provider  string `json:"provider"`
+		Model     string `json:"model"`
+		Timestamp int64  `json:"timestamp"`
+		Usage     *struct {
+			TotalTokens *float64 `json:"totalTokens"`
+			Cost        *struct {
+				Total *float64 `json:"total"`
+			} `json:"cost"`
+		} `json:"usage"`
+		ContextSnapshot *struct {
+			PromptTokens *float64 `json:"promptTokens"`
+		} `json:"contextSnapshot"`
+	} `json:"message"`
+}
+
+func parseAssistantLine(raw string) *assistantLine {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !strings.Contains(raw, `"role"`) {
+		return nil
+	}
+	var parsed assistantLine
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil
+	}
+	if parsed.Message == nil || parsed.Message.Role != "assistant" {
+		return nil
+	}
+	return &parsed
+}
+
+func intOrZero(n *float64) int {
+	if n == nil {
+		return 0
+	}
+	return int(*n)
+}
+
+func floatOrZero(n *float64) float64 {
+	if n == nil {
+		return 0
+	}
+	return *n
+}
+
+// ExtractLatestUsageFromLines walks jsonl lines from the end and returns the
+// latest assistant row with context occupancy (or totalTokens as fallback).
+func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
+	for i := len(lines) - 1; i >= 0; i-- {
+		parsed := parseAssistantLine(lines[i])
+		if parsed == nil || parsed.Message == nil {
+			continue
+		}
+		msg := parsed.Message
+		contextTokens := 0
+		if msg.ContextSnapshot != nil {
+			contextTokens = intOrZero(msg.ContextSnapshot.PromptTokens)
+		}
+		totalTokens := 0
+		cost := 0.0
+		if msg.Usage != nil {
+			totalTokens = intOrZero(msg.Usage.TotalTokens)
+			if msg.Usage.Cost != nil {
+				cost = floatOrZero(msg.Usage.Cost.Total)
+			}
+		}
+		if contextTokens <= 0 {
+			contextTokens = totalTokens
+		}
+		if contextTokens <= 0 {
+			continue
+		}
+		return &SessionUsage{
+			Provider:      msg.Provider,
+			Model:         msg.Model,
+			ContextTokens: contextTokens,
+			TotalTokens:   totalTokens,
+			CostUSD:       cost,
+		}
+	}
+	return nil
+}
+
+// ExtractLatestBackendFromLines returns the most recent assistant provider id.
+func ExtractLatestBackendFromLines(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		parsed := parseAssistantLine(lines[i])
+		if parsed == nil || parsed.Message == nil {
+			continue
+		}
+		if provider := strings.TrimSpace(parsed.Message.Provider); provider != "" {
+			return provider
+		}
+	}
+	return ""
+}
+
+// SumUsageFromLines sums assistant turn totals. When startMs/endMs > 0, only
+// events with timestamps inside [startMs, endMs] are counted. Timestamps of 0
+// are always included when a window is unset (startMs==0 && endMs==0), and
+// skipped when a window is active.
+func SumUsageFromLines(lines []string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	windowed := startMs > 0 || endMs > 0
+	for _, line := range lines {
+		parsed := parseAssistantLine(line)
+		if parsed == nil || parsed.Message == nil || parsed.Message.Usage == nil {
+			continue
+		}
+		msg := parsed.Message
+		if windowed {
+			ts := msg.Timestamp
+			if ts <= 0 {
+				continue
+			}
+			if startMs > 0 && ts < startMs {
+				continue
+			}
+			if endMs > 0 && ts > endMs {
+				continue
+			}
+		}
+		tokens += floatOrZero(msg.Usage.TotalTokens)
+		if msg.Usage.Cost != nil {
+			costUSD += floatOrZero(msg.Usage.Cost.Total)
+		}
+	}
+	return tokens, costUSD
+}

--- a/internal/providers/omp/extract_test.go
+++ b/internal/providers/omp/extract_test.go
@@ -1,0 +1,44 @@
+package omp
+
+import "testing"
+
+func TestExtractLatestUsageFromLines(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"user","content":[]}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","usage":{"totalTokens":100,"cost":{"total":0.01}},"contextSnapshot":{"promptTokens":250}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"deepseek-v4-pro","usage":{"totalTokens":200,"cost":{"total":0.02}},"contextSnapshot":{"promptTokens":400}}}`,
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil {
+		t.Fatal("expected usage")
+	}
+	if got.ContextTokens != 400 || got.TotalTokens != 200 || got.Provider != "deepseek" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestSumUsageFromLines(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","timestamp":100,"usage":{"totalTokens":10,"cost":{"total":0.1}}}}`,
+		`{"type":"message","message":{"role":"assistant","timestamp":200,"usage":{"totalTokens":20,"cost":{"total":0.2}}}}`,
+		`{"type":"message","message":{"role":"assistant","timestamp":300,"usage":{"totalTokens":40,"cost":{"total":0.4}}}}`,
+	}
+	tokens, cost := SumUsageFromLines(lines, 0, 0)
+	if tokens != 70 || cost < 0.699 || cost > 0.701 {
+		t.Fatalf("all: tokens=%v cost=%v", tokens, cost)
+	}
+	tokens, cost = SumUsageFromLines(lines, 150, 250)
+	if tokens != 20 || cost < 0.199 || cost > 0.201 {
+		t.Fatalf("window: tokens=%v cost=%v", tokens, cost)
+	}
+}
+
+func TestExtractLatestBackendFromLines(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"x","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"openai","model":"y","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1}}}`,
+	}
+	if got := ExtractLatestBackendFromLines(lines); got != "openai" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/providers/omp/findsession.go
+++ b/internal/providers/omp/findsession.go
@@ -1,0 +1,121 @@
+/**
+ * Resolves the newest session jsonl for a pane cwd when Herdr has not yet
+ * reported agent_session.kind=path (common before the pi/omp integration
+ * extension is loaded, or right after /reload).
+ */
+package omp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EncodePiSessionDir encodes a cwd the way stock pi does:
+//
+//	/Users/me/proj -> --Users-me-proj--
+func EncodePiSessionDir(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(cwd)
+	if cleaned == string(filepath.Separator) {
+		return "----"
+	}
+	trimmed := strings.TrimPrefix(cleaned, string(filepath.Separator))
+	return "--" + strings.ReplaceAll(trimmed, string(filepath.Separator), "-") + "--"
+}
+
+// EncodeOMPSessionDir encodes a cwd the way OMP organizes sessions:
+// prefer path relative to $HOME (develop/foo -> -develop-foo), else absolute.
+func EncodeOMPSessionDir(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(cwd)
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		home = filepath.Clean(home)
+		if cleaned == home {
+			return "--" + strings.ReplaceAll(strings.TrimPrefix(cleaned, string(filepath.Separator)), string(filepath.Separator), "-") + "--"
+		}
+		if rel, err := filepath.Rel(home, cleaned); err == nil && rel != "" && !strings.HasPrefix(rel, "..") {
+			return "-" + strings.ReplaceAll(rel, string(filepath.Separator), "-")
+		}
+	}
+	trimmed := strings.TrimPrefix(cleaned, string(filepath.Separator))
+	return "-" + strings.ReplaceAll(trimmed, string(filepath.Separator), "-")
+}
+
+func piSessionsRoot() string {
+	if v := os.Getenv("PI_SESSIONS_ROOT"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pi", "agent", "sessions")
+}
+
+func ompSessionsRoot() string {
+	if v := os.Getenv("OMP_SESSIONS_ROOT"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".omp", "agent", "sessions")
+}
+
+// FindLatestSessionInDir returns the newest *.jsonl under dir by mtime.
+func FindLatestSessionInDir(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	var best string
+	var bestMod int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		mod := info.ModTime().UnixNano()
+		if best == "" || mod >= bestMod {
+			best = filepath.Join(dir, e.Name())
+			bestMod = mod
+		}
+	}
+	return best
+}
+
+// FindLatestPiSessionForCwd looks under ~/.pi/agent/sessions/--encoded--/.
+func FindLatestPiSessionForCwd(cwd string) string {
+	root := piSessionsRoot()
+	enc := EncodePiSessionDir(cwd)
+	if root == "" || enc == "" {
+		return ""
+	}
+	return FindLatestSessionInDir(filepath.Join(root, enc))
+}
+
+// FindLatestOMPSessionForCwd looks under ~/.omp/agent/sessions/<encoded>/.
+func FindLatestOMPSessionForCwd(cwd string) string {
+	root := ompSessionsRoot()
+	enc := EncodeOMPSessionDir(cwd)
+	if root == "" || enc == "" {
+		return ""
+	}
+	if path := FindLatestSessionInDir(filepath.Join(root, enc)); path != "" {
+		return path
+	}
+	// Fallback: also try pi-style encoding under the OMP root (some builds).
+	return FindLatestSessionInDir(filepath.Join(root, EncodePiSessionDir(cwd)))
+}

--- a/internal/providers/omp/findsession_test.go
+++ b/internal/providers/omp/findsession_test.go
@@ -1,0 +1,33 @@
+package omp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEncodePiSessionDir(t *testing.T) {
+	got := EncodePiSessionDir("/Users/megablacklabel")
+	want := "--Users-megablacklabel--"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFindLatestSessionInDir(t *testing.T) {
+	dir := t.TempDir()
+	older := filepath.Join(dir, "2026-01-01T00-00-00Z_old.jsonl")
+	newer := filepath.Join(dir, "2026-01-02T00-00-00Z_new.jsonl")
+	if err := os.WriteFile(older, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := os.WriteFile(newer, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := FindLatestSessionInDir(dir)
+	if got != newer {
+		t.Fatalf("got %q want %q", got, newer)
+	}
+}

--- a/internal/providers/omp/modelwindows.go
+++ b/internal/providers/omp/modelwindows.go
@@ -1,0 +1,126 @@
+/**
+ * Resolves context window sizes from OMP's local models.db cache.
+ */
+package omp
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+type modelWindowCache struct {
+	mu      sync.Mutex
+	loaded  time.Time
+	path    string
+	windows map[string]int // "provider/model" and bare "model"
+}
+
+var globalModelWindows modelWindowCache
+
+func modelsDBPath() string {
+	if v := os.Getenv("OMP_MODELS_DB"); v != "" {
+		return v
+	}
+	if v := os.Getenv("PI_MODELS_DB"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	for _, rel := range []string{
+		filepath.Join(".pi", "agent", "models.db"),
+		filepath.Join(".omp", "agent", "models.db"),
+	} {
+		path := filepath.Join(home, rel)
+		if st, err := os.Stat(path); err == nil && !st.IsDir() {
+			return path
+		}
+	}
+	return filepath.Join(home, ".omp", "agent", "models.db")
+}
+
+type catalogModel struct {
+	ID            string `json:"id"`
+	ContextWindow int    `json:"contextWindow"`
+}
+
+func loadWindowsFromDB(path string) map[string]int {
+	out := map[string]int{}
+	if path == "" {
+		return out
+	}
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		return out
+	}
+	defer db.Close()
+	rows, err := db.Query(`SELECT provider_id, models FROM model_cache`)
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var providerID, modelsJSON string
+		if err := rows.Scan(&providerID, &modelsJSON); err != nil {
+			continue
+		}
+		var models []catalogModel
+		if err := json.Unmarshal([]byte(modelsJSON), &models); err != nil {
+			continue
+		}
+		for _, model := range models {
+			if model.ID == "" || model.ContextWindow <= 0 {
+				continue
+			}
+			out[model.ID] = model.ContextWindow
+			if providerID != "" {
+				out[providerID+"/"+model.ID] = model.ContextWindow
+			}
+		}
+	}
+	return out
+}
+
+func windowsForLookup() map[string]int {
+	path := modelsDBPath()
+	globalModelWindows.mu.Lock()
+	defer globalModelWindows.mu.Unlock()
+	if path != "" && (globalModelWindows.windows == nil || globalModelWindows.path != path || time.Since(globalModelWindows.loaded) > 60*time.Second) {
+		globalModelWindows.path = path
+		globalModelWindows.windows = loadWindowsFromDB(path)
+		globalModelWindows.loaded = time.Now()
+	}
+	if globalModelWindows.windows == nil {
+		return map[string]int{}
+	}
+	return globalModelWindows.windows
+}
+
+// ContextWindowFor returns the context window for provider/model when known.
+func ContextWindowFor(provider, model string) *int {
+	provider = strings.TrimSpace(provider)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	windows := windowsForLookup()
+	if provider != "" {
+		if n, ok := windows[provider+"/"+model]; ok {
+			v := n
+			return &v
+		}
+	}
+	if n, ok := windows[model]; ok {
+		v := n
+		return &v
+	}
+	return nil
+}

--- a/internal/providers/omp/provider.go
+++ b/internal/providers/omp/provider.go
@@ -1,0 +1,47 @@
+/**
+ * UsageProvider for OMP and stock Pi coding agent.
+ *
+ * Herdr integrations report agent_session.kind="path" pointing at a session
+ * jsonl under ~/.omp or ~/.pi. When the path is missing (extension not yet
+ * reloaded), we fall back to the newest jsonl for the pane cwd.
+ */
+package omp
+
+import (
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+	"github.com/senna-lang/herdr-agent-usage/internal/provider"
+)
+
+// Provider is the OMP UsageProvider (Herdr agent id "omp").
+var Provider = provider.FuncProvider{
+	ID:   "omp",
+	Func: resolveOMPUsage,
+}
+
+// PiProvider is the stock Pi coding agent UsageProvider (Herdr agent id "pi").
+var PiProvider = provider.FuncProvider{
+	ID:   "pi",
+	Func: resolvePiUsage,
+}
+
+func resolveOMPUsage(input provider.UsageResolveInput) *core.ContextUsage {
+	path := SessionPathFromInput(input)
+	if path == "" && input.Cwd != nil {
+		path = FindLatestOMPSessionForCwd(*input.Cwd)
+	}
+	if path == "" {
+		return nil
+	}
+	return ResolveUsageForPath(path)
+}
+
+func resolvePiUsage(input provider.UsageResolveInput) *core.ContextUsage {
+	path := SessionPathFromInput(input)
+	if path == "" && input.Cwd != nil {
+		path = FindLatestPiSessionForCwd(*input.Cwd)
+	}
+	if path == "" {
+		return nil
+	}
+	return ResolveUsageForPath(path)
+}

--- a/internal/providers/omp/resolve.go
+++ b/internal/providers/omp/resolve.go
@@ -109,5 +109,9 @@ func ActivityForPath(path string, startMs, endMs int64) (tokens float64, costUSD
 			lines = append(lines, line)
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		// Fail closed: a truncated scan would undercount silently.
+		return 0, 0
+	}
 	return SumUsageFromLines(lines, startMs, endMs)
 }

--- a/internal/providers/omp/resolve.go
+++ b/internal/providers/omp/resolve.go
@@ -1,0 +1,113 @@
+/**
+ * Reads session usage from an OMP / pi agent_session path.
+ */
+package omp
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+	"github.com/senna-lang/herdr-agent-usage/internal/fsutil"
+	"github.com/senna-lang/herdr-agent-usage/internal/provider"
+)
+
+const tailScanBytes = 1024 * 1024
+
+func expandHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home + path[1:]
+	}
+	return path
+}
+
+// SessionPathFromInput returns the OMP jsonl path from a herdr agent_session.
+// OMP reports kind="path"; value is the absolute (or ~/...) jsonl path.
+func SessionPathFromInput(input provider.UsageResolveInput) string {
+	if input.Session == nil {
+		return ""
+	}
+	if input.Session.Kind != "path" {
+		return ""
+	}
+	return expandHome(strings.TrimSpace(input.Session.Value))
+}
+
+// SessionPathFromSnapshotValue accepts either a path session value or a bare
+// path string stored on OpenPaneSnapshot.SessionID by the sidebar updater.
+func SessionPathFromSnapshotValue(value string) string {
+	value = expandHome(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	if strings.HasSuffix(value, ".jsonl") {
+		return value
+	}
+	return ""
+}
+
+// ResolveUsageForPath returns ContextUsage for an OMP session jsonl path.
+func ResolveUsageForPath(path string) *core.ContextUsage {
+	path = expandHome(path)
+	if path == "" {
+		return nil
+	}
+	lines, err := fsutil.ReadLastNLines(path, tailScanBytes)
+	if err != nil {
+		return nil
+	}
+	usage := ExtractLatestUsageFromLines(lines)
+	if usage == nil {
+		return nil
+	}
+	out := core.ContextUsage{ContextTokens: usage.ContextTokens}
+	if window := ContextWindowFor(usage.Provider, usage.Model); window != nil {
+		out.WindowTokens = window
+	}
+	return &out
+}
+
+// BackendIDForPath returns the latest assistant provider id for the session.
+func BackendIDForPath(path string) string {
+	path = expandHome(path)
+	if path == "" {
+		return ""
+	}
+	lines, err := fsutil.ReadLastNLines(path, tailScanBytes)
+	if err != nil {
+		return ""
+	}
+	return ExtractLatestBackendFromLines(lines)
+}
+
+// ActivityForPath sums token/cost totals for the session, optionally windowed.
+func ActivityForPath(path string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	path = expandHome(path)
+	if path == "" {
+		return 0, 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 8*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, `"role":"assistant"`) || strings.Contains(line, `"role": "assistant"`) {
+			lines = append(lines, line)
+		}
+	}
+	return SumUsageFromLines(lines, startMs, endMs)
+}

--- a/internal/providers/omp/sessions_list.go
+++ b/internal/providers/omp/sessions_list.go
@@ -1,0 +1,49 @@
+/**
+ * Lists OMP / Pi session jsonl files for panel spend aggregation.
+ */
+package omp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ListSessionJSONLUnder walks root/*/*.jsonl (one project dir deep).
+func ListSessionJSONLUnder(root string) []string {
+	if root == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+				continue
+			}
+			out = append(out, filepath.Join(dir, f.Name()))
+		}
+	}
+	return out
+}
+
+// ListAllOMPSessionFiles returns every session jsonl under the OMP sessions root.
+func ListAllOMPSessionFiles() []string {
+	return ListSessionJSONLUnder(ompSessionsRoot())
+}
+
+// ListAllPiSessionFiles returns every session jsonl under the Pi sessions root.
+func ListAllPiSessionFiles() []string {
+	return ListSessionJSONLUnder(piSessionsRoot())
+}

--- a/internal/providers/omp/types.go
+++ b/internal/providers/omp/types.go
@@ -1,0 +1,22 @@
+/**
+ * Usage shape derived from an OMP / pi agent session jsonl.
+ */
+package omp
+
+// SessionUsage is the latest assistant usage row from an OMP session.
+type SessionUsage struct {
+	Provider      string
+	Model         string
+	ContextTokens int
+	TotalTokens   int
+	CostUSD       float64
+}
+
+// UsageEvent is one assistant turn's token/cost contribution.
+type UsageEvent struct {
+	Provider    string
+	Model       string
+	TotalTokens int
+	CostUSD     float64
+	TimestampMs int64
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/opencode"
 )
 
@@ -17,6 +18,8 @@ var All = []provider.UsageProvider{
 	claude.Provider,
 	codex.Provider,
 	grok.Provider,
+	omp.Provider,
+	omp.PiProvider,
 	opencode.Provider,
 }
 

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -6,7 +6,7 @@ package providers
 import "testing"
 
 func TestFindProvider_Registered(t *testing.T) {
-	for _, id := range []string{"claude", "codex", "grok", "opencode"} {
+	for _, id := range []string{"claude", "codex", "grok", "omp", "pi", "opencode"} {
 		p := FindProvider(id)
 		if p == nil || p.AgentID() != id {
 			t.Fatalf("%s: got %#v", id, p)

--- a/internal/setup/herdrconfig.go
+++ b/internal/setup/herdrconfig.go
@@ -48,7 +48,8 @@ func ToastConfigSnippet() string {
 //
 // $provider replaces the built-in `agent` token: it renders the harness name
 // ("opencode") on a subscription pane and the backend name ("deepseek") on a
-// pay-as-you-go one, where the backend is the more informative half.
+// pay-as-you-go one, where the backend is the more informative half. OMP / Pi
+// keep the harness name because their backends are in-pane model routing.
 func SidebarRowsSnippet() string {
 	return strings.Join([]string{
 		"[ui.sidebar.agents]",

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -27,6 +27,10 @@ func isSettledStatus(status string) bool {
 // informative half (the harness is already implied by the pane's agent icon).
 // It stands in for Herdr's built-in `agent` token, which is why it must carry
 // the harness name in the subscription case.
+//
+// OMP / Pi are the exception: their message.provider is model routing inside
+// one agent, and the adjacent burn total spans every backend in the session,
+// so $provider keeps the harness name.
 func formatSidebarProvider(agentName, providerID string, pane limits.OpenPaneSnapshot) string {
 	return formatSidebarProviderWith(limits.PaneBackendID, agentName, providerID, pane)
 }
@@ -38,6 +42,9 @@ func formatSidebarProviderWith(
 ) string {
 	if agentName == "" {
 		return ""
+	}
+	if providerID == "omp" || providerID == "pi" {
+		return agentName
 	}
 	if backendID := backendFor(providerID, pane); backendID != "" {
 		return backendID

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -102,3 +102,15 @@ func TestFormatSidebarProviderWith_EmptyAgentRendersNothing(t *testing.T) {
 		t.Fatalf("got %q want empty", got)
 	}
 }
+
+func TestFormatSidebarProviderWith_OMPPiKeepHarnessName(t *testing.T) {
+	backendFor := func(providerID string, pane limits.OpenPaneSnapshot) string {
+		return "deepseek"
+	}
+	if got := formatSidebarProviderWith(backendFor, "omp", "omp", limits.OpenPaneSnapshot{}); got != "omp" {
+		t.Fatalf("omp: got %q want omp", got)
+	}
+	if got := formatSidebarProviderWith(backendFor, "pi", "pi", limits.OpenPaneSnapshot{}); got != "pi" {
+		t.Fatalf("pi: got %q want pi", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add first-class `omp` and `pi` providers under `internal/providers/omp/` so sidebar `$context` / `$limit` resolve from session jsonl (with cwd fallback when `agent_session` is missing).
- Extend the existing file-harness / pay-as-you-go Agent Usage pane path for OMP/Pi: scan session files, group by `message.provider`, and show USD when the harness recorded `usage.cost.total`.
- Treat OMP/Pi as always pay-as-you-go (no subscription 5h/7d/30d windows). Document the new harnesses in README and the plugin description.

## Related issue

Related issue: #12

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Tests were added or updated where appropriate

Automated coverage includes registry registration, OMP/Pi jsonl extractors, session finders, and harness row decoding.

Manual verification was done earlier against a live Herdr 0.7.4 install with the local prototype: OMP/Pi panes populated sidebar burn (`Σ … $…`) and Agent Usage pane API blocks (e.g. DeepSeek / Cursor) instead of `(no usage data yet)`.

## User and compatibility impact

- New supported agents: OMP (`herdr:omp`) and stock Pi (`herdr:pi`).
- Existing Claude / Codex / OpenCode / Grok behavior is unchanged aside from `HasCost` now reflecting whether file-harness windows actually carry cost (still false for token-only harnesses).
- No config or persisted-state format changes.
- Requires `herdr integration install omp` / `pi` for reliable `agent_session` path matching; cwd→latest-jsonl fallback covers the pre-reload window.

## AI assistance

Assisted by Cursor while porting the local prototype into this repository, drafting docs, and preparing the PR. I reviewed the change and ran the verification commands above.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed