### PR TITLE
chore: Bump plugin version to 0.4.0

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.3.1"
+version = "0.4.0"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
Release **OMP and Pi coding agent support** (#14).

Closes #12.

- Bumps `herdr-plugin.toml` version `0.3.1` → `0.4.0`.
- The `v0.4.0` tag is already pushed; the release workflow builds the prebuilt `usagebar` binaries and creates the GitHub Release from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFAiEi1xQXFgHfuQmFLgzr