### PR TITLE
chore: Add Claude multi-profile (multi-account) support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,14 @@ linters:
         - (*database/sql.Rows).Close
         - fmt.Fprint
         - golang.org/x/term.Restore
+  exclusions:
+    rules:
+      # staticcheck as bundled in golangci-lint (version: latest) does not model
+      # (*testing.T).Fatal as terminating, so `if p == nil { t.Fatal(...) }`
+      # guards before a deref trip SA5011 (possible nil dereference). Standalone
+      # staticcheck reports these as clean, so they are false positives; a nil
+      # deref in a test just fails the test anyway. Keep SA5011 live in
+      # production code, where it catches real bugs.
+      - path: '_test\.go'
+        linters: [staticcheck]
+        text: 'SA5011'

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
@@ -439,8 +440,23 @@ func runStatusLine() {
 	}
 	stdinJSON := string(data)
 	nowMs := time.Now().UnixMilli()
-	if rateLimits := ratelimit.ParseRateLimits(stdinJSON); rateLimits != nil {
-		// Persist rate_limits so the limits pane can show Claude windows.
+
+	// Route this statusLine invocation to the profile matching its own
+	// CLAUDE_CONFIG_DIR. The statusLine runs inside the Claude process, so the
+	// env var is present and identifies the account unambiguously.
+	env := environment()
+	profiles := setup.ResolveClaudeProfiles(env)
+	profile, known := claude.ResolveActiveProfile(profiles, env["CLAUDE_CONFIG_DIR"])
+	if !known {
+		// Profiles are configured but none match this CLAUDE_CONFIG_DIR: skip all
+		// writes and notifications rather than misattribute the account. Still
+		// print the summary so the Claude status line renders.
+		printStatusLineSummary(stdinJSON)
+		return
+	}
+
+	rateLimits := ratelimit.ParseRateLimits(stdinJSON)
+	if rateLimits != nil {
 		input := limits.RateLimitsInput{}
 		if rateLimits.FiveHour != nil {
 			input.FiveHour = &struct {
@@ -454,18 +470,34 @@ func runStatusLine() {
 				ResetsAt       int64
 			}{rateLimits.SevenDay.UsedPercentage, rateLimits.SevenDay.ResetsAt}
 		}
-		if err := limits.WriteClaudeLimitsCache(input, nowMs, ""); err != nil {
+		// Empty-payload guard lives in WriteClaudeLimitsCacheGuarded so `{}`
+		// cannot clobber a valid cache.
+		if _, err := limits.WriteClaudeLimitsCacheGuarded(input, nowMs, profile.LimitsCache); err != nil {
 			fmt.Fprintf(os.Stderr, "[usagebar-rate] cache write failed: %v\n", err)
 		}
 	}
+
+	// Prefix non-default profile toasts with the profile label so two accounts'
+	// alerts are distinguishable.
+	notify := herdrcli.ShowNotification
+	if !claude.IsDefaultProfile(profile) {
+		label := profile.Label
+		inner := notify
+		notify = func(title, body string) bool { return inner(label+": "+title, body) }
+	}
+
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Fprintf(os.Stderr, "[usagebar-rate] check failed: %v\n", r)
 			}
 		}()
-		ratelimit.RunRateLimitCheck(stdinJSON, nowMs, herdrcli.ShowNotification)
+		ratelimit.RunRateLimitCheckIn(profile.StateDir, stdinJSON, nowMs, notify)
 	}()
+	printStatusLineSummary(stdinJSON)
+}
+
+func printStatusLineSummary(stdinJSON string) {
 	summary := ratelimit.FormatStatusLineSummary(ratelimit.ParseRateLimits(stdinJSON))
 	if summary != "" {
 		fmt.Println(summary)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/senna-lang/herdr-agent-usage
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	golang.org/x/term v0.45.0
 	modernc.org/sqlite v1.54.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/claude/profile.go
+++ b/internal/claude/profile.go
@@ -1,0 +1,171 @@
+/**
+ * Claude multi-account profile model.
+ *
+ * A profile is one CLAUDE_CONFIG_DIR-scoped account. All plugin-derived files
+ * (limits cache, notify state, transcript root) live under the profile's config
+ * dir, so two accounts never collide. Absence of any configured profile
+ * synthesizes today's single implicit "claude" profile, whose derived paths are
+ * byte-identical to the historical ~/.claude defaults (env overrides still win).
+ */
+package claude
+
+import "path/filepath"
+
+// DefaultProfileID is the provider id used for the single implicit profile.
+const DefaultProfileID = "claude"
+
+// DefaultProfileLabel is the display label for the single implicit profile.
+const DefaultProfileLabel = "Claude"
+
+// ProfileSpec is one unresolved [[claude.profiles]] config entry.
+type ProfileSpec struct {
+	ID        string
+	Label     string
+	ConfigDir string
+	JSONPath  string
+}
+
+// ClaudeProfile is a resolved profile with concrete absolute paths.
+type ClaudeProfile struct {
+	ID           string
+	Label        string
+	ConfigDir    string
+	JSONPath     string // .claude.json for this profile
+	LimitsCache  string // statusLine limits cache
+	StateDir     string // notify state + lock dir
+	ProjectsRoot string // transcript projects root
+}
+
+// derivedLimitsCache is the per-config-dir limits cache path.
+func derivedLimitsCache(configDir string) string {
+	return filepath.Join(configDir, "herdr-usagebar", "claude-limits-latest.json")
+}
+
+// derivedStateDir is the per-config-dir notify state dir.
+func derivedStateDir(configDir string) string {
+	return filepath.Join(configDir, "herdr-usagebar")
+}
+
+// derivedProjectsRoot is the per-config-dir transcript projects root.
+func derivedProjectsRoot(configDir string) string {
+	return filepath.Join(configDir, "projects")
+}
+
+// firstNonEmpty returns the first non-empty string, or "".
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// synthesizeDefaultProfile builds the single implicit "claude" profile.
+//
+// Its derived paths are anchored to the historical ~/.claude location, NOT
+// CLAUDE_CONFIG_DIR: the write side (statusLine, in-process) can see that env
+// var but the read side (panel/sidebar/notify, a Herdr plugin action) cannot,
+// so deriving the default off it would make the two sides disagree on where an
+// unconfigured account's files live. Isolation for a relocated CLAUDE_CONFIG_DIR
+// is opt-in via an explicit [[claude.profiles]] entry (config_dir is visible to
+// both sides because it comes from config, not env).
+//
+// The explicit USAGEBAR_*/CLAUDE_PROJECTS_ROOT/CLAUDE_CONFIG_JSON overrides
+// still apply here since they are pre-existing, side-agnostic escape hatches
+// the caller sets deliberately (not an implicit CLAUDE_CONFIG_DIR read).
+func synthesizeDefaultProfile(env map[string]string, home string) ClaudeProfile {
+	configDir := filepath.Join(home, ".claude")
+	return ClaudeProfile{
+		ID:           DefaultProfileID,
+		Label:        DefaultProfileLabel,
+		ConfigDir:    configDir,
+		JSONPath:     firstNonEmpty(env["CLAUDE_CONFIG_JSON"], filepath.Join(home, ".claude.json")),
+		LimitsCache:  firstNonEmpty(env["USAGEBAR_CLAUDE_LIMITS_PATH"], derivedLimitsCache(configDir)),
+		StateDir:     firstNonEmpty(env["USAGEBAR_STATE_DIR"], derivedStateDir(configDir)),
+		ProjectsRoot: firstNonEmpty(env["CLAUDE_PROJECTS_ROOT"], derivedProjectsRoot(configDir)),
+	}
+}
+
+// resolveSpec builds a concrete profile from one config entry. Env path
+// overrides are deliberately ignored in multi-profile mode: a single global
+// override cannot be attributed to one of several profiles.
+func resolveSpec(spec ProfileSpec) ClaudeProfile {
+	label := firstNonEmpty(spec.Label, spec.ID)
+	jsonPath := firstNonEmpty(spec.JSONPath, filepath.Join(spec.ConfigDir, ".claude.json"))
+	return ClaudeProfile{
+		ID:           spec.ID,
+		Label:        label,
+		ConfigDir:    spec.ConfigDir,
+		JSONPath:     jsonPath,
+		LimitsCache:  derivedLimitsCache(spec.ConfigDir),
+		StateDir:     derivedStateDir(spec.ConfigDir),
+		ProjectsRoot: derivedProjectsRoot(spec.ConfigDir),
+	}
+}
+
+// ResolveProfiles turns config entries into concrete profiles.
+//
+//   - No specs -> one synthesized default "claude" profile (backward compat).
+//   - Otherwise each valid spec becomes a profile. Entries missing id or
+//     config_dir are skipped, as are duplicate ids and duplicate config dirs
+//     (first wins), so malformed config degrades safely rather than colliding.
+func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []ClaudeProfile {
+	if len(specs) == 0 {
+		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}
+	}
+	out := make([]ClaudeProfile, 0, len(specs))
+	seenID := map[string]bool{}
+	seenDir := map[string]bool{}
+	for _, spec := range specs {
+		if spec.ID == "" || spec.ConfigDir == "" {
+			continue
+		}
+		if seenID[spec.ID] || seenDir[spec.ConfigDir] {
+			continue
+		}
+		seenID[spec.ID] = true
+		seenDir[spec.ConfigDir] = true
+		out = append(out, resolveSpec(spec))
+	}
+	if len(out) == 0 {
+		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}
+	}
+	return out
+}
+
+// ResolveActiveProfile picks the profile whose ConfigDir matches the given
+// configDir (typically the in-process CLAUDE_CONFIG_DIR on the write side).
+//
+//   - Single profile: always returns it (ok=true) — the single-profile fallback.
+//   - Multiple profiles: returns the config-dir match, or ok=false when none
+//     match, so the caller can skip writes rather than misattribute the account.
+func ResolveActiveProfile(profiles []ClaudeProfile, configDir string) (ClaudeProfile, bool) {
+	if len(profiles) == 1 {
+		return profiles[0], true
+	}
+	for _, p := range profiles {
+		if p.ConfigDir == configDir {
+			return p, true
+		}
+	}
+	return ClaudeProfile{}, false
+}
+
+// IsDefaultProfile reports whether p is the lone implicit default profile,
+// used to decide whether notification titles get a label prefix.
+func IsDefaultProfile(p ClaudeProfile) bool {
+	return p.ID == DefaultProfileID && p.Label == DefaultProfileLabel
+}
+
+// IsClaudeProviderID reports whether a provider id belongs to any configured
+// Claude profile. Replaces literal `== "claude"` checks now that a profile's id
+// may be e.g. "claude-secondary".
+func IsClaudeProviderID(id string, profiles []ClaudeProfile) bool {
+	for _, p := range profiles {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/claude/profile.go
+++ b/internal/claude/profile.go
@@ -87,12 +87,29 @@ func synthesizeDefaultProfile(env map[string]string, home string) ClaudeProfile 
 	}
 }
 
+// defaultJSONPathFor returns the default .claude.json path for configDir.
+//
+// Claude Code does not relocate .claude.json under CLAUDE_CONFIG_DIR — it
+// always lives at the fixed sibling path ~/.claude.json regardless of which
+// config dir is active, unless the user separately sets CLAUDE_CONFIG_JSON.
+// So a profile whose config_dir happens to equal the real default (~/.claude,
+// e.g. when re-declaring the default account alongside additional accounts,
+// as the multi-profile config example does) must default its JSONPath to
+// that same sibling file, not <config_dir>/.claude.json — the naive pattern
+// that holds for any other, genuinely separate config dir.
+func defaultJSONPathFor(configDir, home string) string {
+	if configDir == filepath.Join(home, ".claude") {
+		return filepath.Join(home, ".claude.json")
+	}
+	return filepath.Join(configDir, ".claude.json")
+}
+
 // resolveSpec builds a concrete profile from one config entry. Env path
 // overrides are deliberately ignored in multi-profile mode: a single global
 // override cannot be attributed to one of several profiles.
-func resolveSpec(spec ProfileSpec) ClaudeProfile {
+func resolveSpec(spec ProfileSpec, home string) ClaudeProfile {
 	label := firstNonEmpty(spec.Label, spec.ID)
-	jsonPath := firstNonEmpty(spec.JSONPath, filepath.Join(spec.ConfigDir, ".claude.json"))
+	jsonPath := firstNonEmpty(spec.JSONPath, defaultJSONPathFor(spec.ConfigDir, home))
 	return ClaudeProfile{
 		ID:           spec.ID,
 		Label:        label,
@@ -126,7 +143,7 @@ func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []
 		}
 		seenID[spec.ID] = true
 		seenDir[spec.ConfigDir] = true
-		out = append(out, resolveSpec(spec))
+		out = append(out, resolveSpec(spec, home))
 	}
 	if len(out) == 0 {
 		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}

--- a/internal/claude/profile_test.go
+++ b/internal/claude/profile_test.go
@@ -192,3 +192,34 @@ func TestIsDefaultProfile(t *testing.T) {
 		t.Fatal("custom profile is not default")
 	}
 }
+
+func TestResolveProfiles_DefaultDirProfileUsesSiblingJSONPath(t *testing.T) {
+	// Re-declaring the real default account (config_dir == ~/.claude) as an
+	// explicit profile, alongside other accounts, must still resolve its
+	// .claude.json to the sibling ~/.claude.json -- Claude Code never writes
+	// that file inside ~/.claude/ itself.
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: filepath.Join(home, ".claude")},
+		{ID: "claude-secondary", ConfigDir: "/other/dir"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if profiles[0].JSONPath != filepath.Join(home, ".claude.json") {
+		t.Fatalf("default-dir profile jsonPath = %q, want sibling ~/.claude.json", profiles[0].JSONPath)
+	}
+	// A genuinely separate config dir still defaults to <config_dir>/.claude.json.
+	if profiles[1].JSONPath != filepath.Join("/other/dir", ".claude.json") {
+		t.Fatalf("separate-dir profile jsonPath = %q", profiles[1].JSONPath)
+	}
+}
+
+func TestResolveProfiles_ExplicitJSONPathOverridesDefaultDirHeuristic(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: filepath.Join(home, ".claude"), JSONPath: "/custom/path.json"},
+	}
+	p := ResolveProfiles(specs, map[string]string{}, home)[0]
+	if p.JSONPath != "/custom/path.json" {
+		t.Fatalf("explicit claude_json_path must win, got %q", p.JSONPath)
+	}
+}

--- a/internal/claude/profile_test.go
+++ b/internal/claude/profile_test.go
@@ -1,0 +1,194 @@
+/**
+ * Tests for the Claude multi-account profile model.
+ */
+package claude
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveProfiles_DefaultWhenNoSpecs(t *testing.T) {
+	home := "/home/u"
+	profiles := ResolveProfiles(nil, map[string]string{}, home)
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 default profile, got %d", len(profiles))
+	}
+	p := profiles[0]
+	if p.ID != "claude" || p.Label != "Claude" {
+		t.Fatalf("id/label = %q/%q", p.ID, p.Label)
+	}
+	if p.ConfigDir != filepath.Join(home, ".claude") {
+		t.Fatalf("configDir = %q", p.ConfigDir)
+	}
+	// Byte-identical to historical defaults.
+	if p.LimitsCache != filepath.Join(home, ".claude", "herdr-usagebar", "claude-limits-latest.json") {
+		t.Fatalf("limitsCache = %q", p.LimitsCache)
+	}
+	if p.StateDir != filepath.Join(home, ".claude", "herdr-usagebar") {
+		t.Fatalf("stateDir = %q", p.StateDir)
+	}
+	if p.ProjectsRoot != filepath.Join(home, ".claude", "projects") {
+		t.Fatalf("projectsRoot = %q", p.ProjectsRoot)
+	}
+	if p.JSONPath != filepath.Join(home, ".claude.json") {
+		t.Fatalf("jsonPath = %q", p.JSONPath)
+	}
+}
+
+func TestResolveProfiles_DefaultHonorsEnvOverrides(t *testing.T) {
+	home := "/home/u"
+	env := map[string]string{
+		"USAGEBAR_CLAUDE_LIMITS_PATH": "/override/limits.json",
+		"USAGEBAR_STATE_DIR":          "/override/state",
+		"CLAUDE_PROJECTS_ROOT":        "/override/projects",
+		"CLAUDE_CONFIG_JSON":          "/override/.claude.json",
+	}
+	p := ResolveProfiles(nil, env, home)[0]
+	if p.LimitsCache != "/override/limits.json" {
+		t.Fatalf("limitsCache = %q", p.LimitsCache)
+	}
+	if p.StateDir != "/override/state" {
+		t.Fatalf("stateDir = %q", p.StateDir)
+	}
+	if p.ProjectsRoot != "/override/projects" {
+		t.Fatalf("projectsRoot = %q", p.ProjectsRoot)
+	}
+	if p.JSONPath != "/override/.claude.json" {
+		t.Fatalf("jsonPath = %q", p.JSONPath)
+	}
+}
+
+func TestResolveProfiles_DefaultIgnoresConfigDirEnv(t *testing.T) {
+	// The synthesized default must stay anchored to ~/.claude regardless of
+	// CLAUDE_CONFIG_DIR: that var is visible to the write side (statusLine,
+	// in-process) but invisible to the read side (panel/sidebar, a Herdr plugin
+	// action), so deriving the default off it would make the two sides read and
+	// write different files for the same unconfigured account.
+	home := "/home/u"
+	p := ResolveProfiles(nil, map[string]string{"CLAUDE_CONFIG_DIR": "/alt/cfg"}, home)[0]
+	if p.ConfigDir != filepath.Join(home, ".claude") {
+		t.Fatalf("configDir must ignore CLAUDE_CONFIG_DIR, got %q", p.ConfigDir)
+	}
+	if p.LimitsCache != filepath.Join(home, ".claude", "herdr-usagebar", "claude-limits-latest.json") {
+		t.Fatalf("limitsCache = %q", p.LimitsCache)
+	}
+	if p.ProjectsRoot != filepath.Join(home, ".claude", "projects") {
+		t.Fatalf("projectsRoot = %q", p.ProjectsRoot)
+	}
+}
+
+func TestResolveProfiles_MultipleProfiles(t *testing.T) {
+	specs := []ProfileSpec{
+		{ID: "claude", Label: "Claude", ConfigDir: "/a"},
+		{ID: "claude-m", ConfigDir: "/b"}, // label defaults to id
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
+	if len(profiles) != 2 {
+		t.Fatalf("want 2, got %d", len(profiles))
+	}
+	if profiles[1].Label != "claude-m" {
+		t.Fatalf("label default = %q", profiles[1].Label)
+	}
+	if profiles[1].JSONPath != filepath.Join("/b", ".claude.json") {
+		t.Fatalf("jsonPath default = %q", profiles[1].JSONPath)
+	}
+	if profiles[0].LimitsCache != filepath.Join("/a", "herdr-usagebar", "claude-limits-latest.json") {
+		t.Fatalf("limitsCache = %q", profiles[0].LimitsCache)
+	}
+}
+
+func TestResolveProfiles_MultiIgnoresEnvOverrides(t *testing.T) {
+	// A global override cannot be attributed to one of several profiles.
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: "/a"},
+		{ID: "claude-m", ConfigDir: "/b"},
+	}
+	env := map[string]string{"USAGEBAR_CLAUDE_LIMITS_PATH": "/override/limits.json"}
+	profiles := ResolveProfiles(specs, env, "/home/u")
+	for _, p := range profiles {
+		if p.LimitsCache == "/override/limits.json" {
+			t.Fatalf("multi mode must ignore global override, got %q", p.LimitsCache)
+		}
+	}
+}
+
+func TestResolveProfiles_RejectsDuplicates(t *testing.T) {
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: "/a"},
+		{ID: "claude", ConfigDir: "/c"},   // dup id
+		{ID: "claude-x", ConfigDir: "/a"}, // dup config dir
+		{ID: "claude-y", ConfigDir: "/d"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
+	if len(profiles) != 2 {
+		t.Fatalf("want 2 after dedupe, got %d: %+v", len(profiles), profiles)
+	}
+	if profiles[0].ID != "claude" || profiles[1].ID != "claude-y" {
+		t.Fatalf("unexpected survivors: %q, %q", profiles[0].ID, profiles[1].ID)
+	}
+}
+
+func TestResolveProfiles_SkipsIncompleteEntries(t *testing.T) {
+	specs := []ProfileSpec{
+		{ID: "", ConfigDir: "/a"},       // missing id
+		{ID: "claude-z", ConfigDir: ""}, // missing config dir
+	}
+	// All invalid -> falls back to synthesized default.
+	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
+	if len(profiles) != 1 || profiles[0].ID != "claude" {
+		t.Fatalf("want fallback default, got %+v", profiles)
+	}
+}
+
+func TestIsClaudeProviderID(t *testing.T) {
+	profiles := []ClaudeProfile{{ID: "claude"}, {ID: "claude-secondary"}}
+	if !IsClaudeProviderID("claude-secondary", profiles) {
+		t.Fatal("claude-secondary should be recognized")
+	}
+	if IsClaudeProviderID("codex", profiles) {
+		t.Fatal("codex should not be recognized")
+	}
+}
+
+func TestResolveActiveProfile_SingleAlwaysMatches(t *testing.T) {
+	profiles := ResolveProfiles(nil, map[string]string{"CLAUDE_CONFIG_DIR": "/x"}, "/home/u")
+	p, ok := ResolveActiveProfile(profiles, "/totally/different")
+	if !ok || p.ID != "claude" {
+		t.Fatalf("single-profile fallback failed: ok=%v id=%q", ok, p.ID)
+	}
+}
+
+func TestResolveActiveProfile_MultiMatchesConfigDir(t *testing.T) {
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: "/a"},
+		{ID: "claude-m", ConfigDir: "/b"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
+	p, ok := ResolveActiveProfile(profiles, "/b")
+	if !ok || p.ID != "claude-m" {
+		t.Fatalf("want claude-m, ok=%v id=%q", ok, p.ID)
+	}
+}
+
+func TestResolveActiveProfile_MultiUnknownSkips(t *testing.T) {
+	specs := []ProfileSpec{
+		{ID: "claude", ConfigDir: "/a"},
+		{ID: "claude-m", ConfigDir: "/b"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
+	if _, ok := ResolveActiveProfile(profiles, "/unknown"); ok {
+		t.Fatal("unknown CLAUDE_CONFIG_DIR must not match under multi-profile")
+	}
+}
+
+func TestIsDefaultProfile(t *testing.T) {
+	def := ResolveProfiles(nil, map[string]string{}, "/home/u")[0]
+	if !IsDefaultProfile(def) {
+		t.Fatal("synthesized default should be default")
+	}
+	custom := ResolveProfiles([]ProfileSpec{{ID: "claude-m", ConfigDir: "/b"}}, map[string]string{}, "/home/u")[0]
+	if IsDefaultProfile(custom) {
+		t.Fatal("custom profile is not default")
+	}
+}

--- a/internal/limits/activeproviders.go
+++ b/internal/limits/activeproviders.go
@@ -20,11 +20,26 @@ func ActiveProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool) map[st
 // ActiveProviderSet returns the provider ids that have at least one open
 // pane. Agent ids match case-insensitively; unknown agents are ignored.
 // The result is never nil: an empty set means "no agent panes open".
+//
+// A Claude pane (any account) activates every configured Claude profile id —
+// not just the one that pane happens to belong to — so the panel can show all
+// configured accounts side by side for comparison, per the issue's request.
 func ActiveProviderSet(openPanes []OpenPaneSnapshot) map[string]bool {
 	set := make(map[string]bool)
+	hasClaudePane := false
 	for _, pane := range openPanes {
-		if providerID, ok := agentToProvider[strings.ToLower(pane.Agent)]; ok {
+		agent := strings.ToLower(pane.Agent)
+		if agent == "claude" {
+			hasClaudePane = true
+			continue
+		}
+		if providerID, ok := agentToProvider[agent]; ok {
 			set[providerID] = true
+		}
+	}
+	if hasClaudePane {
+		for _, p := range ResolvedClaudeProfiles() {
+			set[p.ID] = true
 		}
 	}
 	return set

--- a/internal/limits/activeproviders_test.go
+++ b/internal/limits/activeproviders_test.go
@@ -3,9 +3,23 @@
  */
 package limits
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isolatePluginConfig points HERDR_PLUGIN_CONFIG_DIR at an empty temp dir so
+// ResolvedClaudeProfiles() (invoked whenever a claude pane is present) always
+// synthesizes the single default profile here, regardless of the machine
+// running the test.
+func isolatePluginConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", t.TempDir())
+}
 
 func TestActiveProviderSet_OnlyOpenAgents(t *testing.T) {
+	isolatePluginConfig(t)
 	panes := []OpenPaneSnapshot{
 		{PaneID: "w1:p1", Agent: "claude"},
 		{PaneID: "w1:p2", Agent: "claude"},
@@ -56,6 +70,7 @@ func TestActiveProviderFilter_ConfirmedEmptyHidesAll(t *testing.T) {
 }
 
 func TestActiveProviderFilter_OKUsesActiveSet(t *testing.T) {
+	isolatePluginConfig(t)
 	panes := []OpenPaneSnapshot{{PaneID: "w1:p1", Agent: "claude"}}
 	got := ActiveProviderFilter(panes, true)
 	if len(got) != 1 || !got["claude"] {
@@ -64,6 +79,7 @@ func TestActiveProviderFilter_OKUsesActiveSet(t *testing.T) {
 }
 
 func TestActiveProviderSet_CaseInsensitiveAgentIDs(t *testing.T) {
+	isolatePluginConfig(t)
 	panes := []OpenPaneSnapshot{
 		{PaneID: "w1:p1", Agent: "Claude"},
 		{PaneID: "w1:p2", Agent: "OPENCODE"},
@@ -71,5 +87,28 @@ func TestActiveProviderSet_CaseInsensitiveAgentIDs(t *testing.T) {
 	got := ActiveProviderSet(panes)
 	if len(got) != 2 || !got["claude"] || !got["opencode"] {
 		t.Fatalf("got %v, want {claude, opencode}", got)
+	}
+}
+
+func TestActiveProviderSet_ClaudePaneActivatesAllConfiguredProfiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+	toml := `
+[[claude.profiles]]
+id = "claude"
+config_dir = "` + t.TempDir() + `"
+
+[[claude.profiles]]
+id = "claude-secondary"
+config_dir = "` + t.TempDir() + `"
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	panes := []OpenPaneSnapshot{{PaneID: "w1:p1", Agent: "claude"}}
+	got := ActiveProviderSet(panes)
+	if len(got) != 2 || !got["claude"] || !got["claude-secondary"] {
+		t.Fatalf("got %v, want {claude, claude-secondary}", got)
 	}
 }

--- a/internal/limits/apiusage_io.go
+++ b/internal/limits/apiusage_io.go
@@ -32,12 +32,15 @@ type paneBackend struct {
 // panes of one harness. Subscription panes and panes whose backend cannot be
 // resolved are skipped.
 func activeAPIPaneBackends(openPanes []OpenPaneSnapshot, harnessID string) []paneBackend {
+	// Resolve the billing deps (and their profile snapshot) once for the whole
+	// pass rather than per pane.
+	deps := DefaultBillingDeps()
 	var out []paneBackend
 	for _, pane := range openPanes {
 		if agentToProvider[strings.ToLower(pane.Agent)] != harnessID {
 			continue
 		}
-		if PaneBillingMode(harnessID, pane, DefaultBillingDeps()) != BillingPayAsYouGo {
+		if PaneBillingMode(harnessID, pane, deps) != BillingPayAsYouGo {
 			continue
 		}
 		backendID := payAsYouGoBackendID(harnessID, pane)

--- a/internal/limits/attachactivity.go
+++ b/internal/limits/attachactivity.go
@@ -13,7 +13,11 @@ type OpenPaneSnapshot struct {
 	Cwd       *string
 }
 
-// agent id -> ProviderLimits.providerId
+// agent id -> ProviderLimits.providerId. Used as-is for the single-Claude-
+// profile default; when multiple Claude profiles are configured, claude
+// resolution instead goes through an injected PaneProviderResolver that can
+// tell profiles apart (see BuildClaudePaneProviderResolver), since "claude"
+// alone cannot say which profile a pane belongs to.
 var agentToProvider = map[string]string{
 	"claude":   "claude",
 	"codex":    "codex",
@@ -21,11 +25,28 @@ var agentToProvider = map[string]string{
 	"grok":     "grok",
 }
 
+// PaneProviderResolver maps an open pane to the provider id its activity
+// should be attributed to. ok=false means unresolved (e.g. a Claude pane whose
+// session doesn't match any configured profile) — the pane is then excluded
+// from every provider's activity rather than guessed into one.
+type PaneProviderResolver func(pane OpenPaneSnapshot) (providerID string, ok bool)
+
+// defaultPaneProviderResolver is an exact agent-id match. Used when
+// PaneActivityDeps.ResolvePaneProvider is nil, which keeps pre-multi-profile
+// callers (and their tests) unchanged.
+func defaultPaneProviderResolver(pane OpenPaneSnapshot) (string, bool) {
+	id, ok := agentToProvider[pane.Agent]
+	return id, ok
+}
+
 // PaneActivityDeps injects token collectors for tests and I/O adapters.
 type PaneActivityDeps struct {
 	TokensForPane func(providerID string, pane OpenPaneSnapshot, windowStartMs, windowEndMs int64) float64
 	// TotalTokensForProvider is total tokens across all sessions on disk (open + closed).
 	TotalTokensForProvider func(providerID string, windowStartMs, windowEndMs int64) float64
+	// ResolvePaneProvider attributes a pane to a provider id. nil defaults to
+	// defaultPaneProviderResolver (today's single-Claude-profile behavior).
+	ResolvePaneProvider PaneProviderResolver
 }
 
 // AttachPaneActivity attaches paneActivity by combining open panes with each provider's limits.
@@ -35,23 +56,26 @@ func AttachPaneActivity(
 	nowMs int64,
 	deps PaneActivityDeps,
 ) []ProviderLimits {
+	resolve := deps.ResolvePaneProvider
+	if resolve == nil {
+		resolve = defaultPaneProviderResolver
+	}
+	// Resolve each pane once (not once per provider): a claude-family resolver
+	// may scan disk, so this keeps cost O(panes) instead of O(providers*panes).
+	paneProviderID := make(map[string]string, len(openPanes))
+	for _, pane := range openPanes {
+		if id, ok := resolve(pane); ok {
+			paneProviderID[pane.PaneID] = id
+		}
+	}
+
 	out := make([]ProviderLimits, len(providers))
 	for i, p := range providers {
 		out[i] = p
-		var agentID string
-		for a, providerID := range agentToProvider {
-			if providerID == p.ProviderID {
-				agentID = a
-				break
-			}
-		}
-		if agentID == "" {
-			continue
-		}
 
 		var panesForProvider []OpenPaneSnapshot
 		for _, pane := range openPanes {
-			if pane.Agent == agentID {
+			if paneProviderID[pane.PaneID] == p.ProviderID {
 				panesForProvider = append(panesForProvider, pane)
 			}
 		}

--- a/internal/limits/billingmode.go
+++ b/internal/limits/billingmode.go
@@ -36,8 +36,11 @@ const (
 	BillingPayAsYouGo
 )
 
-// allProviderIDs is the display-order provider universe (matches collect.go).
-var allProviderIDs = []string{"claude", "codex", "opencode", "grok"}
+// nonClaudeProviderIDs is the fixed non-Claude portion of the display-order
+// provider universe (matches collect.go). Claude's portion is dynamic — see
+// BillingDeps.ClaudeProfileIDs — since a multi-profile setup's billing gate
+// must consider each configured account independently.
+var nonClaudeProviderIDs = []string{"codex", "opencode", "grok"}
 
 // CombineBillingModes merges account- and session-level evidence.
 // PayAsYouGo wins (positive evidence to hide), then Subscription.
@@ -165,6 +168,11 @@ type BillingDeps struct {
 	PaneMode func(providerID string, pane OpenPaneSnapshot) BillingMode
 	// AccountMode resolves account-scoped evidence for a provider.
 	AccountMode func(providerID string) BillingMode
+	// ClaudeProfileIDs are the configured Claude profile ids, replacing the
+	// single literal "claude" entry in BillingProviderFilter's provider
+	// universe so each configured account is gated independently. Empty
+	// defaults to ["claude"] (today's single-profile behavior).
+	ClaudeProfileIDs []string
 }
 
 // PaneBillingMode combines account- and session-level evidence for one pane.
@@ -186,6 +194,14 @@ func PaneBillingMode(providerID string, pane OpenPaneSnapshot, deps BillingDeps)
 // backend. Providers without open panes (or when the pane query failed)
 // are gated by account evidence alone — fail-open on Unknown.
 func BillingProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool, deps BillingDeps) map[string]bool {
+	claudeIDs := deps.ClaudeProfileIDs
+	if len(claudeIDs) == 0 {
+		claudeIDs = []string{"claude"}
+	}
+	allIDs := make([]string, 0, len(claudeIDs)+len(nonClaudeProviderIDs))
+	allIDs = append(allIDs, claudeIDs...)
+	allIDs = append(allIDs, nonClaudeProviderIDs...)
+
 	byProvider := make(map[string][]OpenPaneSnapshot)
 	if paneQueryOK {
 		for _, pane := range openPanes {
@@ -195,7 +211,7 @@ func BillingProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool, deps 
 		}
 	}
 	set := make(map[string]bool)
-	for _, providerID := range allProviderIDs {
+	for _, providerID := range allIDs {
 		account := BillingUnknown
 		if deps.AccountMode != nil {
 			account = deps.AccountMode(providerID)

--- a/internal/limits/billingmode_io.go
+++ b/internal/limits/billingmode_io.go
@@ -25,20 +25,32 @@ const statusLineCacheFreshMs = 7 * 24 * 60 * 60 * 1000
 
 // DefaultBillingDeps returns production billing-mode resolvers.
 func DefaultBillingDeps() BillingDeps {
+	profiles := ResolvedClaudeProfiles()
+	ids := make([]string, len(profiles))
+	for i, p := range profiles {
+		ids[i] = p.ID
+	}
 	return BillingDeps{
-		PaneMode:    paneBillingModeDefault,
-		AccountMode: accountBillingModeDefault,
+		PaneMode:         paneBillingModeDefault,
+		AccountMode:      accountBillingModeDefault,
+		ClaudeProfileIDs: ids,
 	}
 }
 
+// paneBillingModeDefault dispatches by provider id. Claude-family ids (any
+// configured profile, not just the literal "claude") resolve via that
+// profile's own ConfigDir rather than the ambient CLAUDE_CONFIG_DIR — the read
+// side (panel/sidebar) never sees that env var, so per-profile billing
+// detection must thread the resolved profile's paths explicitly.
 func paneBillingModeDefault(providerID string, pane OpenPaneSnapshot) BillingMode {
+	if profile, ok := claudeProfileByID(providerID); ok {
+		return claudePaneBillingModeIn(profile.ConfigDir, pane)
+	}
 	switch providerID {
 	case "opencode":
 		return opencodePaneBillingMode(pane)
 	case "codex":
 		return codexPaneBillingMode(pane)
-	case "claude":
-		return claudePaneBillingMode(pane)
 	case "grok":
 		return grokPaneBillingMode(pane)
 	default:
@@ -47,9 +59,10 @@ func paneBillingModeDefault(providerID string, pane OpenPaneSnapshot) BillingMod
 }
 
 func accountBillingModeDefault(providerID string) BillingMode {
+	if profile, ok := claudeProfileByID(providerID); ok {
+		return claudeAccountBillingModeIn(profile.JSONPath, profile.LimitsCache, profile.ConfigDir)
+	}
 	switch providerID {
-	case "claude":
-		return claudeAccountBillingMode()
 	case "grok":
 		return grokAccountBillingMode()
 	default:
@@ -83,6 +96,9 @@ func PaneBackendID(providerID string, pane OpenPaneSnapshot) string {
 // OpenCode / Codex record a per-session provider. Claude uses deployment
 // env (settings + process); Grok joins session modelId with config.toml.
 func payAsYouGoBackendID(providerID string, pane OpenPaneSnapshot) string {
+	if profile, ok := claudeProfileByID(providerID); ok {
+		return ResolveClaudeBackendID(loadClaudeEnvIn(profile.ConfigDir, cwdStr(pane)))
+	}
 	switch providerID {
 	case "opencode":
 		backendID := opencodePaneBackendID(pane)
@@ -92,8 +108,6 @@ func payAsYouGoBackendID(providerID string, pane OpenPaneSnapshot) string {
 		return backendID
 	case "codex":
 		return codexPaneBackendID(pane)
-	case "claude":
-		return ResolveClaudeBackendID(claudeEnvForPane(pane))
 	case "grok":
 		return resolveGrokBackendForPane(pane)
 	default:
@@ -101,9 +115,11 @@ func payAsYouGoBackendID(providerID string, pane OpenPaneSnapshot) string {
 	}
 }
 
-// claudePaneBillingMode uses deployment env evidence (Bedrock/Vertex/…).
-func claudePaneBillingMode(pane OpenPaneSnapshot) BillingMode {
-	return ClaudeBillingModeFromEnv(claudeEnvForPane(pane))
+// claudePaneBillingModeIn uses deployment env evidence (Bedrock/Vertex/…) from
+// the given profile's ConfigDir (its own settings.json), not the ambient
+// CLAUDE_CONFIG_DIR.
+func claudePaneBillingModeIn(configDir string, pane OpenPaneSnapshot) BillingMode {
+	return ClaudeBillingModeFromEnv(loadClaudeEnvIn(configDir, cwdStr(pane)))
 }
 
 // grokPaneBillingMode is PayAsYouGo when the pane's model points at a
@@ -123,12 +139,28 @@ func claudeEnvForPane(pane OpenPaneSnapshot) map[string]string {
 }
 
 func loadClaudeEnv(cwd string) map[string]string {
+	return loadClaudeEnvIn("", cwd)
+}
+
+// loadClaudeEnvIn is loadClaudeEnv scoped to an explicit profile ConfigDir.
+// configDir="" keeps today's env/default lookup (ResolveClaudeUserSettingsPath),
+// used by the single-account callers that predate multi-profile support.
+func loadClaudeEnvIn(configDir, cwd string) map[string]string {
 	return MergeClaudeEnv(
 		claudeProcessEnv(),
-		claudeSettingsEnv(ResolveClaudeUserSettingsPath()),
+		claudeSettingsEnv(resolveClaudeUserSettingsPathIn(configDir)),
 		claudeSettingsEnv(filepath.Join(cwd, ".claude", "settings.json")),
 		claudeSettingsEnv(filepath.Join(cwd, ".claude", "settings.local.json")),
 	)
+}
+
+// resolveClaudeUserSettingsPathIn returns <configDir>/settings.json, or the
+// env/default ResolveClaudeUserSettingsPath() when configDir is empty.
+func resolveClaudeUserSettingsPathIn(configDir string) string {
+	if configDir != "" {
+		return filepath.Join(configDir, "settings.json")
+	}
+	return ResolveClaudeUserSettingsPath()
 }
 
 // claudeProcessEnv copies Claude deployment-related keys from the process
@@ -363,8 +395,12 @@ func codexPaneBillingMode(pane OpenPaneSnapshot) BillingMode {
 	return CodexBillingModeFromLines(lines)
 }
 
-func claudeAccountBillingMode() BillingMode {
-	raw, err := os.ReadFile(ResolveClaudeJSONPath())
+// claudeAccountBillingModeIn reads billing evidence from one profile's own
+// claude.json / limits cache / ConfigDir, so each configured account's
+// evidence comes from only its own files rather than the ambient default.
+
+func claudeAccountBillingModeIn(jsonPath, limitsCachePath, configDir string) BillingMode {
+	raw, err := os.ReadFile(jsonPath)
 	mode := BillingUnknown
 	if err == nil {
 		mode = ClaudeBillingModeFromJSON(string(raw))
@@ -372,7 +408,7 @@ func claudeAccountBillingMode() BillingMode {
 			// A fresh statusLine rate_limits cache is subscription evidence too
 			// (the utilization cache can lag behind a new subscription login).
 			nowMs := time.Now().UnixMilli()
-			if cached := collectFromStatusLineCache(nowMs, ResolveClaudeLimitsCachePath()); cached != nil {
+			if cached := collectFromStatusLineCache(nowMs, limitsCachePath); cached != nil {
 				if nowMs-cached.FetchedAtMs <= statusLineCacheFreshMs {
 					mode = BillingSubscription
 				}
@@ -381,7 +417,7 @@ func claudeAccountBillingMode() BillingMode {
 	}
 	// Deployment env (Bedrock/Vertex/…) is account-scoped when set in
 	// user settings or the process environment.
-	return CombineBillingModes(mode, ClaudeBillingModeFromEnv(loadClaudeEnv("")))
+	return CombineBillingModes(mode, ClaudeBillingModeFromEnv(loadClaudeEnvIn(configDir, "")))
 }
 
 func grokAccountBillingMode() BillingMode {

--- a/internal/limits/billingmode_io.go
+++ b/internal/limits/billingmode_io.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/fsutil"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
@@ -23,7 +24,10 @@ import (
 // to still count as subscription evidence (7 days — one full weekly window).
 const statusLineCacheFreshMs = 7 * 24 * 60 * 60 * 1000
 
-// DefaultBillingDeps returns production billing-mode resolvers.
+// DefaultBillingDeps returns production billing-mode resolvers. It resolves the
+// profile snapshot once and shares it across both mode closures and the id
+// list, so a BillingProviderFilter pass agrees on one profile set instead of
+// re-resolving config/env per pane.
 func DefaultBillingDeps() BillingDeps {
 	profiles := ResolvedClaudeProfiles()
 	ids := make([]string, len(profiles))
@@ -31,19 +35,23 @@ func DefaultBillingDeps() BillingDeps {
 		ids[i] = p.ID
 	}
 	return BillingDeps{
-		PaneMode:         paneBillingModeDefault,
-		AccountMode:      accountBillingModeDefault,
+		PaneMode: func(providerID string, pane OpenPaneSnapshot) BillingMode {
+			return paneBillingModeWith(profiles, providerID, pane)
+		},
+		AccountMode: func(providerID string) BillingMode {
+			return accountBillingModeWith(profiles, providerID)
+		},
 		ClaudeProfileIDs: ids,
 	}
 }
 
-// paneBillingModeDefault dispatches by provider id. Claude-family ids (any
-// configured profile, not just the literal "claude") resolve via that
-// profile's own ConfigDir rather than the ambient CLAUDE_CONFIG_DIR — the read
-// side (panel/sidebar) never sees that env var, so per-profile billing
-// detection must thread the resolved profile's paths explicitly.
-func paneBillingModeDefault(providerID string, pane OpenPaneSnapshot) BillingMode {
-	if profile, ok := claudeProfileByID(providerID); ok {
+// paneBillingModeWith dispatches by provider id against an explicit profile
+// snapshot. Claude-family ids (any configured profile, not just the literal
+// "claude") resolve via that profile's own ConfigDir rather than the ambient
+// CLAUDE_CONFIG_DIR — the read side (panel/sidebar) never sees that env var, so
+// per-profile billing detection must thread the resolved profile's paths.
+func paneBillingModeWith(profiles []claude.ClaudeProfile, providerID string, pane OpenPaneSnapshot) BillingMode {
+	if profile, ok := profileByIDIn(profiles, providerID); ok {
 		return claudePaneBillingModeIn(profile.ConfigDir, pane)
 	}
 	switch providerID {
@@ -58,8 +66,8 @@ func paneBillingModeDefault(providerID string, pane OpenPaneSnapshot) BillingMod
 	}
 }
 
-func accountBillingModeDefault(providerID string) BillingMode {
-	if profile, ok := claudeProfileByID(providerID); ok {
+func accountBillingModeWith(profiles []claude.ClaudeProfile, providerID string) BillingMode {
+	if profile, ok := profileByIDIn(profiles, providerID); ok {
 		return claudeAccountBillingModeIn(profile.JSONPath, profile.LimitsCache, profile.ConfigDir)
 	}
 	switch providerID {

--- a/internal/limits/billingmode_io_test.go
+++ b/internal/limits/billingmode_io_test.go
@@ -23,7 +23,12 @@ func encodeGrokCwd(cwd string) string {
 }
 
 // clearClaudeDeployEnv removes process-level deployment flags so tests only
-// see the temp settings files they write.
+// see the temp settings files they write. It also isolates
+// HERDR_PLUGIN_CONFIG_DIR at an empty temp dir: DefaultBillingDeps() now
+// resolves Claude profiles from that config, and a real machine's
+// config.toml (e.g. an id "claude" profile pointing elsewhere) would
+// otherwise override these tests' CLAUDE_CONFIG_JSON/CLAUDE_CONFIG_DIR env
+// values, since explicit-profile mode ignores env path overrides by design.
 func clearClaudeDeployEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
@@ -41,6 +46,7 @@ func clearClaudeDeployEnv(t *testing.T) {
 	} {
 		t.Setenv(k, "")
 	}
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", t.TempDir())
 }
 
 func writeFile(t *testing.T, path, body string) {
@@ -70,6 +76,22 @@ func withTempClaudeConfig(t *testing.T) (configDir, jsonPath string) {
 	// Avoid a real statusLine cache promoting PAYG → subscription mid-test.
 	t.Setenv("HOME", t.TempDir())
 	return configDir, jsonPath
+}
+
+// withClaudeProfileConfig configures a single [[claude.profiles]] entry
+// pointing at configDir/jsonPath, so per-profile billing detection (which
+// reads a profile's own ConfigDir rather than the ambient CLAUDE_CONFIG_DIR)
+// can find this test's temp settings. Reflects how a real user opts a
+// relocated account into isolation: explicit config, not a bare env var.
+func withClaudeProfileConfig(t *testing.T, id, configDir, jsonPath string) {
+	t.Helper()
+	pluginConfigDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginConfigDir)
+	toml := "[[claude.profiles]]\n" +
+		"id = \"" + id + "\"\n" +
+		"config_dir = \"" + configDir + "\"\n" +
+		"claude_json_path = \"" + jsonPath + "\"\n"
+	writeFile(t, filepath.Join(pluginConfigDir, "config.toml"), toml)
 }
 
 func writeGrokSession(t *testing.T, home, sessionID, modelID string) {
@@ -174,6 +196,7 @@ default = "grok-4.5"
 
 func TestIO_ClaudeBedrockSettings_PaneIsPayAsYouGo(t *testing.T) {
 	configDir, jsonPath := withTempClaudeConfig(t)
+	withClaudeProfileConfig(t, "claude", configDir, jsonPath)
 	// Account still looks like a subscription — Bedrock env must win.
 	writeFile(t, jsonPath, `{
 		"cachedUsageUtilization": {"utilization": {"five_hour": {"utilization": 10}}},
@@ -285,5 +308,62 @@ base_url = "http://localhost:11434/v1"
 	}
 	if PaneBackendID("grok", panes[1]) != "ollama" {
 		t.Fatalf("ollama pane backend: got %q", PaneBackendID("grok", panes[1]))
+	}
+}
+
+func TestIO_MultipleClaudeProfiles_IndependentBilling(t *testing.T) {
+	clearClaudeDeployEnv(t)
+	t.Setenv("HOME", t.TempDir())
+
+	configDirA := t.TempDir()
+	jsonPathA := filepath.Join(t.TempDir(), "claude-a.json")
+	configDirB := t.TempDir()
+	jsonPathB := filepath.Join(t.TempDir(), "claude-b.json")
+
+	pluginConfigDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginConfigDir)
+	toml := "[[claude.profiles]]\n" +
+		"id = \"claude\"\n" +
+		"config_dir = \"" + configDirA + "\"\n" +
+		"claude_json_path = \"" + jsonPathA + "\"\n\n" +
+		"[[claude.profiles]]\n" +
+		"id = \"claude-secondary\"\n" +
+		"config_dir = \"" + configDirB + "\"\n" +
+		"claude_json_path = \"" + jsonPathB + "\"\n"
+	writeFile(t, filepath.Join(pluginConfigDir, "config.toml"), toml)
+
+	// Profile A: Bedrock deployment env -> pay-as-you-go.
+	writeFile(t, jsonPathA, `{
+		"cachedUsageUtilization": {"utilization": {"five_hour": {"utilization": 10}}},
+		"oauthAccount": {"billingType": "stripe_subscription"}
+	}`)
+	writeFile(t, filepath.Join(configDirA, "settings.json"), `{
+		"env": {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-east-1"}
+	}`)
+
+	// Profile B: plain subscription, no deployment env.
+	writeFile(t, jsonPathB, `{
+		"cachedUsageUtilization": {"utilization": {"five_hour": {"utilization": 5}}},
+		"oauthAccount": {"billingType": "stripe_subscription"}
+	}`)
+	writeFile(t, filepath.Join(configDirB, "settings.json"), `{"model":"opus"}`)
+
+	cwd := ioTestCwd
+	paneA := OpenPaneSnapshot{PaneID: "pa", Agent: "claude", Cwd: &cwd}
+	paneB := OpenPaneSnapshot{PaneID: "pb", Agent: "claude", Cwd: &cwd}
+
+	if mode := PaneBillingMode("claude", paneA, DefaultBillingDeps()); mode != BillingPayAsYouGo {
+		t.Fatalf("profile A: got %v want PayAsYouGo", mode)
+	}
+	if mode := PaneBillingMode("claude-secondary", paneB, DefaultBillingDeps()); mode != BillingSubscription {
+		t.Fatalf("profile B: got %v want Subscription", mode)
+	}
+
+	set := BillingProviderFilter([]OpenPaneSnapshot{paneA, paneB}, true, DefaultBillingDeps())
+	if set["claude"] {
+		t.Fatalf("profile A (bedrock) should be excluded: %#v", set)
+	}
+	if !set["claude-secondary"] {
+		t.Fatalf("profile B (subscription) should be kept: %#v", set)
 	}
 }

--- a/internal/limits/claudecache.go
+++ b/internal/limits/claudecache.go
@@ -36,7 +36,12 @@ type CollectClaudeLimitsOptions struct {
 	ClaudeJSONPath      string
 }
 
-// ResolveClaudeLimitsCachePath returns the statusLine cache path.
+// ResolveClaudeLimitsCachePath returns the single-default statusLine cache path.
+// Multi-account isolation comes from explicit [[claude.profiles]] config, whose
+// paths are computed per config_dir; the synthesized default must stay
+// byte-identical to the historical location so it resolves the same on the write
+// side (statusLine) and the read side (panel/sidebar), which cannot see
+// CLAUDE_CONFIG_DIR.
 func ResolveClaudeLimitsCachePath() string {
 	if v := os.Getenv("USAGEBAR_CLAUDE_LIMITS_PATH"); v != "" {
 		return v
@@ -77,6 +82,16 @@ func WriteClaudeLimitsCache(rateLimits RateLimitsInput, nowMs int64, path string
 		return err
 	}
 	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// WriteClaudeLimitsCacheGuarded writes the cache only when at least one window
+// is present, so an empty statusLine payload (e.g. `{}`) cannot overwrite a
+// previously valid cache. Returns whether a write happened.
+func WriteClaudeLimitsCacheGuarded(rateLimits RateLimitsInput, nowMs int64, path string) (bool, error) {
+	if rateLimits.FiveHour == nil && rateLimits.SevenDay == nil {
+		return false, nil
+	}
+	return true, WriteClaudeLimitsCache(rateLimits, nowMs, path)
 }
 
 func collectFromStatusLineCache(nowMs int64, path string) *ProviderLimits {

--- a/internal/limits/claudecache_test.go
+++ b/internal/limits/claudecache_test.go
@@ -100,3 +100,56 @@ func TestClaudeLimitsCache_Neither(t *testing.T) {
 		t.Fatalf("note=%v", limits.Note)
 	}
 }
+
+func fiveHourInput(pct float64) RateLimitsInput {
+	return RateLimitsInput{FiveHour: &struct {
+		UsedPercentage float64
+		ResetsAt       int64
+	}{pct, 1000}}
+}
+
+func TestWriteClaudeLimitsCacheGuarded_SkipsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+
+	// Seed a valid cache.
+	if wrote, err := WriteClaudeLimitsCacheGuarded(fiveHourInput(42), 1_000, cachePath); err != nil || !wrote {
+		t.Fatalf("seed write: wrote=%v err=%v", wrote, err)
+	}
+	// An empty payload must not clobber it.
+	wrote, err := WriteClaudeLimitsCacheGuarded(RateLimitsInput{}, 2_000, cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote {
+		t.Fatal("empty payload should not write")
+	}
+	got := CollectClaudeLimits(3_000, CollectClaudeLimitsOptions{
+		StatusLineCachePath: cachePath,
+		ClaudeJSONPath:      filepath.Join(dir, "missing.json"),
+	})
+	if got.Primary == nil || got.Primary.UsedPercentage != 42 {
+		t.Fatalf("prior cache should survive, got %+v", got.Primary)
+	}
+}
+
+func TestWriteClaudeLimitsCacheGuarded_SeparateProfilePaths(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "cache.json")
+	pathB := filepath.Join(dir, "b", "cache.json")
+
+	if _, err := WriteClaudeLimitsCacheGuarded(fiveHourInput(10), 1_000, pathA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteClaudeLimitsCacheGuarded(fiveHourInput(90), 1_000, pathB); err != nil {
+		t.Fatal(err)
+	}
+	a := CollectClaudeLimits(2_000, CollectClaudeLimitsOptions{StatusLineCachePath: pathA, ClaudeJSONPath: filepath.Join(dir, "na.json")})
+	b := CollectClaudeLimits(2_000, CollectClaudeLimitsOptions{StatusLineCachePath: pathB, ClaudeJSONPath: filepath.Join(dir, "nb.json")})
+	if a.Primary == nil || a.Primary.UsedPercentage != 10 {
+		t.Fatalf("profile A = %+v", a.Primary)
+	}
+	if b.Primary == nil || b.Primary.UsedPercentage != 90 {
+		t.Fatalf("profile B = %+v", b.Primary)
+	}
+}

--- a/internal/limits/claudejson.go
+++ b/internal/limits/claudejson.go
@@ -143,6 +143,34 @@ func CollectClaudeLimitsFromJSON(nowMs int64, path string) *ProviderLimits {
 	return ProviderLimitsFromClaudeJSON(string(raw), nowMs)
 }
 
+// AccountEmailFromJSON extracts oauthAccount.emailAddress from a
+// ~/.claude.json body. Used for display only: distinguishing two configured
+// Claude profiles that share no explicit label, by the account actually
+// logged into each one.
+func AccountEmailFromJSON(rawJSON string) (string, bool) {
+	var parsed struct {
+		OAuthAccount *struct {
+			EmailAddress *string `json:"emailAddress"`
+		} `json:"oauthAccount"`
+	}
+	if err := json.Unmarshal([]byte(rawJSON), &parsed); err != nil {
+		return "", false
+	}
+	if parsed.OAuthAccount == nil || parsed.OAuthAccount.EmailAddress == nil || *parsed.OAuthAccount.EmailAddress == "" {
+		return "", false
+	}
+	return *parsed.OAuthAccount.EmailAddress, true
+}
+
+// AccountEmailFromJSONPath reads path and extracts the account email.
+func AccountEmailFromJSONPath(path string) (string, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	return AccountEmailFromJSON(string(raw))
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/internal/limits/claudejson_test.go
+++ b/internal/limits/claudejson_test.go
@@ -5,6 +5,7 @@ package limits
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -122,4 +123,41 @@ func containsStr(s, sub string) bool {
 			}
 			return false
 		}())
+}
+
+func TestAccountEmailFromJSON_Found(t *testing.T) {
+	email, ok := AccountEmailFromJSON(`{
+		"oauthAccount": {"emailAddress": "user@example.com", "organizationType": "claude_pro"}
+	}`)
+	if !ok || email != "user@example.com" {
+		t.Fatalf("ok=%v email=%q", ok, email)
+	}
+}
+
+func TestAccountEmailFromJSON_MissingOAuthAccount(t *testing.T) {
+	_, ok := AccountEmailFromJSON(`{"cachedUsageUtilization": {}}`)
+	if ok {
+		t.Fatal("expected no email without oauthAccount")
+	}
+}
+
+func TestAccountEmailFromJSON_EmptyEmail(t *testing.T) {
+	_, ok := AccountEmailFromJSON(`{"oauthAccount": {"emailAddress": ""}}`)
+	if ok {
+		t.Fatal("expected no email for empty string")
+	}
+}
+
+func TestAccountEmailFromJSON_InvalidJSON(t *testing.T) {
+	_, ok := AccountEmailFromJSON(`not json`)
+	if ok {
+		t.Fatal("expected no email for invalid JSON")
+	}
+}
+
+func TestAccountEmailFromJSONPath_MissingFile(t *testing.T) {
+	_, ok := AccountEmailFromJSONPath(filepath.Join(t.TempDir(), "missing.json"))
+	if ok {
+		t.Fatal("expected no email for missing file")
+	}
 }

--- a/internal/limits/claudeprofiles_io.go
+++ b/internal/limits/claudeprofiles_io.go
@@ -28,14 +28,23 @@ func ResolvedClaudeProfiles() []claude.ClaudeProfile {
 	return setup.ResolveClaudeProfiles(processEnvMap())
 }
 
-// claudeProfileByID looks up one resolved profile by provider id.
-func claudeProfileByID(id string) (claude.ClaudeProfile, bool) {
-	for _, p := range ResolvedClaudeProfiles() {
+// profileByIDIn looks up one profile by provider id within an already-resolved
+// snapshot, so a caller that resolved the profiles once (e.g. per
+// AttachPaneActivity pass) can dispatch without re-reading config/env per hit.
+func profileByIDIn(profiles []claude.ClaudeProfile, id string) (claude.ClaudeProfile, bool) {
+	for _, p := range profiles {
 		if p.ID == id {
 			return p, true
 		}
 	}
 	return claude.ClaudeProfile{}, false
+}
+
+// claudeProfileByID looks up one resolved profile by provider id, resolving the
+// snapshot fresh. Used by non-hot direct callers; hot loops instead capture one
+// snapshot and dispatch via profileByIDIn.
+func claudeProfileByID(id string) (claude.ClaudeProfile, bool) {
+	return profileByIDIn(ResolvedClaudeProfiles(), id)
 }
 
 // applyProfileGrouping nests pl under the shared "Claude" heading when

--- a/internal/limits/claudeprofiles_io.go
+++ b/internal/limits/claudeprofiles_io.go
@@ -1,0 +1,39 @@
+/**
+ * Resolves the configured Claude profiles from the plugin config, shared by
+ * the read-side collectors (panel, sidebar, notify, activity attribution).
+ */
+package limits
+
+import (
+	"os"
+	"strings"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/setup"
+)
+
+func processEnvMap() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			env[kv[:i]] = kv[i+1:]
+		}
+	}
+	return env
+}
+
+// ResolvedClaudeProfiles resolves the configured Claude profiles (synthesizing
+// the single implicit default when none are configured) from process env.
+func ResolvedClaudeProfiles() []claude.ClaudeProfile {
+	return setup.ResolveClaudeProfiles(processEnvMap())
+}
+
+// claudeProfileByID looks up one resolved profile by provider id.
+func claudeProfileByID(id string) (claude.ClaudeProfile, bool) {
+	for _, p := range ResolvedClaudeProfiles() {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return claude.ClaudeProfile{}, false
+}

--- a/internal/limits/claudeprofiles_io.go
+++ b/internal/limits/claudeprofiles_io.go
@@ -37,3 +37,21 @@ func claudeProfileByID(id string) (claude.ClaudeProfile, bool) {
 	}
 	return claude.ClaudeProfile{}, false
 }
+
+// applyProfileGrouping nests pl under the shared "Claude" heading when
+// multiProfile is true, so 2+ configured accounts render as one group instead
+// of N separate top-level blocks. AccountLabel carries p's real logged-in
+// email so the nested row stays distinguishable even when the profile has no
+// explicit label; it falls back to pl.Label when the email can't be read.
+func applyProfileGrouping(pl ProviderLimits, p claude.ClaudeProfile, multiProfile bool) ProviderLimits {
+	if !multiProfile {
+		return pl
+	}
+	pl.GroupLabel = "Claude"
+	if email, ok := AccountEmailFromJSONPath(p.JSONPath); ok {
+		pl.AccountLabel = email
+	} else {
+		pl.AccountLabel = pl.Label
+	}
+	return pl
+}

--- a/internal/limits/collect.go
+++ b/internal/limits/collect.go
@@ -38,6 +38,7 @@ type CollectOptions struct {
 // Claude collector per configured profile (see ResolvedClaudeProfiles).
 func DefaultCollectOptions() CollectOptions {
 	profiles := ResolvedClaudeProfiles()
+	multiProfile := len(profiles) > 1
 	claudeCollectors := make([]ClaudeProfileCollector, len(profiles))
 	for i, p := range profiles {
 		claudeCollectors[i] = ClaudeProfileCollector{
@@ -50,7 +51,11 @@ func DefaultCollectOptions() CollectOptions {
 				})
 				pl.ProviderID = p.ID
 				pl.Label = p.Label
-				return pl
+				// When 2+ accounts are configured, every row nests under one
+				// shared "Claude" group in the panel, labeled by its real
+				// logged-in email rather than the profile's own label — so
+				// the account behind each row is always verifiable.
+				return applyProfileGrouping(pl, p, multiProfile)
 			},
 		}
 	}

--- a/internal/limits/collect.go
+++ b/internal/limits/collect.go
@@ -8,9 +8,22 @@ package limits
 // LimitsCollector fetches one provider's rate-limit snapshot.
 type LimitsCollector func(cwd *string, nowMs int64) ProviderLimits
 
+// ClaudeProfileCollector is one configured Claude profile's collector, keyed by
+// that profile's own provider id/label so multiple accounts collect and display
+// independently instead of sharing the single literal "claude" id.
+type ClaudeProfileCollector struct {
+	ID        string
+	Label     string
+	Collector LimitsCollector
+}
+
 // CollectOptions configures CollectAllProviderLimits.
 type CollectOptions struct {
-	Claude   LimitsCollector
+	// Claude is one entry per configured Claude profile, in config order. Empty
+	// synthesizes a single "claude" stub spec, matching how the other
+	// providers behave when left unconfigured (mainly relevant to tests that
+	// build CollectOptions directly rather than via DefaultCollectOptions).
+	Claude   []ClaudeProfileCollector
 	Codex    LimitsCollector
 	OpenCode LimitsCollector
 	Grok     LimitsCollector
@@ -21,13 +34,29 @@ type CollectOptions struct {
 	Only map[string]bool
 }
 
-// DefaultCollectOptions wires production local collectors (no network).
+// DefaultCollectOptions wires production local collectors (no network), one
+// Claude collector per configured profile (see ResolvedClaudeProfiles).
 func DefaultCollectOptions() CollectOptions {
+	profiles := ResolvedClaudeProfiles()
+	claudeCollectors := make([]ClaudeProfileCollector, len(profiles))
+	for i, p := range profiles {
+		claudeCollectors[i] = ClaudeProfileCollector{
+			ID:    p.ID,
+			Label: p.Label,
+			Collector: func(_ *string, nowMs int64) ProviderLimits {
+				pl := CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{
+					StatusLineCachePath: p.LimitsCache,
+					ClaudeJSONPath:      p.JSONPath,
+				})
+				pl.ProviderID = p.ID
+				pl.Label = p.Label
+				return pl
+			},
+		}
+	}
 	return CollectOptions{
-		Claude: func(_ *string, nowMs int64) ProviderLimits {
-			return CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{})
-		},
-		Codex: CollectCodexLimits,
+		Claude: claudeCollectors,
+		Codex:  CollectCodexLimits,
 		OpenCode: func(_ *string, nowMs int64) ProviderLimits {
 			return CollectOpenCodeLimits(nowMs, "")
 		},
@@ -37,10 +66,11 @@ func DefaultCollectOptions() CollectOptions {
 	}
 }
 
-// CollectAllProviderLimits runs collectors in display order:
-// Claude -> Codex -> OpenCode -> Grok, then attaches pane activity when configured.
-// Providers excluded by opts.Only are skipped (collectors never run).
-// Pass DefaultCollectOptions() for production local collectors.
+// CollectAllProviderLimits runs collectors in display order: each configured
+// Claude profile (config order) -> Codex -> OpenCode -> Grok, then attaches
+// pane activity when configured. Providers excluded by opts.Only are skipped
+// (collectors never run). Pass DefaultCollectOptions() for production local
+// collectors.
 func CollectAllProviderLimits(cwd *string, nowMs int64, opts CollectOptions) []ProviderLimits {
 	collect := func(c LimitsCollector, id, label string) ProviderLimits {
 		if c != nil {
@@ -54,22 +84,35 @@ func CollectAllProviderLimits(cwd *string, nowMs int64, opts CollectOptions) []P
 			Note:        strPtr("limits collector not configured"),
 		}
 	}
-	specs := []struct {
+
+	claudeSpecs := opts.Claude
+	if len(claudeSpecs) == 0 {
+		claudeSpecs = []ClaudeProfileCollector{{ID: "claude", Label: "Claude"}}
+	}
+
+	base := make([]ProviderLimits, 0, len(claudeSpecs)+3)
+	for _, s := range claudeSpecs {
+		if opts.Only != nil && !opts.Only[s.ID] {
+			continue
+		}
+		base = append(base, collect(s.Collector, s.ID, s.Label))
+	}
+
+	otherSpecs := []struct {
 		collector LimitsCollector
 		id, label string
 	}{
-		{opts.Claude, "claude", "Claude"},
 		{opts.Codex, "codex", "Codex"},
 		{opts.OpenCode, "opencode", "OpenCode"},
 		{opts.Grok, "grok", "Grok"},
 	}
-	base := make([]ProviderLimits, 0, len(specs))
-	for _, s := range specs {
+	for _, s := range otherSpecs {
 		if opts.Only != nil && !opts.Only[s.id] {
 			continue
 		}
 		base = append(base, collect(s.collector, s.id, s.label))
 	}
+
 	if opts.Attach != nil {
 		return opts.Attach(base, nowMs)
 	}

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -24,9 +24,12 @@ func TestCollectAllProviderLimits_OrderAndStubs(t *testing.T) {
 func TestCollectAllProviderLimits_WithCollectorsAndAttach(t *testing.T) {
 	cwd := "/tmp"
 	got := CollectAllProviderLimits(&cwd, 200, CollectOptions{
-		Claude: func(c *string, now int64) ProviderLimits {
-			return ProviderLimits{ProviderID: "claude", Label: "Claude", Source: "test", FetchedAtMs: now}
-		},
+		Claude: []ClaudeProfileCollector{{
+			ID: "claude", Label: "Claude",
+			Collector: func(c *string, now int64) ProviderLimits {
+				return ProviderLimits{ProviderID: "claude", Label: "Claude", Source: "test", FetchedAtMs: now}
+			},
+		}},
 		Codex: func(c *string, now int64) ProviderLimits {
 			if c == nil || *c != "/tmp" {
 				t.Fatal("cwd not passed")
@@ -88,5 +91,53 @@ func TestCollectAllProviderLimits_OnlySkipsFilteredCollectors(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ProviderID != "claude" {
 		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestCollectAllProviderLimits_MultipleClaudeProfiles(t *testing.T) {
+	got := CollectAllProviderLimits(nil, 100, CollectOptions{
+		Claude: []ClaudeProfileCollector{
+			{ID: "claude", Label: "Claude", Collector: func(_ *string, now int64) ProviderLimits {
+				return ProviderLimits{ProviderID: "claude", Label: "Claude", Source: "test-a", FetchedAtMs: now}
+			}},
+			{ID: "claude-secondary", Label: "Claude (secondary)", Collector: func(_ *string, now int64) ProviderLimits {
+				return ProviderLimits{ProviderID: "claude-secondary", Label: "Claude (secondary)", Source: "test-b", FetchedAtMs: now}
+			}},
+		},
+		Only: map[string]bool{"claude": true, "claude-secondary": true, "codex": true, "opencode": true, "grok": true},
+	})
+	if len(got) != 5 {
+		t.Fatalf("len=%d want 5: %+v", len(got), got)
+	}
+	if got[0].ProviderID != "claude" || got[0].Source != "test-a" {
+		t.Fatalf("profile 1 = %+v", got[0])
+	}
+	if got[1].ProviderID != "claude-secondary" || got[1].Source != "test-b" {
+		t.Fatalf("profile 2 = %+v", got[1])
+	}
+	if got[2].ProviderID != "codex" {
+		t.Fatalf("codex should follow all claude profiles, got %+v", got[2])
+	}
+}
+
+func TestCollectAllProviderLimits_ClaudeProfileFilteredByOnly(t *testing.T) {
+	secondaryCalled := false
+	got := CollectAllProviderLimits(nil, 100, CollectOptions{
+		Claude: []ClaudeProfileCollector{
+			{ID: "claude", Label: "Claude", Collector: func(_ *string, now int64) ProviderLimits {
+				return ProviderLimits{ProviderID: "claude", Label: "Claude", Source: "test-a", FetchedAtMs: now}
+			}},
+			{ID: "claude-secondary", Label: "Claude (secondary)", Collector: func(_ *string, now int64) ProviderLimits {
+				secondaryCalled = true
+				return ProviderLimits{ProviderID: "claude-secondary", Label: "Claude (secondary)", Source: "test-b", FetchedAtMs: now}
+			}},
+		},
+		Only: map[string]bool{"claude": true},
+	})
+	if len(got) != 1 || got[0].ProviderID != "claude" {
+		t.Fatalf("got %+v", got)
+	}
+	if secondaryCalled {
+		t.Fatal("filtered-out profile's collector must not run")
 	}
 }

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -3,7 +3,11 @@
  */
 package limits
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestCollectAllProviderLimits_OrderAndStubs(t *testing.T) {
 	got := CollectAllProviderLimits(nil, 100, CollectOptions{})
@@ -139,5 +143,79 @@ func TestCollectAllProviderLimits_ClaudeProfileFilteredByOnly(t *testing.T) {
 	}
 	if secondaryCalled {
 		t.Fatal("filtered-out profile's collector must not run")
+	}
+}
+
+func TestDefaultCollectOptions_MultiProfileGroupsEveryProfileUnderClaude(t *testing.T) {
+	pluginConfigDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginConfigDir)
+	dirLabeled := t.TempDir()
+	dirUnlabeled := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirLabeled, ".claude.json"),
+		[]byte(`{"oauthAccount":{"emailAddress":"primary@example.com"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirUnlabeled, ".claude.json"),
+		[]byte(`{"oauthAccount":{"emailAddress":"secondary@example.com"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toml := "[[claude.profiles]]\n" +
+		"id = \"claude\"\n" +
+		"label = \"My Work Account\"\n" +
+		"config_dir = \"" + dirLabeled + "\"\n\n" +
+		"[[claude.profiles]]\n" +
+		"id = \"claude-secondary\"\n" +
+		"config_dir = \"" + dirUnlabeled + "\"\n"
+	if err := os.WriteFile(filepath.Join(pluginConfigDir, "config.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := DefaultCollectOptions()
+	if len(opts.Claude) != 2 {
+		t.Fatalf("want 2 claude collectors, got %d", len(opts.Claude))
+	}
+	// The explicit label must be preserved as Label; AccountLabel carries the
+	// real email so the panel can show it instead once grouped.
+	if opts.Claude[0].Label != "My Work Account" {
+		t.Fatalf("explicit label must be preserved, got %q", opts.Claude[0].Label)
+	}
+	got0 := opts.Claude[0].Collector(nil, 0)
+	if got0.GroupLabel != "Claude" {
+		t.Fatalf("labeled profile should be grouped under Claude, got %q", got0.GroupLabel)
+	}
+	if got0.AccountLabel != "primary@example.com" {
+		t.Fatalf("labeled profile should still resolve AccountLabel from its email, got %q", got0.AccountLabel)
+	}
+	// The unlabeled profile keeps its id as Label, plus the same grouping.
+	if opts.Claude[1].Label != "claude-secondary" {
+		t.Fatalf("unlabeled profile label should default to id, got %q", opts.Claude[1].Label)
+	}
+	got1 := opts.Claude[1].Collector(nil, 0)
+	if got1.GroupLabel != "Claude" {
+		t.Fatalf("unlabeled profile should be grouped under Claude, got %q", got1.GroupLabel)
+	}
+	if got1.AccountLabel != "secondary@example.com" {
+		t.Fatalf("unlabeled profile should resolve AccountLabel from its email, got %q", got1.AccountLabel)
+	}
+}
+
+func TestDefaultCollectOptions_SingleProfileNotGrouped(t *testing.T) {
+	pluginConfigDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginConfigDir)
+	// Isolate from the real machine's ~/.claude.json (age/content varies by
+	// machine and would otherwise make this test's Note assertion flaky).
+	t.Setenv("HOME", t.TempDir())
+	// No [[claude.profiles]] configured -> single synthesized default; grouping
+	// only kicks in once there are 2+ profiles to disambiguate.
+	opts := DefaultCollectOptions()
+	if len(opts.Claude) != 1 {
+		t.Fatalf("want 1 (default) claude collector, got %d", len(opts.Claude))
+	}
+	got := opts.Claude[0].Collector(nil, 0)
+	if got.GroupLabel != "" {
+		t.Fatalf("single-profile mode should not set GroupLabel, got %q", got.GroupLabel)
+	}
+	if got.AccountLabel != "" {
+		t.Fatalf("single-profile mode should not set AccountLabel, got %q", got.AccountLabel)
 	}
 }

--- a/internal/limits/formatpanel.go
+++ b/internal/limits/formatpanel.go
@@ -224,6 +224,22 @@ func paneActivityLine(activity ProviderPaneActivity, layout PanelLayout) string 
 	return "  " + label + "  " + strings.Join(parts, " · ") + tail
 }
 
+// noteLine renders p.Note (stale-cache warnings, account identity, spend
+// summaries, …), truncated to fit the pane width. Empty when there is no
+// note — callers only append it when non-empty.
+func noteLine(note *string, layout PanelLayout) string {
+	if note == nil || *note == "" {
+		return ""
+	}
+	text := *note
+	budget := max(layout.Columns-3, 8) // "  " prefix + 1 margin
+	if utf8.RuneCountInString(text) > budget {
+		runes := []rune(text)
+		text = string(runes[:budget-1]) + "…"
+	}
+	return "  " + bar.Dim(text, layout.Color)
+}
+
 func providerHeader(p ProviderLimits, layout PanelLayout) string {
 	name := bar.Bold(p.Label, layout.Color)
 	if p.PlanType != nil {
@@ -355,6 +371,11 @@ func richBlock(p ProviderLimits, layout PanelLayout, withExtras bool, nowMs int6
 			lines = append(lines, paneLine)
 		}
 	}
+	if withExtras {
+		if note := noteLine(p.Note, layout); note != "" {
+			lines = append(lines, note)
+		}
+	}
 	return lines
 }
 
@@ -432,9 +453,7 @@ func FormatUsagePanel(providers []ProviderLimits, apiUsage []APIProviderUsage, n
 	}
 
 	blocks := make([]panelBlock, 0, len(providers)+len(apiUsage))
-	for _, p := range providers {
-		blocks = append(blocks, subscriptionBlock(p, layout, nowMs))
-	}
+	blocks = append(blocks, buildProviderBlocks(providers, layout, nowMs)...)
 	for _, p := range apiUsage {
 		blocks = append(blocks, apiBlock(p, layout))
 	}
@@ -488,6 +507,83 @@ func subscriptionBlock(p ProviderLimits, layout PanelLayout, nowMs int64) panelB
 		richSlim: func() []string { return richBlock(p, layout, false, nowMs) },
 		compact:  func() []string { return []string{compactLine(p, layout)} },
 	}
+}
+
+// buildProviderBlocks turns each contiguous run of 2+ providers sharing the
+// same non-empty GroupLabel (e.g. multiple configured Claude accounts) into
+// one nested groupedSubscriptionBlock; every other provider keeps its normal
+// standalone subscriptionBlock. Groups are expected to be contiguous, which
+// holds for how CollectAllProviderLimits orders configured Claude profiles.
+func buildProviderBlocks(providers []ProviderLimits, layout PanelLayout, nowMs int64) []panelBlock {
+	blocks := make([]panelBlock, 0, len(providers))
+	for i := 0; i < len(providers); {
+		label := providers[i].GroupLabel
+		j := i + 1
+		if label != "" {
+			for j < len(providers) && providers[j].GroupLabel == label {
+				j++
+			}
+		}
+		if label != "" && j-i >= 2 {
+			blocks = append(blocks, groupedSubscriptionBlock(label, providers[i:j], layout, nowMs))
+		} else {
+			blocks = append(blocks, subscriptionBlock(providers[i], layout, nowMs))
+			j = i + 1
+		}
+		i = j
+	}
+	return blocks
+}
+
+// groupedSubscriptionBlock renders a shared heading (e.g. "Claude") followed
+// by each member indented two spaces, using AccountLabel in place of Label so
+// the members stay distinguishable under the one heading.
+func groupedSubscriptionBlock(label string, members []ProviderLimits, layout PanelLayout, nowMs int64) panelBlock {
+	inner := layout
+	inner.Columns = max(layout.Columns-2, richMinColumns)
+
+	memberWithAccountLabel := func(m ProviderLimits) ProviderLimits {
+		if m.AccountLabel != "" {
+			m.Label = m.AccountLabel
+		}
+		return m
+	}
+
+	render := func(withExtras bool) []string {
+		lines := []string{bar.Bold(label, layout.Color)}
+		for i, m := range members {
+			if i > 0 {
+				lines = append(lines, "")
+			}
+			sub := richBlock(memberWithAccountLabel(m), inner, withExtras, nowMs)
+			lines = append(lines, indentLines(sub, "  ")...)
+		}
+		return lines
+	}
+
+	return panelBlock{
+		rich:     func() []string { return render(true) },
+		richSlim: func() []string { return render(false) },
+		compact: func() []string {
+			lines := []string{bar.Bold(label, layout.Color)}
+			for _, m := range members {
+				lines = append(lines, "  "+compactLine(memberWithAccountLabel(m), inner))
+			}
+			return lines
+		},
+	}
+}
+
+func indentLines(lines []string, prefix string) []string {
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		if l == "" {
+			out[i] = l
+			continue
+		}
+		out[i] = prefix + l
+	}
+	return out
 }
 
 func apiBlock(p APIProviderUsage, layout PanelLayout) panelBlock {

--- a/internal/limits/formatpanel_test.go
+++ b/internal/limits/formatpanel_test.go
@@ -222,3 +222,83 @@ func TestFormatLimitsPanel_RowBudget(t *testing.T) {
 		t.Fatalf("too many lines: %d", len(strings.Split(text, "\n")))
 	}
 }
+
+func TestFormatProviderBlock_Note(t *testing.T) {
+	p := sampleProvider()
+	note := "stale ~45m ago"
+	p.Note = &note
+	text := FormatProviderBlock(p, wide, 1_700_000_000_000)
+	if !strings.Contains(text, "stale ~45m ago") {
+		t.Fatalf("note not rendered:\n%s", text)
+	}
+}
+
+func TestFormatProviderBlock_NoteTruncatesToFitWidth(t *testing.T) {
+	narrow := PanelLayout{Columns: 20, Rows: 9999, Color: false}
+	note := "a very long note that does not fit in a narrow pane at all"
+	line := noteLine(&note, narrow)
+	if utf8.RuneCountInString(line) > narrow.Columns+1 {
+		t.Fatalf("note line exceeds width budget: %q", line)
+	}
+	if !strings.Contains(line, "…") {
+		t.Fatalf("expected truncation ellipsis: %q", line)
+	}
+}
+
+func TestFormatProviderBlock_NoNoteWhenAbsent(t *testing.T) {
+	text := FormatProviderBlock(sampleProvider(), wide, 1_700_000_000_000)
+	if strings.Contains(text, "…") {
+		t.Fatalf("unexpected truncation with no note:\n%s", text)
+	}
+}
+
+func claudeProfileSample(accountEmail string, usedPct float64) ProviderLimits {
+	r1, r2 := int64(2_000_000_000), int64(2_000_500_000)
+	wm1, wm2 := 300, 10080
+	plan := "Pro"
+	return ProviderLimits{
+		ProviderID:   "claude-" + accountEmail,
+		Label:        "claude-" + accountEmail,
+		AccountLabel: accountEmail,
+		GroupLabel:   "Claude",
+		Primary:      &LimitWindow{UsedPercentage: usedPct, ResetsAt: &r1, WindowMinutes: &wm1},
+		Secondary:    &LimitWindow{UsedPercentage: usedPct, ResetsAt: &r2, WindowMinutes: &wm2},
+		PlanType:     &plan,
+		Source:       "claude.json cachedUsageUtilization",
+		FetchedAtMs:  1_700_000_000_000,
+	}
+}
+
+func TestFormatUsagePanel_GroupsMultipleClaudeProfilesUnderSharedHeading(t *testing.T) {
+	providers := []ProviderLimits{
+		claudeProfileSample("you@example.com", 12),
+		claudeProfileSample("colleague@example.com", 32),
+	}
+	text := FormatLimitsPanel(providers, 1_700_000_000_000, wide)
+	if !strings.Contains(text, "Claude\n") && !strings.Contains(text, "Claude ") {
+		t.Fatalf("expected a single shared Claude heading:\n%s", text)
+	}
+	for _, want := range []string{"you@example.com · Pro", "colleague@example.com · Pro"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing account line %q:\n%s", want, text)
+		}
+	}
+	// Only one "Claude" heading, not one per account.
+	if strings.Count(text, "Claude") != 1 {
+		t.Fatalf("want exactly one Claude heading, got %d:\n%s", strings.Count(text, "Claude"), text)
+	}
+}
+
+func TestFormatUsagePanel_SingleClaudeProfileNotGrouped(t *testing.T) {
+	p := claudeProfileSample("you@example.com", 12)
+	p.GroupLabel = ""
+	p.AccountLabel = ""
+	p.Label = "Claude"
+	text := FormatLimitsPanel([]ProviderLimits{p}, 1_700_000_000_000, wide)
+	if !strings.Contains(text, "Claude · Pro") {
+		t.Fatalf("expected ungrouped single profile to keep its own header:\n%s", text)
+	}
+	if strings.Contains(text, "you@example.com") {
+		t.Fatalf("single profile should not show an account email line:\n%s", text)
+	}
+}

--- a/internal/limits/grokwebbilling_test.go
+++ b/internal/limits/grokwebbilling_test.go
@@ -35,6 +35,7 @@ func TestParseGrokWebBillingResponse(t *testing.T) {
 	snap := ParseGrokWebBillingResponse(data, nowMs)
 	if snap == nil {
 		t.Fatal("expected snapshot")
+		return
 	}
 	if snap.UsedPercent != 55 {
 		t.Fatalf("usedPercent=%v want 55", snap.UsedPercent)

--- a/internal/limits/grokwebbilling_test.go
+++ b/internal/limits/grokwebbilling_test.go
@@ -35,7 +35,6 @@ func TestParseGrokWebBillingResponse(t *testing.T) {
 	snap := ParseGrokWebBillingResponse(data, nowMs)
 	if snap == nil {
 		t.Fatal("expected snapshot")
-		return
 	}
 	if snap.UsedPercent != 55 {
 		t.Fatalf("usedPercent=%v want 55", snap.UsedPercent)

--- a/internal/limits/notifystate.go
+++ b/internal/limits/notifystate.go
@@ -7,15 +7,17 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
 
-// NotifyProviderPrimaryLimits checks non-Claude primary windows under the shared lock.
+// NotifyProviderPrimaryLimits checks non-Claude primary windows under the
+// shared lock, excluding every configured Claude profile id.
 func NotifyProviderPrimaryLimits(providers []ProviderLimits, nowMs int64) {
+	claudeProfiles := ResolvedClaudeProfiles()
 	ratelimit.WithLockedProviderState(func(current ratelimit.ProviderNotifyStateMap) ratelimit.ProviderNotifyStateMap {
 		// convert to limits.ProviderNotifyState
 		cur := ProviderNotifyState{}
 		for k, v := range current {
 			cur[k] = v
 		}
-		next := CheckProviderPrimaryLimits(providers, cur, nowMs, herdrcliShowNotification)
+		next := CheckProviderPrimaryLimits(providers, cur, nowMs, herdrcliShowNotification, claudeProfiles)
 		out := ratelimit.ProviderNotifyStateMap{}
 		for k, v := range next {
 			out[k] = v

--- a/internal/limits/paneprovider_test.go
+++ b/internal/limits/paneprovider_test.go
@@ -1,0 +1,126 @@
+/**
+ * Tests for BuildClaudePaneProviderResolver and the claude-profile dispatch in
+ * TokensForPaneDefault / TotalTokensForProviderDefault.
+ */
+package limits
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+)
+
+func writeTranscript(t *testing.T, root, projectDir, sessionID, body string) {
+	t.Helper()
+	dir := filepath.Join(root, projectDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildClaudePaneProviderResolver_SingleProfileShortCircuits(t *testing.T) {
+	profiles := []claude.ClaudeProfile{{ID: "claude", ProjectsRoot: t.TempDir()}}
+	resolve := BuildClaudePaneProviderResolver(profiles)
+	id, ok := resolve(OpenPaneSnapshot{Agent: "claude"})
+	if !ok || id != "claude" {
+		t.Fatalf("ok=%v id=%q", ok, id)
+	}
+	// Non-claude agents still resolve via the static map.
+	id, ok = resolve(OpenPaneSnapshot{Agent: "codex"})
+	if !ok || id != "codex" {
+		t.Fatalf("codex: ok=%v id=%q", ok, id)
+	}
+}
+
+func TestBuildClaudePaneProviderResolver_SingleCustomIDProfile(t *testing.T) {
+	// A single explicitly configured profile need not be id "claude" —
+	// the resolver must still attribute the pane to that profile's id.
+	profiles := []claude.ClaudeProfile{{ID: "work", ProjectsRoot: t.TempDir()}}
+	resolve := BuildClaudePaneProviderResolver(profiles)
+	id, ok := resolve(OpenPaneSnapshot{Agent: "claude"})
+	if !ok || id != "work" {
+		t.Fatalf("ok=%v id=%q, want work", ok, id)
+	}
+}
+
+func TestBuildClaudePaneProviderResolver_MultiProfileMatchesBySession(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeTranscript(t, rootB, "-home-b", "sess-b", "line\n")
+
+	profiles := []claude.ClaudeProfile{
+		{ID: "claude", ProjectsRoot: rootA},
+		{ID: "claude-secondary", ProjectsRoot: rootB},
+	}
+	resolve := BuildClaudePaneProviderResolver(profiles)
+	sid := "sess-b"
+	id, ok := resolve(OpenPaneSnapshot{Agent: "claude", SessionID: &sid})
+	if !ok || id != "claude-secondary" {
+		t.Fatalf("ok=%v id=%q", ok, id)
+	}
+}
+
+func TestBuildClaudePaneProviderResolver_MultiProfileUnknownSessionRefuses(t *testing.T) {
+	profiles := []claude.ClaudeProfile{
+		{ID: "claude", ProjectsRoot: t.TempDir()},
+		{ID: "claude-secondary", ProjectsRoot: t.TempDir()},
+	}
+	resolve := BuildClaudePaneProviderResolver(profiles)
+	sid := "unknown-session"
+	_, ok := resolve(OpenPaneSnapshot{Agent: "claude", SessionID: &sid})
+	if ok {
+		t.Fatal("unresolved claude session must not attribute to any profile")
+	}
+}
+
+func TestBuildClaudePaneProviderResolver_MultiProfileNonClaudeUnaffected(t *testing.T) {
+	profiles := []claude.ClaudeProfile{
+		{ID: "claude", ProjectsRoot: t.TempDir()},
+		{ID: "claude-secondary", ProjectsRoot: t.TempDir()},
+	}
+	resolve := BuildClaudePaneProviderResolver(profiles)
+	id, ok := resolve(OpenPaneSnapshot{Agent: "grok"})
+	if !ok || id != "grok" {
+		t.Fatalf("ok=%v id=%q", ok, id)
+	}
+}
+
+func claudeUsageLine() string {
+	return `{"type":"assistant","isSidechain":false,"timestamp":"2026-01-01T00:00:00.000Z","message":{"model":"claude-sonnet-5","usage":{"input_tokens":100,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":10}}}` + "\n"
+}
+
+func TestTokensForPaneDefault_DispatchesToResolvedProfileRoot(t *testing.T) {
+	pluginConfigDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", pluginConfigDir)
+	configDirA := t.TempDir()
+	configDirB := t.TempDir()
+
+	cfg := "[[claude.profiles]]\n" +
+		"id = \"claude\"\n" +
+		"config_dir = \"" + configDirA + "\"\n\n" +
+		"[[claude.profiles]]\n" +
+		"id = \"claude-secondary\"\n" +
+		"config_dir = \"" + configDirB + "\"\n"
+	if err := os.WriteFile(filepath.Join(pluginConfigDir, "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// claude-secondary's ProjectsRoot is <configDirB>/projects (see profile.go).
+	writeTranscript(t, filepath.Join(configDirB, "projects"), "-home-b", "sess-real", claudeUsageLine())
+
+	sid := "sess-real"
+	pane := OpenPaneSnapshot{Agent: "claude", SessionID: &sid}
+	tokens := TokensForPaneDefault("claude-secondary", pane, 0, 1<<62)
+	if tokens != 110 {
+		t.Fatalf("tokens=%v want 110", tokens)
+	}
+	// The default "claude" profile must not see claude-secondary's session.
+	if got := TokensForPaneDefault("claude", pane, 0, 1<<62); got != 0 {
+		t.Fatalf("default profile should not see claude-secondary's session, got %v", got)
+	}
+}

--- a/internal/limits/panetokens_io.go
+++ b/internal/limits/panetokens_io.go
@@ -21,10 +21,19 @@ import (
 // resolve Claude panes by profile (session-transcript match) when more than
 // one Claude profile is configured.
 func DefaultPaneActivityDeps() PaneActivityDeps {
+	// Resolve the profile snapshot once and share it across all three deps, so
+	// the whole AttachPaneActivity pass agrees on one profile set instead of
+	// the resolver and the token/total dispatch each re-resolving (which could
+	// also skew if config changed mid-pass).
+	profiles := ResolvedClaudeProfiles()
 	return PaneActivityDeps{
-		TokensForPane:          TokensForPaneDefault,
-		TotalTokensForProvider: TotalTokensForProviderDefault,
-		ResolvePaneProvider:    BuildClaudePaneProviderResolver(ResolvedClaudeProfiles()),
+		TokensForPane: func(providerID string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
+			return tokensForPaneWith(profiles, providerID, pane, startMs, endMs)
+		},
+		TotalTokensForProvider: func(providerID string, startMs, endMs int64) float64 {
+			return totalTokensForProviderWith(profiles, providerID, startMs, endMs)
+		},
+		ResolvePaneProvider: BuildClaudePaneProviderResolver(profiles),
 	}
 }
 
@@ -68,7 +77,14 @@ func BuildClaudePaneProviderResolver(profiles []claude.ClaudeProfile) PaneProvid
 // "claude"), so Claude is dispatched by profile lookup rather than a switch
 // case: each profile's tokens are read from only its own transcript root.
 func TokensForPaneDefault(providerID string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
-	if profile, ok := claudeProfileByID(providerID); ok {
+	return tokensForPaneWith(ResolvedClaudeProfiles(), providerID, pane, startMs, endMs)
+}
+
+// tokensForPaneWith is TokensForPaneDefault dispatched against an explicit
+// profile snapshot (see DefaultPaneActivityDeps): Claude ids resolve their
+// transcript root from profiles, other agents via the static switch.
+func tokensForPaneWith(profiles []claude.ClaudeProfile, providerID string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
+	if profile, ok := profileByIDIn(profiles, providerID); ok {
 		return claudeTokensForPaneIn(profile.ProjectsRoot, pane, startMs, endMs)
 	}
 	switch providerID {
@@ -117,7 +133,13 @@ func TokensForPaneAnyBackend(providerID string, pane OpenPaneSnapshot, startMs, 
 // disk. Claude profile ids are dispatched by lookup (see TokensForPaneDefault)
 // so each profile's total is scanned from only its own transcript root.
 func TotalTokensForProviderDefault(providerID string, startMs, endMs int64) float64 {
-	if profile, ok := claudeProfileByID(providerID); ok {
+	return totalTokensForProviderWith(ResolvedClaudeProfiles(), providerID, startMs, endMs)
+}
+
+// totalTokensForProviderWith is TotalTokensForProviderDefault dispatched against
+// an explicit profile snapshot (see DefaultPaneActivityDeps).
+func totalTokensForProviderWith(profiles []claude.ClaudeProfile, providerID string, startMs, endMs int64) float64 {
+	if profile, ok := profileByIDIn(profiles, providerID); ok {
 		return claudeTotalIn(profile.ProjectsRoot, startMs, endMs)
 	}
 	switch providerID {

--- a/internal/limits/panetokens_io.go
+++ b/internal/limits/panetokens_io.go
@@ -10,27 +10,68 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+	claudeprovider "github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
 	_ "modernc.org/sqlite"
 )
 
-// DefaultPaneActivityDeps returns production token collectors.
+// DefaultPaneActivityDeps returns production token collectors, wired to
+// resolve Claude panes by profile (session-transcript match) when more than
+// one Claude profile is configured.
 func DefaultPaneActivityDeps() PaneActivityDeps {
 	return PaneActivityDeps{
 		TokensForPane:          TokensForPaneDefault,
 		TotalTokensForProvider: TotalTokensForProviderDefault,
+		ResolvePaneProvider:    BuildClaudePaneProviderResolver(ResolvedClaudeProfiles()),
+	}
+}
+
+// BuildClaudePaneProviderResolver attributes Claude panes to the specific
+// configured profile matching their session transcript, and other agents via
+// the static agentToProvider map.
+//
+// A single Claude profile (whether the synthesized default or one explicitly
+// configured profile, which need not be id "claude") short-circuits to that
+// profile's id directly rather than session matching — same cost as today,
+// but correct even when the lone profile has a custom id.
+func BuildClaudePaneProviderResolver(profiles []claude.ClaudeProfile) PaneProviderResolver {
+	if len(profiles) == 1 {
+		soleID := profiles[0].ID
+		return func(pane OpenPaneSnapshot) (string, bool) {
+			if pane.Agent == "claude" {
+				return soleID, true
+			}
+			id, ok := agentToProvider[pane.Agent]
+			return id, ok
+		}
+	}
+	roots := make(map[string]string, len(profiles))
+	for _, p := range profiles {
+		roots[p.ID] = p.ProjectsRoot
+	}
+	return func(pane OpenPaneSnapshot) (string, bool) {
+		if pane.Agent != "claude" {
+			id, ok := agentToProvider[pane.Agent]
+			return id, ok
+		}
+		return claudeprovider.ResolveProfileForSession(sessionIDStr(pane), roots)
 	}
 }
 
 // TokensForPaneDefault sums windowed tokens for one open pane, counting only
 // subscription-billed traffic (opencode-go for OpenCode): it feeds the plan
 // budget share under a provider's limits.
+//
+// providerID may be any configured Claude profile id (not just the literal
+// "claude"), so Claude is dispatched by profile lookup rather than a switch
+// case: each profile's tokens are read from only its own transcript root.
 func TokensForPaneDefault(providerID string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
+	if profile, ok := claudeProfileByID(providerID); ok {
+		return claudeTokensForPaneIn(profile.ProjectsRoot, pane, startMs, endMs)
+	}
 	switch providerID {
-	case "claude":
-		return claudeTokensForPane(pane, startMs, endMs)
 	case "codex":
 		return codexTokensForPane(pane, startMs, endMs)
 	case "opencode":
@@ -72,11 +113,14 @@ func TokensForPaneAnyBackend(providerID string, pane OpenPaneSnapshot, startMs, 
 	return TokensForPaneDefault(providerID, pane, startMs, endMs)
 }
 
-// TotalTokensForProviderDefault sums windowed tokens across all sessions on disk.
+// TotalTokensForProviderDefault sums windowed tokens across all sessions on
+// disk. Claude profile ids are dispatched by lookup (see TokensForPaneDefault)
+// so each profile's total is scanned from only its own transcript root.
 func TotalTokensForProviderDefault(providerID string, startMs, endMs int64) float64 {
+	if profile, ok := claudeProfileByID(providerID); ok {
+		return claudeTotalIn(profile.ProjectsRoot, startMs, endMs)
+	}
 	switch providerID {
-	case "claude":
-		return claudeTotal(startMs, endMs)
 	case "codex":
 		return codexTotal(startMs, endMs)
 	case "opencode":
@@ -102,12 +146,15 @@ func cwdStr(pane OpenPaneSnapshot) string {
 	return *pane.Cwd
 }
 
-func claudeTokensForPane(pane OpenPaneSnapshot, startMs, endMs int64) float64 {
+// claudeTokensForPaneIn sums one pane's windowed tokens from an explicit
+// projects root, so a pane's tokens are read from only its resolved profile's
+// root (see claudeProfileByID dispatch in TokensForPaneDefault).
+func claudeTokensForPaneIn(root string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
 	sid := sessionIDStr(pane)
 	if sid == "" {
 		return 0
 	}
-	path := claude.ResolveTranscriptPathForSession(sid)
+	path := claudeprovider.ResolveTranscriptPathForSessionIn(root, sid)
 	if path == "" {
 		return 0
 	}
@@ -258,8 +305,10 @@ func claudeProjectsRoot() string {
 	return filepath.Join(home, ".claude", "projects")
 }
 
-func claudeTotal(startMs, endMs int64) float64 {
-	root := claudeProjectsRoot()
+// claudeTotalIn sums windowed tokens across all sessions under an explicit
+// projects root, so each Claude profile's activity total is scanned from only
+// its own root (see claudeProfileByID dispatch in TotalTokensForProviderDefault).
+func claudeTotalIn(root string, startMs, endMs int64) float64 {
 	var sum float64
 	for _, dir := range listDirSafe(root) {
 		dirPath := filepath.Join(root, dir)

--- a/internal/limits/primarynotify.go
+++ b/internal/limits/primarynotify.go
@@ -6,7 +6,10 @@
  */
 package limits
 
-import "github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
+import (
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
+)
 
 // NotifyFunc shows a toast; returns whether it was displayed.
 type NotifyFunc func(title, body string) bool
@@ -43,20 +46,24 @@ func processProvider(
 	return ratelimit.ApplyNotifyResult(previous, decision.NewState, notify(text.Title, text.Body))
 }
 
-// CheckProviderPrimaryLimits is the pure state transition for non-Claude primary windows.
-// Claude is deliberately excluded because its statusLine already owns its alerts.
+// CheckProviderPrimaryLimits is the pure state transition for non-Claude
+// primary windows. Every configured Claude profile id is excluded (not just
+// the literal "claude") because Claude's statusLine already owns its own
+// per-profile alerts — without this, a non-default profile like
+// "claude-secondary" would double-notify through this generic loop too.
 func CheckProviderPrimaryLimits(
 	providers []ProviderLimits,
 	current ProviderNotifyState,
 	nowMs int64,
 	notify NotifyFunc,
+	claudeProfiles []claude.ClaudeProfile,
 ) ProviderNotifyState {
 	next := make(ProviderNotifyState, len(current)+len(providers))
 	for k, v := range current {
 		next[k] = v
 	}
 	for _, provider := range providers {
-		if provider.ProviderID == "claude" {
+		if claude.IsClaudeProviderID(provider.ProviderID, claudeProfiles) {
 			continue
 		}
 		prev := current[provider.ProviderID]

--- a/internal/limits/primarynotify_test.go
+++ b/internal/limits/primarynotify_test.go
@@ -6,8 +6,11 @@ package limits
 import (
 	"testing"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
+
+var defaultClaudeProfiles = []claude.ClaudeProfile{{ID: "claude"}}
 
 const (
 	notifyNowMs    int64 = 1_800_000_000_000
@@ -40,6 +43,7 @@ func TestCheckProviderPrimaryLimits_Notifies(t *testing.T) {
 			notifications = append(notifications, title+": "+body)
 			return true
 		},
+		defaultClaudeProfiles,
 	)
 	if len(notifications) != 1 || notifications[0] != "Codex limit: 50% remaining · resets in 2h 0m" {
 		t.Fatalf("notifications=%v", notifications)
@@ -62,6 +66,7 @@ func TestCheckProviderPrimaryLimits_NoRenotify(t *testing.T) {
 			t.Fatal("should not notify")
 			return false
 		},
+		defaultClaudeProfiles,
 	)
 	if next["codex"] == nil || next["codex"].NotifiedBucket == nil || *next["codex"].NotifiedBucket != ratelimit.Bucket50 {
 		t.Fatalf("next=%+v", next["codex"])
@@ -71,7 +76,7 @@ func TestCheckProviderPrimaryLimits_NoRenotify(t *testing.T) {
 func TestCheckProviderPrimaryLimits_IgnoresClaudeAndSecondary(t *testing.T) {
 	wm := 300
 	r := notifyResetsAt
-	claude := notifyTestProvider(func(p *ProviderLimits) {
+	claudeProvider := notifyTestProvider(func(p *ProviderLimits) {
 		p.ProviderID = "claude"
 		p.Label = "Claude"
 		p.Primary = &LimitWindow{UsedPercentage: 99, ResetsAt: &r, WindowMinutes: &wm}
@@ -83,13 +88,14 @@ func TestCheckProviderPrimaryLimits_IgnoresClaudeAndSecondary(t *testing.T) {
 	})
 	var notifications []string
 	next := CheckProviderPrimaryLimits(
-		[]ProviderLimits{claude, codexNoPrimary},
+		[]ProviderLimits{claudeProvider, codexNoPrimary},
 		ProviderNotifyState{},
 		notifyNowMs,
 		func(title, body string) bool {
 			notifications = append(notifications, title)
 			return true
 		},
+		defaultClaudeProfiles,
 	)
 	if len(notifications) != 0 {
 		t.Fatalf("notifications=%v", notifications)
@@ -97,5 +103,30 @@ func TestCheckProviderPrimaryLimits_IgnoresClaudeAndSecondary(t *testing.T) {
 	// codex without primary keeps previous (nil)
 	if next["codex"] != nil {
 		t.Fatalf("expected nil codex state, got %+v", next["codex"])
+	}
+}
+
+func TestCheckProviderPrimaryLimits_IgnoresConfiguredSecondaryProfile(t *testing.T) {
+	wm := 300
+	r := notifyResetsAt
+	secondary := notifyTestProvider(func(p *ProviderLimits) {
+		p.ProviderID = "claude-secondary"
+		p.Label = "Claude (secondary)"
+		p.Primary = &LimitWindow{UsedPercentage: 99, ResetsAt: &r, WindowMinutes: &wm}
+	})
+	profiles := []claude.ClaudeProfile{{ID: "claude"}, {ID: "claude-secondary"}}
+	var notifications []string
+	CheckProviderPrimaryLimits(
+		[]ProviderLimits{secondary},
+		ProviderNotifyState{},
+		notifyNowMs,
+		func(title, body string) bool {
+			notifications = append(notifications, title)
+			return true
+		},
+		profiles,
+	)
+	if len(notifications) != 0 {
+		t.Fatalf("claude-secondary must not double-notify through the generic loop: %v", notifications)
 	}
 }

--- a/internal/limits/runout.go
+++ b/internal/limits/runout.go
@@ -133,18 +133,11 @@ func EnrichRunOut(
 
 	nextProviders := make([]ProviderLimits, len(providers))
 	for i, p := range providers {
-		nextProviders[i] = ProviderLimits{
-			ProviderID:   p.ProviderID,
-			Label:        p.Label,
-			Primary:      withRunOut(p.ProviderID, kindPrimary, p.Primary),
-			Secondary:    withRunOut(p.ProviderID, kindSecondary, p.Secondary),
-			Tertiary:     withRunOut(p.ProviderID, kindTertiary, p.Tertiary),
-			PlanType:     p.PlanType,
-			Source:       p.Source,
-			FetchedAtMs:  p.FetchedAtMs,
-			Note:         p.Note,
-			PaneActivity: p.PaneActivity,
-		}
+		next := p
+		next.Primary = withRunOut(p.ProviderID, kindPrimary, p.Primary)
+		next.Secondary = withRunOut(p.ProviderID, kindSecondary, p.Secondary)
+		next.Tertiary = withRunOut(p.ProviderID, kindTertiary, p.Tertiary)
+		nextProviders[i] = next
 	}
 
 	return EnrichRunOutResult{Providers: nextProviders, History: history}

--- a/internal/limits/runout_test.go
+++ b/internal/limits/runout_test.go
@@ -97,6 +97,7 @@ func TestElapsedAverageRatePerMin_FrontLoadedOneDayOfSeven(t *testing.T) {
 	rate := ElapsedAverageRatePerMin(w, runNow, LongWindowMinElapsedMin)
 	if rate == nil {
 		t.Fatal("expected rate")
+		return
 	}
 	want := 60.0 / float64(day)
 	if math.Abs(*rate-want) > 1e-8 {
@@ -116,6 +117,7 @@ func TestElapsedAverageRatePerMin_ClampsUpToMinElapsed(t *testing.T) {
 	rate := ElapsedAverageRatePerMin(w, runNow, LongWindowMinElapsedMin)
 	if rate == nil {
 		t.Fatal("expected rate")
+		return
 	}
 	want := 10.0 / float64(LongWindowMinElapsedMin)
 	if math.Abs(*rate-want) > 1e-8 {

--- a/internal/limits/runout_test.go
+++ b/internal/limits/runout_test.go
@@ -97,7 +97,6 @@ func TestElapsedAverageRatePerMin_FrontLoadedOneDayOfSeven(t *testing.T) {
 	rate := ElapsedAverageRatePerMin(w, runNow, LongWindowMinElapsedMin)
 	if rate == nil {
 		t.Fatal("expected rate")
-		return
 	}
 	want := 60.0 / float64(day)
 	if math.Abs(*rate-want) > 1e-8 {
@@ -117,7 +116,6 @@ func TestElapsedAverageRatePerMin_ClampsUpToMinElapsed(t *testing.T) {
 	rate := ElapsedAverageRatePerMin(w, runNow, LongWindowMinElapsedMin)
 	if rate == nil {
 		t.Fatal("expected rate")
-		return
 	}
 	want := 10.0 / float64(LongWindowMinElapsedMin)
 	if math.Abs(*rate-want) > 1e-8 {

--- a/internal/limits/types.go
+++ b/internal/limits/types.go
@@ -42,6 +42,15 @@ type ProviderLimits struct {
 	Note        *string
 	// PaneActivity is per-pane token activity share over the smallest window.
 	PaneActivity *ProviderPaneActivity
+	// GroupLabel nests this entry under one shared heading in the panel
+	// (e.g. multiple configured Claude accounts under "Claude") instead of
+	// its own top-level block. Only takes effect when 2+ entries share the
+	// same non-empty GroupLabel; a lone entry renders as if it were empty.
+	GroupLabel string
+	// AccountLabel is shown in place of Label for the per-account line inside
+	// a group (e.g. the account's real login email), so members sharing one
+	// GroupLabel stay distinguishable. Ignored outside a group.
+	AccountLabel string
 }
 
 // ProviderPaneActivity is windowed per-pane activity for one provider.

--- a/internal/providers/claude/transcript.go
+++ b/internal/providers/claude/transcript.go
@@ -26,10 +26,9 @@ func projectsRoot() string {
 	return filepath.Join(home, ".claude", "projects")
 }
 
-// findSessionFile scans project directories for {sessionId}.jsonl.
+// findSessionFileIn scans root's project directories for {sessionId}.jsonl.
 // The project directory name (encoded cwd) is lossy; UUIDs are globally unique.
-func findSessionFile(sessionID string) string {
-	root := projectsRoot()
+func findSessionFileIn(root, sessionID string) string {
 	if root == "" {
 		return ""
 	}
@@ -50,12 +49,20 @@ func findSessionFile(sessionID string) string {
 	return ""
 }
 
-// ResolveTranscriptPathForSession returns the transcript jsonl path, or empty when not found.
+// ResolveTranscriptPathForSession returns the transcript jsonl path under the
+// default projects root, or empty when not found.
 func ResolveTranscriptPathForSession(sessionID string) string {
+	return ResolveTranscriptPathForSessionIn(projectsRoot(), sessionID)
+}
+
+// ResolveTranscriptPathForSessionIn is ResolveTranscriptPathForSession scoped
+// to an explicit projects root, so a multi-profile caller can search one
+// profile's root without touching global env state.
+func ResolveTranscriptPathForSessionIn(root, sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
-	return findSessionFile(sessionID)
+	return findSessionFileIn(root, sessionID)
 }
 
 func totalTokensOf(usage TranscriptUsage) int {
@@ -116,9 +123,16 @@ func intOrZero(n *float64) int {
 	return int(*n)
 }
 
-// ResolveUsageForSession resolves the latest usage for a session ID.
+// ResolveUsageForSession resolves the latest usage for a session ID under the
+// default projects root.
 func ResolveUsageForSession(sessionID string) *TranscriptUsage {
-	path := findSessionFile(sessionID)
+	return ResolveUsageForSessionIn(projectsRoot(), sessionID)
+}
+
+// ResolveUsageForSessionIn is ResolveUsageForSession scoped to an explicit
+// projects root.
+func ResolveUsageForSessionIn(root, sessionID string) *TranscriptUsage {
+	path := findSessionFileIn(root, sessionID)
 	if path == "" {
 		return nil
 	}
@@ -127,4 +141,22 @@ func ResolveUsageForSession(sessionID string) *TranscriptUsage {
 		return nil
 	}
 	return ExtractLatestUsageFromLines(lines)
+}
+
+// ResolveProfileForSession scans each profile's ProjectsRoot for the session's
+// transcript file. Session UUIDs are globally unique, so at most one profile
+// should match; returns ok=false when none do (never guesses).
+func ResolveProfileForSession(sessionID string, roots map[string]string) (providerID string, ok bool) {
+	if sessionID == "" {
+		return "", false
+	}
+	for id, root := range roots {
+		if root == "" {
+			continue
+		}
+		if findSessionFileIn(root, sessionID) != "" {
+			return id, true
+		}
+	}
+	return "", false
 }

--- a/internal/providers/claude/transcript_test.go
+++ b/internal/providers/claude/transcript_test.go
@@ -5,6 +5,8 @@ package claude
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -74,5 +76,73 @@ func TestExtractLatestUsageFromLines_NoValid(t *testing.T) {
 	meta, _ := json.Marshal(map[string]any{"type": "ai-title"})
 	if got := ExtractLatestUsageFromLines([]string{string(meta), string(meta)}); got != nil {
 		t.Fatalf("got %+v", got)
+	}
+}
+
+func writeSessionFile(t *testing.T, root, projectDir, sessionID string) string {
+	t.Helper()
+	dir := filepath.Join(root, projectDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("line1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolveTranscriptPathForSessionIn_FindsInRoot(t *testing.T) {
+	root := t.TempDir()
+	want := writeSessionFile(t, root, "-home-user-proj", "sess-1")
+	got := ResolveTranscriptPathForSessionIn(root, "sess-1")
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestResolveTranscriptPathForSessionIn_MissingReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	if got := ResolveTranscriptPathForSessionIn(root, "no-such-session"); got != "" {
+		t.Fatalf("want empty, got %q", got)
+	}
+}
+
+func TestResolveTranscriptPathForSessionIn_EmptySessionID(t *testing.T) {
+	root := t.TempDir()
+	if got := ResolveTranscriptPathForSessionIn(root, ""); got != "" {
+		t.Fatalf("want empty, got %q", got)
+	}
+}
+
+func TestResolveProfileForSession_MatchesCorrectRoot(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeSessionFile(t, rootB, "-home-user-b", "sess-b")
+
+	id, ok := ResolveProfileForSession("sess-b", map[string]string{
+		"claude":   rootA,
+		"claude-m": rootB,
+	})
+	if !ok || id != "claude-m" {
+		t.Fatalf("ok=%v id=%q", ok, id)
+	}
+}
+
+func TestResolveProfileForSession_NoMatchRefuses(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	id, ok := ResolveProfileForSession("unknown-session", map[string]string{
+		"claude":   rootA,
+		"claude-m": rootB,
+	})
+	if ok {
+		t.Fatalf("expected no match, got id=%q", id)
+	}
+}
+
+func TestResolveProfileForSession_EmptySessionID(t *testing.T) {
+	if _, ok := ResolveProfileForSession("", map[string]string{"claude": t.TempDir()}); ok {
+		t.Fatal("empty session id must not match")
 	}
 }

--- a/internal/ratelimit/run.go
+++ b/internal/ratelimit/run.go
@@ -34,8 +34,15 @@ func ProcessWindow(
 	return ApplyNotifyResult(previous, decision.NewState, shown)
 }
 
-// RunRateLimitCheck parses stdin JSON and updates Claude notify state under lock.
+// RunRateLimitCheck parses stdin JSON and updates Claude notify state under lock
+// in the default (env/CLAUDE_CONFIG_DIR-derived) state dir.
 func RunRateLimitCheck(stdinJSON string, nowMs int64, notify ShowNotificationFn) {
+	RunRateLimitCheckIn("", stdinJSON, nowMs, notify)
+}
+
+// RunRateLimitCheckIn is RunRateLimitCheck scoped to an explicit per-profile
+// state dir, so two Claude accounts keep independent notify state.
+func RunRateLimitCheckIn(stateDir string, stdinJSON string, nowMs int64, notify ShowNotificationFn) {
 	rateLimits := ParseRateLimits(stdinJSON)
 	if rateLimits == nil {
 		return
@@ -43,7 +50,7 @@ func RunRateLimitCheck(stdinJSON string, nowMs int64, notify ShowNotificationFn)
 	if rateLimits.FiveHour == nil && rateLimits.SevenDay == nil {
 		return
 	}
-	WithLockedState(func(current ClaudeNotifyState) ClaudeNotifyState {
+	WithLockedStateIn(stateDir, func(current ClaudeNotifyState) ClaudeNotifyState {
 		return ClaudeNotifyState{
 			FiveHour: ProcessWindow(WindowFiveHour, rateLimits.FiveHour, current.FiveHour, nowMs, notify),
 			SevenDay: ProcessWindow(WindowSevenDay, rateLimits.SevenDay, current.SevenDay, nowMs, notify),

--- a/internal/ratelimit/statestore.go
+++ b/internal/ratelimit/statestore.go
@@ -17,6 +17,10 @@ const (
 	lockStale         = 10 * time.Second
 )
 
+// baseDir is the single-default notify-state dir. Per-profile isolation is
+// threaded explicitly via the *In variants (resolveDir); the default here stays
+// byte-identical to the historical location so it resolves the same regardless
+// of whether CLAUDE_CONFIG_DIR is visible (it is not on the read side).
 func baseDir() string {
 	if v := os.Getenv("USAGEBAR_STATE_DIR"); v != "" {
 		_ = os.MkdirAll(v, 0o755)
@@ -28,25 +32,38 @@ func baseDir() string {
 	return dir
 }
 
-func stateFilePath() string {
-	return filepath.Join(baseDir(), "rate-limit-state.json")
+// resolveDir returns an explicit per-profile state dir, or the env/default
+// baseDir() when empty. The multi-profile write path passes the resolved
+// profile's StateDir so two accounts never share notify state or lock.
+func resolveDir(dir string) string {
+	if dir == "" {
+		return baseDir()
+	}
+	_ = os.MkdirAll(dir, 0o755)
+	return dir
 }
 
-func lockFilePath() string {
-	return filepath.Join(baseDir(), "rate-limit-state.lock")
+func stateFilePathIn(dir string) string {
+	return filepath.Join(resolveDir(dir), "rate-limit-state.json")
 }
 
-func providerStateFilePath() string {
+func lockFilePathIn(dir string) string {
+	return filepath.Join(resolveDir(dir), "rate-limit-state.lock")
+}
+
+func providerStateFilePathIn(dir string) string {
 	if v := os.Getenv("USAGEBAR_PROVIDER_NOTIFY_PATH"); v != "" {
 		return v
 	}
-	return filepath.Join(baseDir(), "provider-limit-notify-state.json")
+	return filepath.Join(resolveDir(dir), "provider-limit-notify-state.json")
 }
 
-// AcquireLock returns true when the lock was acquired.
+func providerStateFilePath() string { return providerStateFilePathIn("") }
+
+// AcquireLockIn returns true when the lock in dir was acquired.
 // On timeout returns false without destroying another process's lock.
-func AcquireLock() bool {
-	path := lockFilePath()
+func AcquireLockIn(dir string) bool {
+	path := lockFilePathIn(dir)
 	deadline := time.Now().Add(lockTimeout)
 	for {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
@@ -68,10 +85,17 @@ func AcquireLock() bool {
 	}
 }
 
-// ReleaseLock removes the lock file.
-func ReleaseLock() {
-	_ = os.Remove(lockFilePath())
+// ReleaseLockIn removes the lock file in dir.
+func ReleaseLockIn(dir string) {
+	_ = os.Remove(lockFilePathIn(dir))
 }
+
+// AcquireLock returns true when the lock was acquired.
+// On timeout returns false without destroying another process's lock.
+func AcquireLock() bool { return AcquireLockIn("") }
+
+// ReleaseLock removes the lock file.
+func ReleaseLock() { ReleaseLockIn("") }
 
 // windowStateWire is the on-disk JSON shape for WindowState.
 type windowStateWire struct {
@@ -116,8 +140,8 @@ type ClaudeNotifyState struct {
 	SevenDay *WindowState `json:"sevenDay"`
 }
 
-func readClaudeState() ClaudeNotifyState {
-	raw, err := os.ReadFile(stateFilePath())
+func readClaudeStateIn(dir string) ClaudeNotifyState {
+	raw, err := os.ReadFile(stateFilePathIn(dir))
 	if err != nil {
 		return ClaudeNotifyState{}
 	}
@@ -134,12 +158,12 @@ func readClaudeState() ClaudeNotifyState {
 	}
 }
 
-func writeClaudeState(state ClaudeNotifyState) {
+func writeClaudeStateIn(dir string, state ClaudeNotifyState) {
 	wire := map[string]any{
 		"fiveHour": toWire(state.FiveHour),
 		"sevenDay": toWire(state.SevenDay),
 	}
-	path := stateFilePath()
+	path := stateFilePathIn(dir)
 	tmp := path + ".tmp"
 	b, err := json.Marshal(wire)
 	if err != nil {
@@ -153,16 +177,21 @@ func writeClaudeState(state ClaudeNotifyState) {
 
 // WithLockedState runs read→update→write under lock for Claude statusLine state.
 func WithLockedState(update func(current ClaudeNotifyState) ClaudeNotifyState) ClaudeNotifyState {
-	locked := AcquireLock()
+	return WithLockedStateIn("", update)
+}
+
+// WithLockedStateIn is WithLockedState scoped to an explicit state dir.
+func WithLockedStateIn(dir string, update func(current ClaudeNotifyState) ClaudeNotifyState) ClaudeNotifyState {
+	locked := AcquireLockIn(dir)
 	defer func() {
 		if locked {
-			ReleaseLock()
+			ReleaseLockIn(dir)
 		}
 	}()
-	current := readClaudeState()
+	current := readClaudeStateIn(dir)
 	next := update(current)
 	if locked {
-		writeClaudeState(next)
+		writeClaudeStateIn(dir, next)
 	}
 	return next
 }

--- a/internal/setup/pluginconfig.go
+++ b/internal/setup/pluginconfig.go
@@ -1,15 +1,21 @@
 /**
  * Seeds and loads the plugin-specific config (HERDR_PLUGIN_CONFIG_DIR).
  * Lives in a separate space from the main Herdr config.toml.
+ *
+ * Parsing uses a real TOML decoder (BurntSushi) so array-of-tables
+ * ([[claude.profiles]]) is handled correctly; the seed body is still authored as
+ * a string for readable inline comments.
  */
 package setup
 
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 )
 
 // DefaultRemainingThresholds are the toast remaining-% buckets.
@@ -20,12 +26,33 @@ type PluginConfig struct {
 	RemainingThresholds []int
 	// NotifyEnabled is the plugin-side intent (separate from host toast delivery).
 	NotifyEnabled bool
+	// ClaudeProfiles are the configured [[claude.profiles]] entries (unresolved).
+	// Empty means the single implicit "claude" profile is synthesized downstream.
+	ClaudeProfiles []claude.ProfileSpec
 }
 
 // DefaultPluginConfig is the seed default.
 var DefaultPluginConfig = PluginConfig{
 	RemainingThresholds: append([]int(nil), DefaultRemainingThresholds...),
 	NotifyEnabled:       true,
+}
+
+// pluginConfigWire mirrors the on-disk TOML shape for decoding.
+type pluginConfigWire struct {
+	Notify struct {
+		Enabled             *bool `toml:"enabled"`
+		RemainingThresholds []int `toml:"remaining_thresholds"`
+	} `toml:"notify"`
+	Claude struct {
+		Profiles []profileWire `toml:"profiles"`
+	} `toml:"claude"`
+}
+
+type profileWire struct {
+	ID             string `toml:"id"`
+	Label          string `toml:"label"`
+	ConfigDir      string `toml:"config_dir"`
+	ClaudeJSONPath string `toml:"claude_json_path"`
 }
 
 // ResolvePluginConfigDir resolves the config directory.
@@ -69,50 +96,66 @@ func DefaultPluginConfigTOML(config PluginConfig) string {
 		"# remaining % thresholds that may fire a toast (once per window/bucket)",
 		"remaining_thresholds = [" + thresholds + "]",
 		"",
+		"# Multi-account Claude: uncomment and add one block per CLAUDE_CONFIG_DIR.",
+		"# Absence of any profile keeps the single default account (fully backward",
+		"# compatible). config_dir must be unique per profile.",
+		"#",
+		"# [[claude.profiles]]",
+		"# id = \"claude\"",
+		"# label = \"Claude\"",
+		"# config_dir = \"/home/you/.claude\"",
+		"# claude_json_path = \"/home/you/.claude.json\"",
+		"#",
+		"# [[claude.profiles]]",
+		"# id = \"claude-secondary\"",
+		"# label = \"Claude (secondary)\"",
+		"# config_dir = \"/home/you/.claude-secondary\"",
+		"",
 	}, "\n")
 }
 
-var (
-	enabledRe = regexp.MustCompile(`(?i)^enabled\s*=\s*(true|false)\s*$`)
-	thrRe     = regexp.MustCompile(`(?i)^remaining_thresholds\s*=\s*\[([^\]]*)\]\s*$`)
-)
-
-// ParsePluginConfigTOML is a minimal TOML parser for this plugin's seed format.
-func ParsePluginConfigTOML(raw string) PluginConfig {
-	notifyEnabled := DefaultPluginConfig.NotifyEnabled
-	remaining := append([]int(nil), DefaultPluginConfig.RemainingThresholds...)
-
-	for _, line := range strings.Split(raw, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "[") {
-			continue
-		}
-		if m := enabledRe.FindStringSubmatch(trimmed); m != nil {
-			notifyEnabled = strings.EqualFold(m[1], "true")
-			continue
-		}
-		if m := thrRe.FindStringSubmatch(trimmed); m != nil {
-			parts := strings.Split(m[1], ",")
-			var nums []int
-			ok := true
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				if p == "" {
-					continue
-				}
-				n, err := strconv.Atoi(p)
-				if err != nil || n <= 0 || n > 100 {
-					ok = false
-					break
-				}
-				nums = append(nums, n)
-			}
-			if ok && len(nums) > 0 {
-				remaining = nums
-			}
-		}
+// validThresholds keeps the historical rule: every value must be 1..100, else
+// the whole set is rejected in favor of the default.
+func validThresholds(in []int) ([]int, bool) {
+	if len(in) == 0 {
+		return nil, false
 	}
-	return PluginConfig{NotifyEnabled: notifyEnabled, RemainingThresholds: remaining}
+	out := make([]int, 0, len(in))
+	for _, n := range in {
+		if n <= 0 || n > 100 {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
+}
+
+// ParsePluginConfigTOML decodes the plugin config, falling back to defaults for
+// missing/invalid fields (malformed TOML yields all defaults).
+func ParsePluginConfigTOML(raw string) PluginConfig {
+	cfg := PluginConfig{
+		NotifyEnabled:       DefaultPluginConfig.NotifyEnabled,
+		RemainingThresholds: append([]int(nil), DefaultPluginConfig.RemainingThresholds...),
+	}
+	var wire pluginConfigWire
+	if _, err := toml.Decode(raw, &wire); err != nil {
+		return cfg
+	}
+	if wire.Notify.Enabled != nil {
+		cfg.NotifyEnabled = *wire.Notify.Enabled
+	}
+	if thr, ok := validThresholds(wire.Notify.RemainingThresholds); ok {
+		cfg.RemainingThresholds = thr
+	}
+	for _, p := range wire.Claude.Profiles {
+		cfg.ClaudeProfiles = append(cfg.ClaudeProfiles, claude.ProfileSpec{
+			ID:        p.ID,
+			Label:     p.Label,
+			ConfigDir: p.ConfigDir,
+			JSONPath:  p.ClaudeJSONPath,
+		})
+	}
+	return cfg
 }
 
 // SeedPluginConfigIfMissing writes default config.toml when missing; returns true if created.
@@ -124,6 +167,16 @@ func SeedPluginConfigIfMissing(configDir string) bool {
 	}
 	_ = os.WriteFile(path, []byte(DefaultPluginConfigTOML(DefaultPluginConfig)), 0o644)
 	return true
+}
+
+// ResolveClaudeProfiles loads the plugin config and resolves its
+// [[claude.profiles]] into concrete profiles (synthesizing the single implicit
+// default when none are configured). Shared by the write side (statusLine
+// routing) and the read side (panel/sidebar/notify).
+func ResolveClaudeProfiles(env map[string]string) []claude.ClaudeProfile {
+	cfg := LoadPluginConfig(ResolvePluginConfigDir(env))
+	home, _ := os.UserHomeDir()
+	return claude.ResolveProfiles(cfg.ClaudeProfiles, env, home)
 }
 
 // LoadPluginConfig loads config.toml or returns defaults.

--- a/internal/setup/pluginconfig_test.go
+++ b/internal/setup/pluginconfig_test.go
@@ -34,6 +34,43 @@ remaining_thresholds = [30, 10]
 	}
 }
 
+func TestParsePluginConfigTOML_ClaudeProfiles(t *testing.T) {
+	cfg := ParsePluginConfigTOML(`
+[[claude.profiles]]
+id = "claude"
+label = "Claude"
+config_dir = "/home/u/.claude"
+claude_json_path = "/home/u/.claude.json"
+
+[[claude.profiles]]
+id = "claude-secondary"
+label = "Claude (secondary)"
+config_dir = "/home/u/.claude-m"
+`)
+	if len(cfg.ClaudeProfiles) != 2 {
+		t.Fatalf("want 2 profiles, got %d", len(cfg.ClaudeProfiles))
+	}
+	p0 := cfg.ClaudeProfiles[0]
+	if p0.ID != "claude" || p0.ConfigDir != "/home/u/.claude" || p0.JSONPath != "/home/u/.claude.json" {
+		t.Fatalf("p0 = %+v", p0)
+	}
+	p1 := cfg.ClaudeProfiles[1]
+	if p1.ID != "claude-secondary" || p1.Label != "Claude (secondary)" || p1.ConfigDir != "/home/u/.claude-m" {
+		t.Fatalf("p1 = %+v", p1)
+	}
+	// notify defaults still apply when [notify] is absent.
+	if !cfg.NotifyEnabled {
+		t.Fatal("expected notify default enabled")
+	}
+}
+
+func TestParsePluginConfigTOML_NoProfilesByDefault(t *testing.T) {
+	cfg := ParsePluginConfigTOML(DefaultPluginConfigTOML(DefaultPluginConfig))
+	if len(cfg.ClaudeProfiles) != 0 {
+		t.Fatalf("seed must not define active profiles, got %+v", cfg.ClaudeProfiles)
+	}
+}
+
 func TestSeedPluginConfigIfMissing(t *testing.T) {
 	dir := t.TempDir()
 	if !SeedPluginConfigIfMissing(dir) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -31,6 +31,43 @@ func isSettledStatus(status string) bool {
 	return status != "working"
 }
 
+// resolveSidebarAccountLabel picks the text that identifies profile in the
+// sidebar's $limit slot once it has been displaced by the account row: the
+// real login email when readable, otherwise the profile's own label (which
+// defaults to its id, never empty).
+func resolveSidebarAccountLabel(profile claude.ClaudeProfile) string {
+	if email, ok := limits.AccountEmailFromJSONPath(profile.JSONPath); ok {
+		return email
+	}
+	return profile.Label
+}
+
+// reserveColumnsFor shrinks a MaxColumns budget to leave room for a fixed
+// "<prefix> · " segment that combineLimitAndContext will join onto the
+// context text, so FormatUsageStatus's own truncation still accounts for it.
+func reserveColumnsFor(maxColumns *int, prefix string) *int {
+	if maxColumns == nil || prefix == "" {
+		return maxColumns
+	}
+	reserved := core.DisplayWidth(prefix) + 3 // " · "
+	adjusted := max(*maxColumns-reserved, 3)
+	return &adjusted
+}
+
+// combineLimitAndContext joins the account's limit text with its context
+// status ("5h 88% · ⛁ 14% (136k)") for the sidebar's $context row, once a
+// multi-profile Claude pane has moved account identity into $limit's row and
+// this is the only row left to carry the limit percentage.
+func combineLimitAndContext(limitText, statusText string) string {
+	if limitText == "" {
+		return statusText
+	}
+	if statusText == "" {
+		return limitText
+	}
+	return limitText + " · " + statusText
+}
+
 // formatSidebarProvider renders the sidebar's agent line: the backend name on
 // a pay-as-you-go pane ("deepseek"), the harness name otherwise ("opencode").
 //
@@ -152,7 +189,24 @@ func RunUpdate(force bool) {
 			limitText = limits.FormatSidebarLimit(providerLimits[0], nowMs)
 		}
 	}
-	writeMetadataToken(paneID, "limit", limitText, force)
+
+	// With 2+ configured Claude accounts, the $limit row's job shifts from
+	// "show the limit" to "show which account this pane is" (joined with
+	// $provider as "claude · you@example.com") since that's otherwise
+	// invisible in the sidebar. The limit percentage moves down into
+	// $context instead, as this pane's own account is already unambiguous.
+	multiProfile := *pane.Agent == "claude" && len(claudeProfiles) > 1
+	accountText := ""
+	limitToken := limitText
+	if multiProfile {
+		if profile, ok := findClaudeProfile(claudeProfiles, providerID); ok {
+			accountText = resolveSidebarAccountLabel(profile)
+		}
+		if accountText != "" {
+			limitToken = accountText
+		}
+	}
+	writeMetadataToken(paneID, "limit", limitToken, force)
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
@@ -176,14 +230,20 @@ func RunUpdate(force bool) {
 		})
 	}
 
+	contextPrefix := ""
+	if accountText != "" {
+		contextPrefix = limitText
+	}
+
 	if usage == nil {
-		writeMetadataToken(paneID, "context", "", force)
+		writeMetadataToken(paneID, "context", contextPrefix, force)
 		return
 	}
 
 	liveWidth := herdrcli.GetSidebarWidthColumns(paneID)
 	sidebarW := core.ResolveSidebarWidth(liveWidth, core.ResolveConfigSidebarWidth())
 	maxCols := core.EstimateStatusMaxColumns(&sidebarW, pane.RowLabel)
+	maxCols = reserveColumnsFor(maxCols, contextPrefix)
 	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{MaxColumns: maxCols})
-	writeMetadataToken(paneID, "context", statusText, force)
+	writeMetadataToken(paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -8,12 +8,24 @@ import (
 	"os"
 	"time"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers"
+	claudeprovider "github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 )
+
+// findClaudeProfile looks up one resolved profile by provider id.
+func findClaudeProfile(profiles []claude.ClaudeProfile, id string) (claude.ClaudeProfile, bool) {
+	for _, p := range profiles {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return claude.ClaudeProfile{}, false
+}
 
 func isSettledStatus(status string) bool {
 	return status != "working"
@@ -100,10 +112,6 @@ func RunUpdate(force bool) {
 	if cwd == nil {
 		cwd = pane.Cwd
 	}
-	usage := p.ResolveUsage(provider.UsageResolveInput{
-		Session: pane.AgentSession,
-		Cwd:     cwd,
-	})
 	nowMs := time.Now().UnixMilli()
 	limitText := ""
 	// Subscription limits only apply when the pane's session is billed against
@@ -115,14 +123,30 @@ func RunUpdate(force bool) {
 		sid = &pane.AgentSession.Value
 	}
 	snapshot := limits.OpenPaneSnapshot{PaneID: paneID, Agent: *pane.Agent, SessionID: sid, Cwd: cwd}
-	if limits.PaneBillingMode(p.AgentID(), snapshot, limits.DefaultBillingDeps()) == limits.BillingPayAsYouGo {
-		totalTokens, totalCostUSD := limits.PaneTotalUsage(p.AgentID(), snapshot, nowMs)
+
+	// Resolve which specific provider this pane belongs to. For claude this is
+	// profile-aware (session-transcript match across configured accounts);
+	// other agents resolve 1:1 with p.AgentID() as before. ok=false only
+	// happens for an ambiguous multi-profile claude pane.
+	claudeProfiles := limits.ResolvedClaudeProfiles()
+	providerID, resolved := limits.BuildClaudePaneProviderResolver(claudeProfiles)(snapshot)
+	if !resolved {
+		// Cannot tell which account this pane belongs to: clear rather than
+		// guess into the wrong account's limits/tokens.
+		writeMetadataToken(paneID, "limit", "", force)
+		writeMetadataToken(paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+		writeMetadataToken(paneID, "context", "", force)
+		return
+	}
+
+	if limits.PaneBillingMode(providerID, snapshot, limits.DefaultBillingDeps()) == limits.BillingPayAsYouGo {
+		totalTokens, totalCostUSD := limits.PaneTotalUsage(providerID, snapshot, nowMs)
 		limitText = limits.FormatSidebarBurn(totalTokens, totalCostUSD)
 	} else {
 		collectOptions := limits.DefaultCollectOptions()
 		// Sidebar refresh deliberately collects only this pane's provider and leaves
 		// Attach nil, avoiding the heavier cross-pane activity aggregation path.
-		collectOptions.Only = map[string]bool{p.AgentID(): true}
+		collectOptions.Only = map[string]bool{providerID: true}
 		providerLimits := limits.CollectAllProviderLimits(cwd, nowMs, collectOptions)
 		if len(providerLimits) > 0 {
 			limitText = limits.FormatSidebarLimit(providerLimits[0], nowMs)
@@ -133,6 +157,24 @@ func RunUpdate(force bool) {
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
 	writeMetadataToken(paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+
+	// Context tokens: claude is read from its resolved profile's own transcript
+	// root (bypassing the registry's default-root lookup) so a non-default
+	// account's context display doesn't fall back to ~/.claude/projects.
+	var usage *core.ContextUsage
+	if *pane.Agent == "claude" {
+		if profile, ok := findClaudeProfile(claudeProfiles, providerID); ok && sid != nil {
+			if transcript := claudeprovider.ResolveUsageForSessionIn(profile.ProjectsRoot, *sid); transcript != nil {
+				u := claudeprovider.ToContextUsage(*transcript)
+				usage = &u
+			}
+		}
+	} else {
+		usage = p.ResolveUsage(provider.UsageResolveInput{
+			Session: pane.AgentSession,
+			Cwd:     cwd,
+		})
+	}
 
 	if usage == nil {
 		writeMetadataToken(paneID, "context", "", force)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -4,8 +4,10 @@
 package update
 
 import (
+	"os"
 	"testing"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 )
 
@@ -100,5 +102,63 @@ func TestFormatSidebarProviderWith_EmptyAgentRendersNothing(t *testing.T) {
 	}
 	if got := formatSidebarProviderWith(backendFor, "", "opencode", limits.OpenPaneSnapshot{}); got != "" {
 		t.Fatalf("got %q want empty", got)
+	}
+}
+
+func TestResolveSidebarAccountLabel_PrefersEmailOverLabel(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := dir + "/.claude.json"
+	if err := os.WriteFile(jsonPath, []byte(`{"oauthAccount":{"emailAddress":"you@example.com"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	profile := claude.ClaudeProfile{ID: "claude", Label: "My Work Account", JSONPath: jsonPath}
+	if got := resolveSidebarAccountLabel(profile); got != "you@example.com" {
+		t.Fatalf("got %q want email", got)
+	}
+}
+
+func TestResolveSidebarAccountLabel_FallsBackToLabelWithoutEmail(t *testing.T) {
+	profile := claude.ClaudeProfile{ID: "claude-secondary", Label: "claude-secondary", JSONPath: t.TempDir() + "/missing.json"}
+	if got := resolveSidebarAccountLabel(profile); got != "claude-secondary" {
+		t.Fatalf("got %q want label fallback", got)
+	}
+}
+
+func TestCombineLimitAndContext(t *testing.T) {
+	cases := []struct{ limitText, statusText, want string }{
+		{"5h 88%", "⛁ 14% (136k)", "5h 88% · ⛁ 14% (136k)"},
+		{"", "⛁ 14% (136k)", "⛁ 14% (136k)"},
+		{"5h 88%", "", "5h 88%"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		if got := combineLimitAndContext(c.limitText, c.statusText); got != c.want {
+			t.Fatalf("combineLimitAndContext(%q, %q) = %q, want %q", c.limitText, c.statusText, got, c.want)
+		}
+	}
+}
+
+func TestReserveColumnsFor(t *testing.T) {
+	base := 20
+	got := reserveColumnsFor(&base, "you@example.com")
+	if got == nil {
+		t.Fatal("want non-nil budget")
+	}
+	// 20 - (15 for the email + 3 for " · ") = 2, floored to 3.
+	if *got != 3 {
+		t.Fatalf("got %d want 3 (floored)", *got)
+	}
+
+	wide := 60
+	got = reserveColumnsFor(&wide, "you@example.com")
+	if *got != 60-len("you@example.com")-3 {
+		t.Fatalf("got %d want %d", *got, 60-len("you@example.com")-3)
+	}
+
+	if got := reserveColumnsFor(nil, "you@example.com"); got != nil {
+		t.Fatal("nil budget must stay nil")
+	}
+	if got := reserveColumnsFor(&wide, ""); *got != wide {
+		t.Fatal("empty prefix must not shrink the budget")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `[[claude.profiles]]` config, per-profile statusLine write-side isolation, and session-transcript-based pane→profile resolution so multiple Claude accounts (each with their own `CLAUDE_CONFIG_DIR`) are tracked independently instead of colliding under one shared `claude` id.
- Nests 2+ configured accounts under one shared `Claude` heading in the panel and sidebar instead of showing them as unrelated rows, labeled by each account's real login email.
- Backward compatible: no `[[claude.profiles]]` configured synthesizes the single existing default profile with unchanged behavior.

Closes #10.


<img width="404" height="163" alt="スクリーンショット 2026-07-22 20 35 57" src="https://github.com/user-attachments/assets/7b685ee0-795a-4074-9327-08e308e7b1e3" />
<img width="245" height="58" alt="スクリーンショット 2026-07-22 20 36 27" src="https://github.com/user-attachments/assets/5058a2b1-8490-444d-9e6f-c211180099b8" />



## Commits
- Phase 1: Claude multi-profile config + statusLine write-side isolation
- Phase 2: read-side profile resolution (panel/sidebar/notify/activity attribution)
- Phase 3: nest multi-profile accounts under one panel/sidebar heading; fixes `EnrichRunOut` dropping the new grouping fields

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manually verified against the compiled plugin binary with two configured mock profiles: panel nests both accounts under one `Claude` heading; sidebar shows `claude · <email>` / `<limit> · <context>` for a pane resolved to the non-default profile
- [x] Confirmed single-profile (no `[[claude.profiles]]`) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFAiEi1xQXFgHfuQmFLgzr