### PR TITLE
chore: Bump plugin version to 0.3.1

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.3.0"
+version = "0.3.1"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, and Grok"


### PR DESCRIPTION
Bumps `herdr-plugin.toml` to 0.3.1 for the release that ships Claude multi-profile (multi-account) support (#15).

The Go binary version comes from the release tag via ldflags; this manifest bump is the runtime source-of-truth the update checker reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)