### PR TITLE
refactor: Make billing providers first-class across harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Monitor context usage and provider rate limits for agents running in [Herdr](htt
 - **Provider limit row** — a separate sidebar row shows the shortest account-limit window (`5h 72%`) without crowding the context meter.
 - **Account rate-limit windows at a glance** — one live pane shows how much 5h / 7d / 30d allowance is left for Claude, Codex, OpenCode Go, and Grok, with reset countdowns and which open pane is burning it.
 - **Low-allowance warnings** — optional toasts fire when a window drops below your thresholds (default 50 / 20 / 10 / 5 % left), before you hit the wall mid-task.
-- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across supported harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`), and OMP / Pi assistant `message.provider`. The sidebar totals what that pane spent (e.g. `Σ 425k $0.04`); on most pay-as-you-go panes `$provider` names the backend (`deepseek`), while OMP / Pi keep the harness name, and the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode, OMP, and Pi today); otherwise the block is token-only.
+- **Pay-as-you-go API backends** — when a pane runs a direct API key instead of a subscription, there's no plan quota to show. Works with **any** provider a harness can reach (DeepSeek, OpenAI, Together, OpenRouter, Ollama, Bedrock, Vertex, a custom gateway, …), not just the one the screenshot happens to show. Detected across supported harnesses from what each records locally: OpenCode's per-message `providerID`, Codex's `model_provider`, Claude's deployment env (Bedrock / Vertex / Foundry / gateway), Grok custom models (`~/.grok/config.toml` `[model.*]` `base_url`), and OMP / Pi assistant `message.provider`. The sidebar shows the pane's current backend and what that backend spent in the session (e.g. `deepseek · Σ 425k $0.04`); the Agent Usage pane adds a per-backend block with rolling 24h / 7d / 30d totals for that provider, a per-model breakdown, and which open pane is spending it. Dollar cost is shown when the harness records it (OpenCode, OMP, and Pi today); otherwise the block is token-only.
 
 ## Requirements
 
@@ -107,8 +107,8 @@ herdr plugin action invoke usagebar.setup
 | --- | --- |
 | **Sidebar `$context` row** | Per-pane context usage: `⛁ 13% (130k)` when the window size is known, or the token count alone |
 | **Sidebar `$limit` row** | Shortest provider limit window (`5h 72%` remaining), or — on a pay-as-you-go pane — what that pane spent on its backend (`Σ 425k $0.04`, scoped to the pane's session and backend) |
-| **Sidebar `$provider` row** | Harness name (`opencode`), or the backend it's actually billing on a pay-as-you-go pane (`deepseek`). OMP / Pi keep the harness name — their backends are in-pane model routing, and the burn total spans the whole session |
-| **Agent Usage pane** | Subscription providers: plan, usage windows (5h / 7d / 30d), remaining % bars, reset countdown, open-pane token share. Pay-as-you-go backends: the provider's rolling 24h / 7d / 30d totals (all sessions, not just this pane), per-model breakdown, and open-pane spend share |
+| **Sidebar `$provider` row** | Subscription provider (`opencode-go`, `grok`, `claude`, …) on a subscription pane, or the backend actually billed on a pay-as-you-go pane (`deepseek`). The adjacent burn total is scoped to that same backend in the pane's session |
+| **Agent Usage pane** | One block per billing provider, independent of harness. Subscription providers show plan windows and cross-harness pane activity. Pay-as-you-go backends show one merged 24h / 7d / 30d block, model breakdown, and pane share even when multiple harnesses use the same backend |
 | **Toasts** (optional) | Remaining-limit warnings at configured thresholds (default 50 / 20 / 10 / 5 % left) |
 
 ### Supported agents
@@ -117,10 +117,10 @@ herdr plugin action invoke usagebar.setup
 | --- | --- | --- | --- |
 | Claude Code | Yes | Yes | Subscription windows from `~/.claude.json` / statusLine cache. Pay-as-you-go (API key, Bedrock, Vertex, Foundry, gateway) hides those windows and labels the backend from deployment env / settings |
 | Codex | Yes | Yes | Context + rate windows from local rollouts; custom `model_provider` panes are pay-as-you-go |
-| OpenCode Go | Yes | Yes | Prefer official web usage when `OPENCODE_GO_COOKIE` is set; else local SQLite. Non-`opencode-go` backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
+| OpenCode | Yes | Yes | The `opencode-go` subscription uses official web usage when `OPENCODE_GO_COOKIE` is set, else local SQLite. Other backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
 | Grok | Yes | Yes | Context from `signals.json`; SuperGrok credits when auth is present. Custom models (`~/.grok/config.toml` `[model.*]` with `base_url`) are pay-as-you-go and labelled from the endpoint host (openai, ollama, …) |
-| OMP (Oh My Pi) | Yes | Yes | Session jsonl under `~/.omp/agent/sessions/`; always pay-as-you-go. Sidebar keeps harness name on `$provider` and shows session burn on `$limit`; Agent Usage pane groups API blocks by `message.provider` and shows USD when recorded |
-| Pi coding agent | Yes | Yes | Session jsonl under `~/.pi/agent/sessions/`; same pay-as-you-go path as OMP (shared extractors), including harness-name `$provider` |
+| OMP (Oh My Pi) | Yes | Yes | Session jsonl plus its credential metadata. Subscription routes: OpenCode Go, Grok OAuth, Anthropic OAuth → Claude, and OpenAI Codex OAuth → Codex. API-key backends show backend-scoped session burn |
+| Pi coding agent | Yes | Yes | Session jsonl plus `~/.pi/agent/auth.json`; uses the same recognized OAuth/subscription routes and pay-as-you-go rules as OMP |
 
 Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 
@@ -151,13 +151,14 @@ rows = [
 ]
 ```
 
-`$provider` replaces Herdr's built-in `agent` token: it renders the harness
-name (`opencode`) normally, and the backend name (`deepseek`) on a
-pay-as-you-go pane instead — Herdr joins row tokens with `·` and has no
-separator setting, so the two can't be shown side by side without crowding
-the row. This makes the standard display `tab · pane`, `provider · limit`,
-then context. Run `herdr server reload-config` after editing. The limit
-disappears automatically when the matching provider has no limit data.
+`$provider` replaces Herdr's built-in `agent` token: it renders the quota
+provider (`opencode-go`, `grok`, `claude`, …) on a subscription pane, and the
+backend (`deepseek`) on a pay-as-you-go pane. Herdr joins row tokens with `·`
+and has no separator setting, so the harness and billing identity are not
+shown side by side. This makes the standard display `tab · pane`,
+`provider · limit`, then context. Run `herdr server reload-config` after
+editing. The limit disappears automatically when the matching provider has no
+limit data.
 
 ### Plugin config
 
@@ -245,15 +246,47 @@ Everything is computed from files that the agents already keep on your machine:
 | --- | --- |
 | Claude Code | `~/.claude.json`, statusLine cache under `~/.claude/herdr-usagebar/`, `settings.json` (deployment env) |
 | Codex | rollout files under `~/.codex/sessions/` |
-| OpenCode Go | `~/.local/share/opencode/opencode.db` |
+| OpenCode | `~/.local/share/opencode/opencode.db` (session usage), `~/.local/share/opencode/auth.json` (credential kind only) |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch), `~/.grok/config.toml` (custom-model base URLs) |
-| OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup) |
-| Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present |
+| OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup), `~/.omp/agent/agent.db` (credential kind only) |
+| Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present, `~/.pi/agent/auth.json` (credential kind only) |
 
 Pay-as-you-go detection is not tied to any one harness: it reads the same
 per-harness files above (the backend a session used is already recorded there —
 OpenCode's `providerID`, Codex's `model_provider`, Claude's deployment env,
 Grok's `config.toml`, OMP/Pi `message.provider`). No extra data sources, no network calls.
+
+### Harness and billing identity
+
+The agent running in a pane and the account paying for a turn are separate.
+The plugin resolves a session's backend **and authentication kind**, then uses
+the matching quota collector. Today the supported subscription routes are:
+
+| Harness | Session provider + auth | Limit account shown |
+| --- | --- | --- |
+| Claude Code | Claude login | Claude |
+| Codex | ChatGPT login | Codex |
+| OpenCode | `opencode-go` | OpenCode Go |
+| OpenCode | OpenAI / Codex OAuth | Codex |
+| Grok | Grok OAuth | Grok |
+| OMP / Pi | `opencode-go` | OpenCode Go |
+| OMP / Pi | `xai-oauth` | Grok |
+| OMP / Pi | `anthropic` + OAuth | Claude |
+| OMP / Pi | `openai` / `openai-codex` + OAuth | Codex |
+
+The same provider id with an API key is pay-as-you-go, so it is never routed
+to a subscription limit by name alone. A subscription whose collector is not
+implemented (for example Copilot) is intentionally not presented as API
+spend; add its collector and an explicit route first. OpenCode's official
+documentation does not support routing Claude Pro/Max through OpenCode, so it
+is not a supported Claude subscription route here.
+
+The Usage pane keys both subscription and API blocks by billing provider, not
+by harness. For example, OpenCode and OMP using OpenCode Go produce one
+`OpenCode · Go` block; OpenCode and OMP using the same DeepSeek API produce one
+merged `DeepSeek · API` block. Harness-specific code is limited to reading its
+session and credential formats before emitting the common provider identity
+and usage observations.
 
 Network requests happen in the following cases:
 

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -198,10 +198,7 @@ func openPaneSnapshots() ([]limits.OpenPaneSnapshot, bool) {
 		if p.AgentSession != nil {
 			sid = &p.AgentSession.Value
 		}
-		cwd := p.ForegroundCwd
-		if cwd == nil {
-			cwd = p.Cwd
-		}
+		cwd := herdrcli.PaneSessionCwd(p.PaneInfo)
 		snaps = append(snaps, limits.OpenPaneSnapshot{
 			PaneID: p.PaneID, Agent: agent, Label: label,
 			SessionID: sid, Cwd: cwd,

--- a/docs/LLM-SETUP.md
+++ b/docs/LLM-SETUP.md
@@ -243,8 +243,11 @@ herdr plugin action invoke usagebar.open-limits
 ```
 
 After an agent turn completes on a supported pane (Claude / Codex / OpenCode /
-Grok), verify with `herdr pane get <pane-id>` that both `tokens.context` and
-`tokens.limit` are present. The sidebar should render limit above context.
+Grok / OMP / Pi), verify with `herdr pane get <pane-id>` that both
+`tokens.context` and `tokens.limit` are present. The sidebar should render
+limit above context. On OMP/Pi, `$provider` is the resolved subscription
+provider (`opencode-go`, `grok`, `claude`, or `codex`), or the current API
+backend.
 
 ### 9. Report back
 

--- a/internal/herdrcli/herdr.go
+++ b/internal/herdrcli/herdr.go
@@ -70,6 +70,20 @@ type OpenAgentPane struct {
 	PaneInfo
 }
 
+// PaneSessionCwd chooses the project directory used to resolve local session
+// files. OMP/Pi can leave a language server in the foreground with a cwd
+// inside a virtualenv; without an explicit agent session their pane cwd is
+// the stable project identity. Other harnesses retain foreground-cwd priority.
+func PaneSessionCwd(pane PaneInfo) *string {
+	if pane.Agent != nil && (*pane.Agent == "omp" || *pane.Agent == "pi") && pane.AgentSession == nil && pane.Cwd != nil {
+		return pane.Cwd
+	}
+	if pane.ForegroundCwd != nil {
+		return pane.ForegroundCwd
+	}
+	return pane.Cwd
+}
+
 func firstNonEmpty(values ...string) *string {
 	for _, v := range values {
 		if v != "" {

--- a/internal/limits/activeproviders.go
+++ b/internal/limits/activeproviders.go
@@ -6,6 +6,8 @@ package limits
 
 import "strings"
 
+import "github.com/senna-lang/herdr-agent-usage/internal/claude"
+
 // ActiveProviderFilter builds the CollectOptions.Only filter from a pane
 // query result. When the query failed (paneQueryOK=false) it returns nil —
 // fail-open to all providers rather than blanking the panel on a transient
@@ -25,6 +27,14 @@ func ActiveProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool) map[st
 // not just the one that pane happens to belong to — so the panel can show all
 // configured accounts side by side for comparison, per the issue's request.
 func ActiveProviderSet(openPanes []OpenPaneSnapshot) map[string]bool {
+	profiles := ResolvedClaudeProfiles()
+	return activeProviderSetWith(profiles, openPanes, func(pane OpenPaneSnapshot) (string, bool) {
+		providerID, _, ok := resolveBilledPane(profiles, pane)
+		return providerID, ok
+	})
+}
+
+func activeProviderSetWith(profiles []claude.ClaudeProfile, openPanes []OpenPaneSnapshot, resolve func(OpenPaneSnapshot) (string, bool)) map[string]bool {
 	set := make(map[string]bool)
 	hasClaudePane := false
 	for _, pane := range openPanes {
@@ -33,12 +43,21 @@ func ActiveProviderSet(openPanes []OpenPaneSnapshot) map[string]bool {
 			hasClaudePane = true
 			continue
 		}
-		if providerID, ok := agentToProvider[agent]; ok {
-			set[providerID] = true
+		if providerID, ok := resolve(pane); ok {
+			if providerID == "claude" {
+				hasClaudePane = true
+				continue
+			}
+			for _, supportedID := range nonClaudeProviderIDs {
+				if providerID == supportedID {
+					set[providerID] = true
+					break
+				}
+			}
 		}
 	}
 	if hasClaudePane {
-		for _, p := range ResolvedClaudeProfiles() {
+		for _, p := range profiles {
 			set[p.ID] = true
 		}
 	}

--- a/internal/limits/activeproviders_test.go
+++ b/internal/limits/activeproviders_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
 )
 
 // isolatePluginConfig points HERDR_PLUGIN_CONFIG_DIR at an empty temp dir so
@@ -110,5 +112,24 @@ config_dir = "` + t.TempDir() + `"
 	got := ActiveProviderSet(panes)
 	if len(got) != 2 || !got["claude"] || !got["claude-secondary"] {
 		t.Fatalf("got %v, want {claude, claude-secondary}", got)
+	}
+}
+
+func TestActiveAndBillingFilters_RoutedOMPClaudeSurvivesIntersection(t *testing.T) {
+	profiles := []claude.ClaudeProfile{{ID: "claude"}}
+	panes := []OpenPaneSnapshot{{PaneID: "omp-claude", Agent: "omp"}}
+	active := activeProviderSetWith(profiles, panes, func(OpenPaneSnapshot) (string, bool) {
+		return "claude", true
+	})
+	billing := BillingProviderFilter(panes, true, BillingDeps{
+		ClaudeProfileIDs: []string{"claude"},
+		ResolvePane: func(OpenPaneSnapshot) (string, string, bool) {
+			return "claude", "omp", true
+		},
+		PaneMode: func(string, OpenPaneSnapshot) BillingMode { return BillingSubscription },
+	})
+	got := IntersectFilters(active, billing)
+	if !got["claude"] || len(got) != 1 {
+		t.Fatalf("active=%#v billing=%#v intersection=%#v", active, billing, got)
 	}
 }

--- a/internal/limits/apiusage.go
+++ b/internal/limits/apiusage.go
@@ -6,8 +6,9 @@
  * USD, when the harness records it) over 24h / 7d / 30d, a per-model
  * breakdown, and the same 24h pane share the subscription blocks show.
  *
- * Every harness can contribute a pay-as-you-go block when it has an open
- * API-billed pane. Only OpenCode records per-message cost; Claude / Codex /
+ * Every harness can contribute observations when it has an open API-billed
+ * pane; observations sharing a backend id are merged into one provider block.
+ * Only OpenCode records per-message cost; Claude / Codex /
  * Grok blocks are token-only. Backend labels come from session providerIDs
  * (OpenCode, Codex), deployment env (Claude), or modelId+config.toml (Grok).
  *
@@ -188,6 +189,111 @@ func AnyAPICost(windows []APIUsageWindow) bool {
 		}
 	}
 	return false
+}
+
+// MergeAPIProviderUsage collapses harness-specific observations into one
+// block per billed backend. Harnesses are input adapters; BackendID is the
+// identity displayed and aggregated by the Usage pane.
+func MergeAPIProviderUsage(blocks []APIProviderUsage) []APIProviderUsage {
+	byBackend := make(map[string]*APIProviderUsage)
+	order := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.BackendID == "" {
+			continue
+		}
+		dst, ok := byBackend[block.BackendID]
+		if !ok {
+			dst = &APIProviderUsage{BackendID: block.BackendID, Label: block.Label}
+			byBackend[block.BackendID] = dst
+			order = append(order, block.BackendID)
+		}
+		if dst.Label == "" {
+			dst.Label = block.Label
+		}
+		mergeAPIWindows(dst, block.Windows)
+		mergeAPIModels(dst, block.Models)
+		mergeAPIActivity(dst, block.PaneActivity)
+	}
+	out := make([]APIProviderUsage, 0, len(order))
+	for _, id := range order {
+		block := byBackend[id]
+		sort.Slice(block.Windows, func(i, j int) bool { return block.Windows[i].WindowMinutes < block.Windows[j].WindowMinutes })
+		sort.Slice(block.Models, func(i, j int) bool {
+			if block.Models[i].CostUSD != block.Models[j].CostUSD {
+				return block.Models[i].CostUSD > block.Models[j].CostUSD
+			}
+			if block.Models[i].Tokens != block.Models[j].Tokens {
+				return block.Models[i].Tokens > block.Models[j].Tokens
+			}
+			return block.Models[i].ModelID < block.Models[j].ModelID
+		})
+		block.HasCost = AnyAPICost(block.Windows)
+		out = append(out, *block)
+	}
+	return out
+}
+
+func mergeAPIWindows(dst *APIProviderUsage, src []APIUsageWindow) {
+	index := make(map[int]int, len(dst.Windows))
+	for i, w := range dst.Windows {
+		index[w.WindowMinutes] = i
+	}
+	for _, w := range src {
+		if i, ok := index[w.WindowMinutes]; ok {
+			dst.Windows[i].Tokens += w.Tokens
+			dst.Windows[i].CostUSD += w.CostUSD
+		} else {
+			index[w.WindowMinutes] = len(dst.Windows)
+			dst.Windows = append(dst.Windows, w)
+		}
+	}
+}
+
+func mergeAPIModels(dst *APIProviderUsage, src []APIModelUsage) {
+	index := make(map[string]int, len(dst.Models))
+	for i, m := range dst.Models {
+		index[m.ModelID] = i
+	}
+	for _, m := range src {
+		if i, ok := index[m.ModelID]; ok {
+			dst.Models[i].Tokens += m.Tokens
+			dst.Models[i].CostUSD += m.CostUSD
+		} else {
+			index[m.ModelID] = len(dst.Models)
+			dst.Models = append(dst.Models, m)
+		}
+	}
+}
+
+func mergeAPIActivity(dst *APIProviderUsage, src *ProviderPaneActivity) {
+	if src == nil {
+		return
+	}
+	if dst.PaneActivity == nil {
+		dst.PaneActivity = &ProviderPaneActivity{WindowMinutes: src.WindowMinutes}
+	}
+	activity := dst.PaneActivity
+	activity.TotalTokens += src.TotalTokens
+	rows := make(map[string]PaneTokenRow)
+	for _, existing := range activity.Panes {
+		rows[existing.PaneID] = PaneTokenRow{PaneID: existing.PaneID, Label: existing.Label, Tokens: existing.Tokens}
+	}
+	for _, pane := range src.Panes {
+		row := rows[pane.PaneID]
+		row.PaneID = pane.PaneID
+		if row.Label == "" {
+			row.Label = pane.Label
+		}
+		row.Tokens += pane.Tokens
+		rows[pane.PaneID] = row
+	}
+	actual := make([]PaneTokenRow, 0, len(rows))
+	for id, row := range rows {
+		if id != OtherPaneID {
+			actual = append(actual, row)
+		}
+	}
+	_, activity.Panes = ComputeSharesWithOther(DisambiguateLabels(actual), float64(activity.TotalTokens))
 }
 
 // HumanizeBackendID is the label fallback when a backend is absent from

--- a/internal/limits/apiusage_io.go
+++ b/internal/limits/apiusage_io.go
@@ -61,6 +61,7 @@ func activeAPIPaneBackends(openPanes []OpenPaneSnapshot, harnessID string) []pan
 func CollectAPIProviderUsage(openPanes []OpenPaneSnapshot, nowMs int64) []APIProviderUsage {
 	out := collectOpenCodeAPIUsage(openPanes, nowMs)
 	out = append(out, collectFileHarnessAPIUsage(openPanes, nowMs)...)
+	out = MergeAPIProviderUsage(out)
 	sortAPIProviderUsage(out)
 	return out
 }

--- a/internal/limits/apiusage_test.go
+++ b/internal/limits/apiusage_test.go
@@ -138,6 +138,24 @@ func TestAnyAPICost(t *testing.T) {
 	}
 }
 
+func TestMergeAPIProviderUsage_GroupsSameBackendAcrossHarnesses(t *testing.T) {
+	blocks := []APIProviderUsage{
+		{BackendID: "deepseek", Label: "DeepSeek", Windows: []APIUsageWindow{{WindowMinutes: 1440, Tokens: 100, CostUSD: .01}}, Models: []APIModelUsage{{ModelID: "chat", Tokens: 100, CostUSD: .01}}, PaneActivity: &ProviderPaneActivity{WindowMinutes: 1440, TotalTokens: 100, Panes: []PaneActivityShare{{PaneID: "open", Label: "OpenCode", Tokens: 100}}}},
+		{BackendID: "deepseek", Label: "DeepSeek", Windows: []APIUsageWindow{{WindowMinutes: 1440, Tokens: 50, CostUSD: .02}}, Models: []APIModelUsage{{ModelID: "chat", Tokens: 20, CostUSD: .01}, {ModelID: "reasoner", Tokens: 30, CostUSD: .01}}, PaneActivity: &ProviderPaneActivity{WindowMinutes: 1440, TotalTokens: 50, Panes: []PaneActivityShare{{PaneID: "omp", Label: "OMP", Tokens: 50}}}},
+	}
+	got := MergeAPIProviderUsage(blocks)
+	if len(got) != 1 {
+		t.Fatalf("got %d blocks: %#v", len(got), got)
+	}
+	block := got[0]
+	if block.Windows[0].Tokens != 150 || block.Windows[0].CostUSD != .03 || len(block.Models) != 2 {
+		t.Fatalf("merged block=%#v", block)
+	}
+	if block.PaneActivity == nil || len(block.PaneActivity.Panes) != 2 || block.PaneActivity.TotalTokens != 150 {
+		t.Fatalf("activity=%#v", block.PaneActivity)
+	}
+}
+
 func TestHumanizeBackendID(t *testing.T) {
 	cases := map[string]string{
 		"deepseek":    "Deepseek",

--- a/internal/limits/attachactivity_test.go
+++ b/internal/limits/attachactivity_test.go
@@ -107,4 +107,33 @@ func TestAttachPaneActivity_NoOpenPanes(t *testing.T) {
 	}
 }
 
+func TestAttachPaneActivity_GroupsHarnessesBySubscriptionProvider(t *testing.T) {
+	wm := 300
+	providers := []ProviderLimits{{
+		ProviderID: "opencode", Label: "OpenCode", Source: "test",
+		Primary: &LimitWindow{WindowMinutes: &wm},
+	}}
+	open := []OpenPaneSnapshot{
+		{PaneID: "open", Agent: "opencode", Label: "OpenCode pane"},
+		{PaneID: "omp", Agent: "omp", Label: "OMP pane"},
+	}
+	result := AttachPaneActivity(providers, open, 1_700_000_000_000, PaneActivityDeps{
+		ResolvePaneProvider: func(p OpenPaneSnapshot) (string, bool) {
+			// Both harnesses used the OpenCode Go subscription route.
+			return "opencode", true
+		},
+		TokensForPane: func(_ string, pane OpenPaneSnapshot, _, _ int64) float64 {
+			if pane.PaneID == "open" {
+				return 60
+			}
+			return 40
+		},
+		TotalTokensForProvider: func(string, int64, int64) float64 { return 100 },
+	})
+	activity := result[0].PaneActivity
+	if activity == nil || len(activity.Panes) != 2 || activity.Panes[0].Tokens != 60 || activity.Panes[1].Tokens != 40 {
+		t.Fatalf("activity=%+v", activity)
+	}
+}
+
 func strP(s string) *string { return &s }

--- a/internal/limits/billingmode.go
+++ b/internal/limits/billingmode.go
@@ -67,6 +67,53 @@ func OpenCodeBillingModeFromProviderID(providerID *string) BillingMode {
 	return BillingPayAsYouGo
 }
 
+// SubscriptionRoute identifies the quota collector and sidebar label for a
+// subscription gateway used inside another harness.  The harness and the
+// subscription are deliberately separate: OMP/Pi may execute through an
+// OpenCode Go or Grok login without themselves owning either quota.
+type SubscriptionRoute struct {
+	CollectorProviderID string
+	DisplayProviderID   string
+}
+
+// OMPPiSubscriptionRoute maps the provider id recorded in an OMP/Pi session
+// to one of the subscription collectors this plugin already implements.
+//
+// Keep this positive-evidence-only: an ordinary provider id such as
+// "anthropic" may mean an API key as well as an OAuth login, and must not be
+// guessed into a subscription account.
+func OMPPiSubscriptionRoute(backendID string) (SubscriptionRoute, bool) {
+	return SubscriptionRouteForProviderAuth(backendID, "")
+}
+
+// SubscriptionRouteForProviderAuth maps a session provider plus its recorded
+// credential kind to one of this plugin's subscription collectors.  OAuth is
+// required for ambiguous provider ids such as "anthropic"; the same id with
+// an API key remains pay-as-you-go.
+func SubscriptionRouteForProviderAuth(backendID, credentialType string) (SubscriptionRoute, bool) {
+	backendID = strings.ToLower(strings.TrimSpace(backendID))
+	credentialType = strings.ToLower(strings.TrimSpace(credentialType))
+	switch strings.ToLower(strings.TrimSpace(backendID)) {
+	case "opencode-go":
+		return SubscriptionRoute{CollectorProviderID: "opencode", DisplayProviderID: "opencode-go"}, true
+	case "xai-oauth":
+		return SubscriptionRoute{CollectorProviderID: "grok", DisplayProviderID: "grok"}, true
+	case "anthropic":
+		if strings.Contains(credentialType, "oauth") {
+			return SubscriptionRoute{CollectorProviderID: "claude", DisplayProviderID: "claude"}, true
+		}
+	case "openai", "openai-codex":
+		if strings.Contains(credentialType, "oauth") {
+			return SubscriptionRoute{CollectorProviderID: "codex", DisplayProviderID: "codex"}, true
+		}
+	case "openai-codex-oauth":
+		return SubscriptionRoute{CollectorProviderID: "codex", DisplayProviderID: "codex"}, true
+	default:
+		return SubscriptionRoute{}, false
+	}
+	return SubscriptionRoute{}, false
+}
+
 // CodexBillingModeFromLines inspects a rollout tail. A token_count event
 // carrying rate_limits proves a subscription backend (unless plan_type says
 // API key); token_count events without any rate_limits mean the backend
@@ -173,6 +220,9 @@ type BillingDeps struct {
 	// universe so each configured account is gated independently. Empty
 	// defaults to ["claude"] (today's single-profile behavior).
 	ClaudeProfileIDs []string
+	// ResolvePane maps one harness pane to its billed provider while retaining
+	// the harness id needed to read session-specific evidence.
+	ResolvePane func(pane OpenPaneSnapshot) (providerID, harnessID string, ok bool)
 }
 
 // PaneBillingMode combines account- and session-level evidence for one pane.
@@ -202,11 +252,21 @@ func BillingProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool, deps 
 	allIDs = append(allIDs, claudeIDs...)
 	allIDs = append(allIDs, nonClaudeProviderIDs...)
 
-	byProvider := make(map[string][]OpenPaneSnapshot)
+	type billedPane struct {
+		harnessID string
+		pane      OpenPaneSnapshot
+	}
+	byProvider := make(map[string][]billedPane)
 	if paneQueryOK {
 		for _, pane := range openPanes {
-			if providerID, ok := agentToProvider[strings.ToLower(pane.Agent)]; ok {
-				byProvider[providerID] = append(byProvider[providerID], pane)
+			providerID, harnessID, ok := "", "", false
+			if deps.ResolvePane != nil {
+				providerID, harnessID, ok = deps.ResolvePane(pane)
+			} else if id, found := agentToProvider[strings.ToLower(pane.Agent)]; found {
+				providerID, harnessID, ok = id, id, true
+			}
+			if ok {
+				byProvider[providerID] = append(byProvider[providerID], billedPane{harnessID: harnessID, pane: pane})
 			}
 		}
 	}
@@ -224,10 +284,10 @@ func BillingProviderFilter(openPanes []OpenPaneSnapshot, paneQueryOK bool, deps 
 			set[providerID] = true
 			continue
 		}
-		for _, pane := range panes {
+		for _, entry := range panes {
 			session := BillingUnknown
 			if deps.PaneMode != nil {
-				session = deps.PaneMode(providerID, pane)
+				session = deps.PaneMode(entry.harnessID, entry.pane)
 			}
 			if CombineBillingModes(account, session) != BillingPayAsYouGo {
 				set[providerID] = true

--- a/internal/limits/billingmode_io.go
+++ b/internal/limits/billingmode_io.go
@@ -18,6 +18,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/opencode"
 	_ "modernc.org/sqlite"
 )
 
@@ -43,7 +44,25 @@ func DefaultBillingDeps() BillingDeps {
 			return accountBillingModeWith(profiles, providerID)
 		},
 		ClaudeProfileIDs: ids,
+		ResolvePane: func(pane OpenPaneSnapshot) (string, string, bool) {
+			return resolveBilledPane(profiles, pane)
+		},
 	}
+}
+
+func resolveBilledPane(profiles []claude.ClaudeProfile, pane OpenPaneSnapshot) (providerID, harnessID string, ok bool) {
+	harnessID, ok = agentToProvider[strings.ToLower(pane.Agent)]
+	if !ok {
+		return "", "", false
+	}
+	if harnessID == "claude" {
+		providerID, ok = BuildClaudePaneProviderResolver(profiles)(pane)
+		return providerID, harnessID, ok
+	}
+	if route, routed := paneSubscriptionRoute(harnessID, pane); routed {
+		return route.CollectorProviderID, harnessID, true
+	}
+	return harnessID, harnessID, true
 }
 
 // paneBillingModeWith dispatches by provider id against an explicit profile
@@ -57,9 +76,27 @@ func paneBillingModeWith(profiles []claude.ClaudeProfile, providerID string, pan
 	}
 	switch providerID {
 	case "opencode":
+		if _, ok := paneSubscriptionRoute(providerID, pane); ok {
+			return BillingSubscription
+		}
+		if paneHasOAuthCredential(providerID, pane) {
+			// This is a real subscription/login, but its collector is not
+			// implemented yet (for example Copilot). Never turn it into a
+			// fabricated API spend total merely because the collector is absent.
+			return BillingUnknown
+		}
 		return opencodePaneBillingMode(pane)
 	case "omp", "pi":
-		// OMP / stock Pi sessions are API-key / Cursor-backed; no subscription quota windows.
+		if _, ok := paneSubscriptionRoute(providerID, pane); ok {
+			// The session records a known subscription gateway.  Its quota is
+			// owned by that gateway's account, not by the OMP/Pi harness.
+			return BillingSubscription
+		}
+		if paneHasOAuthCredential(providerID, pane) {
+			return BillingUnknown
+		}
+		// Other OMP / stock Pi sessions have no positive subscription route
+		// evidence, so retain the backend-scoped PAYG behavior.
 		return BillingPayAsYouGo
 	case "codex":
 		return codexPaneBillingMode(pane)
@@ -68,6 +105,26 @@ func paneBillingModeWith(profiles []claude.ClaudeProfile, providerID string, pan
 	default:
 		return BillingUnknown
 	}
+}
+
+// SubscriptionLimitsProviderID maps a pane's harness provider to the account
+// provider that owns its subscription windows. OMP/Pi can run supported
+// subscription gateways inside their own harness sessions.
+func SubscriptionLimitsProviderID(providerID string, pane OpenPaneSnapshot) string {
+	if route, ok := paneSubscriptionRoute(providerID, pane); ok {
+		return route.CollectorProviderID
+	}
+	return providerID
+}
+
+// SubscriptionDisplayProviderID returns the provider label that should sit
+// beside a subscription limit.  It preserves the gateway's distinct name
+// (not the OMP/Pi harness and not the collector's internal id).
+func SubscriptionDisplayProviderID(providerID string, pane OpenPaneSnapshot) string {
+	if route, ok := paneSubscriptionRoute(providerID, pane); ok {
+		return route.DisplayProviderID
+	}
+	return providerID
 }
 
 func accountBillingModeWith(profiles []claude.ClaudeProfile, providerID string) BillingMode {
@@ -456,6 +513,54 @@ func ompPaneBackendID(pane OpenPaneSnapshot) string {
 		return ""
 	}
 	return omp.BackendIDForPath(path)
+}
+
+func ompPiPaneBackendID(providerID string, pane OpenPaneSnapshot) string {
+	if providerID == "omp" {
+		return ompPaneBackendID(pane)
+	}
+	if providerID == "pi" {
+		return piPaneBackendID(pane)
+	}
+	return ""
+}
+
+func ompPiSubscriptionRoute(providerID string, pane OpenPaneSnapshot) (SubscriptionRoute, bool) {
+	backendID := ompPiPaneBackendID(providerID, pane)
+	credentialType := paneCredentialType(providerID, pane)
+	return SubscriptionRouteForProviderAuth(backendID, credentialType)
+}
+
+func paneCredentialType(providerID string, pane OpenPaneSnapshot) string {
+	switch providerID {
+	case "omp":
+		return omp.CredentialType(ompPiPaneBackendID(providerID, pane))
+	case "pi":
+		return omp.PiCredentialType(ompPiPaneBackendID(providerID, pane))
+	case "opencode":
+		backendID := opencodePaneBackendID(pane)
+		return opencode.CredentialType(backendID)
+	default:
+		return ""
+	}
+}
+
+func paneHasOAuthCredential(providerID string, pane OpenPaneSnapshot) bool {
+	return strings.Contains(paneCredentialType(providerID, pane), "oauth")
+}
+
+// paneSubscriptionRoute resolves the subscription owner for harnesses that
+// may delegate a turn to another provider account.
+func paneSubscriptionRoute(providerID string, pane OpenPaneSnapshot) (SubscriptionRoute, bool) {
+	switch providerID {
+	case "omp", "pi":
+		return ompPiSubscriptionRoute(providerID, pane)
+	case "opencode":
+		backendID := opencodePaneBackendID(pane)
+		return SubscriptionRouteForProviderAuth(backendID, paneCredentialType(providerID, pane))
+	default:
+		return SubscriptionRoute{}, false
+	}
 }
 
 // ompSessionPath resolves the OMP jsonl path from SessionID, else newest cwd session.

--- a/internal/limits/billingmode_test.go
+++ b/internal/limits/billingmode_test.go
@@ -115,6 +115,52 @@ func TestGrokBillingModeFromAuthMode(t *testing.T) {
 	}
 }
 
+func TestOMPPiSubscriptionRoute(t *testing.T) {
+	cases := []struct {
+		backend, collector, display string
+		ok                          bool
+	}{
+		{"opencode-go", "opencode", "opencode-go", true},
+		{" OpenCode-Go ", "opencode", "opencode-go", true},
+		{"xai-oauth", "grok", "grok", true},
+		{"XAI-OAUTH", "grok", "grok", true},
+		{"xai", "", "", false},
+		{"anthropic", "", "", false}, // can be API key or OAuth; do not guess
+	}
+	for _, c := range cases {
+		route, ok := OMPPiSubscriptionRoute(c.backend)
+		if ok != c.ok || route.CollectorProviderID != c.collector || route.DisplayProviderID != c.display {
+			t.Fatalf("OMPPiSubscriptionRoute(%q) = %#v, %v", c.backend, route, ok)
+		}
+	}
+}
+
+func TestSubscriptionRouteForProviderAuth(t *testing.T) {
+	cases := []struct {
+		provider, credential, collector string
+		ok                              bool
+	}{
+		{"anthropic", "oauth", "claude", true},
+		{"anthropic", "api_key", "", false},
+		{"anthropic", "", "", false},
+		{"openai-codex", "oauth", "codex", true},
+		{"openai", "oauth", "codex", true},
+		{"openai-codex", "api_key", "", false},
+		{"openai-codex", "", "", false},
+		{"openai-codex-oauth", "", "codex", true},
+		{"openai", "api", "", false},
+		{"opencode-go", "api_key", "opencode", true},
+		{"xai-oauth", "oauth", "grok", true},
+		{"github-copilot", "oauth", "", false},
+	}
+	for _, c := range cases {
+		route, ok := SubscriptionRouteForProviderAuth(c.provider, c.credential)
+		if ok != c.ok || route.CollectorProviderID != c.collector {
+			t.Fatalf("SubscriptionRouteForProviderAuth(%q, %q) = %#v, %v", c.provider, c.credential, route, ok)
+		}
+	}
+}
+
 func TestCombineBillingModes_ClaudeEnvOverridesSubscription(t *testing.T) {
 	// Stripe subscription account running through Bedrock must hide sub windows.
 	if got := CombineBillingModes(BillingSubscription, BillingPayAsYouGo); got != BillingPayAsYouGo {
@@ -157,6 +203,23 @@ func TestBillingProviderFilter_MixedPanesKeepProvider(t *testing.T) {
 	set := BillingProviderFilter(panes, true, deps)
 	if !set["opencode"] {
 		t.Fatalf("opencode should stay included: %#v", set)
+	}
+}
+
+func TestBillingProviderFilter_RoutedHarnessUsesBilledProvider(t *testing.T) {
+	panes := []OpenPaneSnapshot{{PaneID: "omp-go", Agent: "omp"}}
+	deps := BillingDeps{
+		ResolvePane: func(OpenPaneSnapshot) (string, string, bool) { return "opencode", "omp", true },
+		PaneMode: func(providerID string, _ OpenPaneSnapshot) BillingMode {
+			if providerID != "omp" {
+				t.Fatalf("PaneMode provider=%q want harness omp", providerID)
+			}
+			return BillingSubscription
+		},
+	}
+	set := BillingProviderFilter(panes, true, deps)
+	if !set["opencode"] {
+		t.Fatalf("routed provider missing: %#v", set)
 	}
 }
 

--- a/internal/limits/panetokens_io.go
+++ b/internal/limits/panetokens_io.go
@@ -15,6 +15,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/opencode"
 	_ "modernc.org/sqlite"
 )
 
@@ -34,7 +35,24 @@ func DefaultPaneActivityDeps() PaneActivityDeps {
 		TotalTokensForProvider: func(providerID string, startMs, endMs int64) float64 {
 			return totalTokensForProviderWith(profiles, providerID, startMs, endMs)
 		},
-		ResolvePaneProvider: BuildClaudePaneProviderResolver(profiles),
+		ResolvePaneProvider: BuildPaneActivityProviderResolver(profiles),
+	}
+}
+
+// BuildPaneActivityProviderResolver extends the normal harness resolver only
+// for the Limits pane's subscription activity: OMP/Pi subscription gateways
+// belong under their collector account.  Keep this separate from
+// BuildClaudePaneProviderResolver, which sidebar updates use to retain the
+// actual harness id before resolving its billing route.
+func BuildPaneActivityProviderResolver(profiles []claude.ClaudeProfile) PaneProviderResolver {
+	base := BuildClaudePaneProviderResolver(profiles)
+	return func(pane OpenPaneSnapshot) (string, bool) {
+		if pane.Agent == "omp" || pane.Agent == "pi" || pane.Agent == "opencode" {
+			if route, ok := paneSubscriptionRoute(pane.Agent, pane); ok {
+				return route.CollectorProviderID, true
+			}
+		}
+		return base(pane)
 	}
 }
 
@@ -85,6 +103,26 @@ func TokensForPaneDefault(providerID string, pane OpenPaneSnapshot, startMs, end
 // profile snapshot (see DefaultPaneActivityDeps): Claude ids resolve their
 // transcript root from profiles, other agents via the static switch.
 func tokensForPaneWith(profiles []claude.ClaudeProfile, providerID string, pane OpenPaneSnapshot, startMs, endMs int64) float64 {
+	if pane.Agent == "opencode" {
+		backendID := opencodePaneBackendID(pane)
+		if route, ok := paneSubscriptionRoute("opencode", pane); ok && route.CollectorProviderID == providerID {
+			return opencodeTokensForPane(pane, backendID, startMs, endMs)
+		}
+	}
+	// An OMP/Pi subscription session belongs to the gateway's quota account,
+	// but its local activity lives in the harness JSONL. Count only the gateway
+	// recorded on this session; never mix earlier API backends into its share.
+	if pane.Agent == "omp" || pane.Agent == "pi" {
+		backendID := ompPiPaneBackendID(pane.Agent, pane)
+		if route, ok := paneSubscriptionRoute(pane.Agent, pane); ok && route.CollectorProviderID == providerID {
+			if pane.Agent == "omp" {
+				tokens, _ := ompActivityForPaneBackend(pane, backendID, startMs, endMs)
+				return tokens
+			}
+			tokens, _ := piActivityForPaneBackend(pane, backendID, startMs, endMs)
+			return tokens
+		}
+	}
 	if profile, ok := profileByIDIn(profiles, providerID); ok {
 		return claudeTokensForPaneIn(profile.ProjectsRoot, pane, startMs, endMs)
 	}
@@ -124,10 +162,10 @@ func PaneTotalUsage(providerID string, pane OpenPaneSnapshot, nowMs int64) (toke
 		return opencodeActivityForPane(pane, backendID, 0, nowMs)
 	}
 	if providerID == "omp" {
-		return ompActivityForPane(pane, 0, nowMs)
+		return ompActivityForPaneBackend(pane, ompPaneBackendID(pane), 0, nowMs)
 	}
 	if providerID == "pi" {
-		return piActivityForPane(pane, 0, nowMs)
+		return piActivityForPaneBackend(pane, piPaneBackendID(pane), 0, nowMs)
 	}
 	return TokensForPaneAnyBackend(providerID, pane, 0, nowMs), 0
 }
@@ -152,19 +190,109 @@ func TotalTokensForProviderDefault(providerID string, startMs, endMs int64) floa
 // totalTokensForProviderWith is TotalTokensForProviderDefault dispatched against
 // an explicit profile snapshot (see DefaultPaneActivityDeps).
 func totalTokensForProviderWith(profiles []claude.ClaudeProfile, providerID string, startMs, endMs int64) float64 {
+	routed := routedSubscriptionTotal(providerID, startMs, endMs)
 	if profile, ok := profileByIDIn(profiles, providerID); ok {
-		return claudeTotalIn(profile.ProjectsRoot, startMs, endMs)
+		return claudeTotalIn(profile.ProjectsRoot, startMs, endMs) + routed
 	}
 	switch providerID {
 	case "codex":
-		return codexTotal(startMs, endMs)
+		return codexTotal(startMs, endMs) + routed
 	case "opencode":
-		return openCodeTotal(startMs, endMs)
+		return openCodeTotal(startMs, endMs) + routed
 	case "grok":
-		return grokTotal(startMs, endMs)
+		return grokTotal(startMs, endMs) + routed
 	default:
+		return routed
+	}
+}
+
+// routedSubscriptionTotal adds activity recorded by harnesses other than the
+// collector's native one. This keeps the provider block authoritative when
+// OMP/Pi/OpenCode all spend the same subscription account.
+func routedSubscriptionTotal(providerID string, startMs, endMs int64) float64 {
+	var total float64
+	for _, source := range []struct {
+		harness string
+		paths   []string
+	}{
+		{"omp", omp.ListAllOMPSessionFiles()},
+		{"pi", omp.ListAllPiSessionFiles()},
+	} {
+		byBackend := scanOMPPiRowsByBackend(source.paths, startMs)
+		for backendID, rows := range byBackend {
+			credentialType := ""
+			if source.harness == "omp" {
+				credentialType = omp.CredentialType(backendID)
+			} else {
+				credentialType = omp.PiCredentialType(backendID)
+			}
+			route, ok := SubscriptionRouteForProviderAuth(backendID, credentialType)
+			if !ok || route.CollectorProviderID != providerID {
+				continue
+			}
+			for _, row := range rows {
+				if row.CreatedMs >= startMs && row.CreatedMs <= endMs {
+					total += row.Tokens
+				}
+			}
+		}
+	}
+	// OpenCode Go is already included by openCodeTotal; only add OpenCode
+	// sessions routed to a different subscription collector (e.g. Codex).
+	if providerID != "opencode" {
+		total += openCodeRoutedSubscriptionTotal(providerID, startMs, endMs)
+	}
+	return total
+}
+
+func openCodeRoutedSubscriptionTotal(providerID string, startMs, endMs int64) float64 {
+	dbPath := ResolveOpenCodeLimitsDBPath()
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	if err != nil {
 		return 0
 	}
+	defer db.Close()
+	rows, err := db.Query(
+		`SELECT DISTINCT json_extract(data, '$.providerID') FROM message
+		 WHERE time_created >= ? AND time_created <= ? AND json_valid(data)
+		   AND json_extract(data, '$.role') = 'assistant'`, startMs, endMs)
+	if err != nil {
+		return 0
+	}
+	defer rows.Close()
+	var backendIDs []string
+	for rows.Next() {
+		var backendID string
+		if rows.Scan(&backendID) == nil && backendID != "" {
+			backendIDs = append(backendIDs, backendID)
+		}
+	}
+	var total float64
+	for _, backendID := range backendIDs {
+		route, ok := SubscriptionRouteForProviderAuth(backendID, opencode.CredentialType(backendID))
+		if !ok || route.CollectorProviderID != providerID {
+			continue
+		}
+		query := `SELECT data, time_created FROM message
+		 WHERE time_created >= ? AND time_created <= ? AND json_valid(data)
+		   AND json_extract(data, '$.role') = 'assistant'
+		   AND json_extract(data, '$.providerID') = ?`
+		messageRows, err := db.Query(query, startMs, endMs, backendID)
+		if err != nil {
+			continue
+		}
+		var list []OpenCodeTokenRow
+		for messageRows.Next() {
+			var data string
+			var created int64
+			if messageRows.Scan(&data, &created) == nil {
+				list = append(list, OpenCodeTokenRow{Data: data, TimeCreated: created})
+			}
+		}
+		messageRows.Close()
+		total += SumOpenCodeProviderTokensInWindow(list, backendID, startMs, endMs)
+	}
+	return total
 }
 
 func sessionIDStr(pane OpenPaneSnapshot) string {
@@ -441,10 +569,26 @@ func ompActivityForPane(pane OpenPaneSnapshot, startMs, endMs int64) (tokens flo
 	return omp.ActivityForPath(path, startMs, endMs)
 }
 
+func ompActivityForPaneBackend(pane OpenPaneSnapshot, backendID string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	path := ompSessionPath(pane)
+	if path == "" || backendID == "" {
+		return 0, 0
+	}
+	return omp.ActivityForProviderPath(path, backendID, startMs, endMs)
+}
+
 func piActivityForPane(pane OpenPaneSnapshot, startMs, endMs int64) (tokens float64, costUSD float64) {
 	path := piSessionPath(pane)
 	if path == "" {
 		return 0, 0
 	}
 	return omp.ActivityForPath(path, startMs, endMs)
+}
+
+func piActivityForPaneBackend(pane OpenPaneSnapshot, backendID string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	path := piSessionPath(pane)
+	if path == "" || backendID == "" {
+		return 0, 0
+	}
+	return omp.ActivityForProviderPath(path, backendID, startMs, endMs)
 }

--- a/internal/providers/omp/auth.go
+++ b/internal/providers/omp/auth.go
@@ -1,0 +1,56 @@
+package omp
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// CredentialType returns the active OMP credential kind for a provider
+// without reading its secret material. OMP records OAuth and API-key
+// credentials separately in agent.db.
+func CredentialType(provider string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(home, ".omp", "agent", "agent.db")+"?mode=ro")
+	if err != nil {
+		return ""
+	}
+	defer db.Close()
+	var kind string
+	err = db.QueryRow(`SELECT credential_type FROM auth_credentials WHERE provider = ? AND disabled_cause IS NULL ORDER BY updated_at DESC LIMIT 1`, provider).Scan(&kind)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(kind))
+}
+
+// PiCredentialType reads only the credential kind from Pi's auth.json. Pi
+// stores provider entries as JSON objects; tokens are intentionally ignored.
+func PiCredentialType(provider string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".pi", "agent", "auth.json"))
+	if err != nil {
+		return ""
+	}
+	var entries map[string]map[string]any
+	if json.Unmarshal(raw, &entries) != nil {
+		return ""
+	}
+	entry := entries[provider]
+	for _, key := range []string{"type", "credential_type", "auth_type"} {
+		if value, ok := entry[key].(string); ok {
+			return strings.ToLower(strings.TrimSpace(value))
+		}
+	}
+	return ""
+}

--- a/internal/providers/omp/extract.go
+++ b/internal/providers/omp/extract.go
@@ -108,11 +108,18 @@ func ExtractLatestBackendFromLines(lines []string) string {
 	return ""
 }
 
-// SumUsageFromLines sums assistant turn totals. When startMs/endMs > 0, only
-// events with timestamps inside [startMs, endMs] are counted. Timestamps of 0
-// are always included when a window is unset (startMs==0 && endMs==0), and
-// skipped when a window is active.
+// SumUsageFromLines sums assistant turn totals across all backends. When
+// startMs/endMs > 0, only events with timestamps inside [startMs, endMs] are
+// counted. Timestamps of 0 are always included when a window is unset
+// (startMs==0 && endMs==0), and skipped when a window is active.
 func SumUsageFromLines(lines []string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	return SumUsageForProviderFromLines(lines, "", startMs, endMs)
+}
+
+// SumUsageForProviderFromLines sums assistant turn totals for one backend.
+// provider is empty to include all backends.
+func SumUsageForProviderFromLines(lines []string, provider string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	provider = strings.TrimSpace(provider)
 	windowed := startMs > 0 || endMs > 0
 	for _, line := range lines {
 		parsed := parseAssistantLine(line)
@@ -120,6 +127,9 @@ func SumUsageFromLines(lines []string, startMs, endMs int64) (tokens float64, co
 			continue
 		}
 		msg := parsed.Message
+		if provider != "" && strings.TrimSpace(msg.Provider) != provider {
+			continue
+		}
 		if windowed {
 			ts := msg.Timestamp
 			if ts <= 0 {

--- a/internal/providers/omp/extract_test.go
+++ b/internal/providers/omp/extract_test.go
@@ -33,6 +33,22 @@ func TestSumUsageFromLines(t *testing.T) {
 	}
 }
 
+func TestSumUsageForProviderFromLines_FiltersBackend(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","timestamp":100,"usage":{"totalTokens":10,"cost":{"total":0.1}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"openai","timestamp":200,"usage":{"totalTokens":20,"cost":{"total":0.2}}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","timestamp":300,"usage":{"totalTokens":40,"cost":{"total":0.4}}}}`,
+	}
+	tokens, cost := SumUsageForProviderFromLines(lines, "deepseek", 0, 0)
+	if tokens != 50 || cost < 0.499 || cost > 0.501 {
+		t.Fatalf("deepseek: tokens=%v cost=%v", tokens, cost)
+	}
+	tokens, cost = SumUsageForProviderFromLines(lines, "openai", 0, 0)
+	if tokens != 20 || cost < 0.199 || cost > 0.201 {
+		t.Fatalf("openai: tokens=%v cost=%v", tokens, cost)
+	}
+}
+
 func TestExtractLatestBackendFromLines(t *testing.T) {
 	lines := []string{
 		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"x","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1}}}`,

--- a/internal/providers/omp/resolve.go
+++ b/internal/providers/omp/resolve.go
@@ -88,8 +88,15 @@ func BackendIDForPath(path string) string {
 	return ExtractLatestBackendFromLines(lines)
 }
 
-// ActivityForPath sums token/cost totals for the session, optionally windowed.
+// ActivityForPath sums token/cost totals across every backend in the session,
+// optionally windowed.
 func ActivityForPath(path string, startMs, endMs int64) (tokens float64, costUSD float64) {
+	return ActivityForProviderPath(path, "", startMs, endMs)
+}
+
+// ActivityForProviderPath sums token/cost totals for one backend in the
+// session. provider is empty to include every backend.
+func ActivityForProviderPath(path, provider string, startMs, endMs int64) (tokens float64, costUSD float64) {
 	path = expandHome(path)
 	if path == "" {
 		return 0, 0
@@ -113,5 +120,5 @@ func ActivityForPath(path string, startMs, endMs int64) (tokens float64, costUSD
 		// Fail closed: a truncated scan would undercount silently.
 		return 0, 0
 	}
-	return SumUsageFromLines(lines, startMs, endMs)
+	return SumUsageForProviderFromLines(lines, provider, startMs, endMs)
 }

--- a/internal/providers/opencode/auth.go
+++ b/internal/providers/opencode/auth.go
@@ -1,0 +1,35 @@
+package opencode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CredentialType returns only the authentication kind stored for an OpenCode
+// provider (oauth, api, …), never the credential value itself.
+func CredentialType(providerID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".local", "share", "opencode", "auth.json"))
+	if err != nil {
+		return ""
+	}
+	var entries map[string]map[string]any
+	if json.Unmarshal(raw, &entries) != nil {
+		return ""
+	}
+	for _, id := range []string{providerID, "openai-codex", "openai"} {
+		entry, ok := entries[id]
+		if !ok {
+			continue
+		}
+		if kind, ok := entry["type"].(string); ok {
+			return strings.ToLower(strings.TrimSpace(kind))
+		}
+	}
+	return ""
+}

--- a/internal/setup/herdrconfig.go
+++ b/internal/setup/herdrconfig.go
@@ -46,10 +46,9 @@ func ToastConfigSnippet() string {
 // an existing [ui.sidebar.agents] section must merge these tokens into it
 // instead of appending a duplicate TOML table.
 //
-// $provider replaces the built-in `agent` token: it renders the harness name
-// ("opencode") on a subscription pane and the backend name ("deepseek") on a
-// pay-as-you-go one, where the backend is the more informative half. OMP / Pi
-// keep the harness name because their backends are in-pane model routing.
+// $provider replaces the built-in `agent` token: it renders the subscription
+// provider ("opencode-go", "grok", "claude") when one owns the pane's
+// limit, and the backend name ("deepseek") on a pay-as-you-go pane.
 func SidebarRowsSnippet() string {
 	return strings.Join([]string{
 		"[ui.sidebar.agents]",

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -31,6 +31,16 @@ func isSettledStatus(status string) bool {
 	return status != "working"
 }
 
+// paneCwdForUpdate chooses the directory used to resolve agent-local session
+// files. OMP/Pi may put a language-server process in the foreground, whose
+// cwd is inside a virtual environment rather than the agent's project. Their
+// session fallback is keyed by the pane's project cwd, so prefer it whenever
+// Herdr has not supplied a session path. Other agents preserve the existing
+// foreground-cwd preference.
+func paneCwdForUpdate(pane herdrcli.PaneInfo) *string {
+	return herdrcli.PaneSessionCwd(pane)
+}
+
 // resolveSidebarAccountLabel picks the text that identifies profile in the
 // sidebar's $limit slot once it has been displaced by the account row: the
 // real login email when readable, otherwise the profile's own label (which
@@ -69,17 +79,14 @@ func combineLimitAndContext(limitText, statusText string) string {
 }
 
 // formatSidebarProvider renders the sidebar's agent line: the backend name on
-// a pay-as-you-go pane ("deepseek"), the harness name otherwise ("opencode").
+// a pay-as-you-go pane ("deepseek"), and the harness name as a provisional
+// fallback until a subscription route supplies its quota-provider label.
 //
 // The backend replaces the harness rather than joining it — the sidebar is
 // too narrow for both, and on a pay-as-you-go pane the backend is the more
 // informative half (the harness is already implied by the pane's agent icon).
 // It stands in for Herdr's built-in `agent` token, which is why it must carry
-// the harness name in the subscription case.
-//
-// OMP / Pi are the exception: their message.provider is model routing inside
-// one agent, and the adjacent burn total spans every backend in the session,
-// so $provider keeps the harness name.
+// a fallback name when no more specific label is available.
 func formatSidebarProvider(agentName, providerID string, pane limits.OpenPaneSnapshot) string {
 	return formatSidebarProviderWith(limits.PaneBackendID, agentName, providerID, pane)
 }
@@ -92,10 +99,13 @@ func formatSidebarProviderWith(
 	if agentName == "" {
 		return ""
 	}
+	backendID := backendFor(providerID, pane)
 	if providerID == "omp" || providerID == "pi" {
-		return agentName
+		// Without a recorded backend, leaving this blank is more accurate than
+		// naming the harness beside an empty or unscoped burn total.
+		return backendID
 	}
-	if backendID := backendFor(providerID, pane); backendID != "" {
+	if backendID != "" {
 		return backendID
 	}
 	return agentName
@@ -152,10 +162,7 @@ func RunUpdate(force bool) {
 		return
 	}
 
-	cwd := pane.ForegroundCwd
-	if cwd == nil {
-		cwd = pane.Cwd
-	}
+	cwd := paneCwdForUpdate(pane)
 	nowMs := time.Now().UnixMilli()
 	limitText := ""
 	// Subscription limits only apply when the pane's session is billed against
@@ -183,14 +190,17 @@ func RunUpdate(force bool) {
 		return
 	}
 
-	if limits.PaneBillingMode(providerID, snapshot, limits.DefaultBillingDeps()) == limits.BillingPayAsYouGo {
+	billingMode := limits.PaneBillingMode(providerID, snapshot, limits.DefaultBillingDeps())
+	limitsProviderID := limits.SubscriptionLimitsProviderID(providerID, snapshot)
+	displayProviderID := limits.SubscriptionDisplayProviderID(providerID, snapshot)
+	if billingMode == limits.BillingPayAsYouGo {
 		totalTokens, totalCostUSD := limits.PaneTotalUsage(providerID, snapshot, nowMs)
 		limitText = limits.FormatSidebarBurn(totalTokens, totalCostUSD)
 	} else {
 		collectOptions := limits.DefaultCollectOptions()
 		// Sidebar refresh deliberately collects only this pane's provider and leaves
 		// Attach nil, avoiding the heavier cross-pane activity aggregation path.
-		collectOptions.Only = map[string]bool{providerID: true}
+		collectOptions.Only = map[string]bool{limitsProviderID: true}
 		providerLimits := limits.CollectAllProviderLimits(cwd, nowMs, collectOptions)
 		if len(providerLimits) > 0 {
 			limitText = limits.FormatSidebarLimit(providerLimits[0], nowMs)
@@ -217,7 +227,11 @@ func RunUpdate(force bool) {
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
-	writeMetadataToken(paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+	providerText := formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot)
+	if billingMode == limits.BillingSubscription {
+		providerText = displayProviderID
+	}
+	writeMetadataToken(paneID, "provider", providerText, force)
 
 	// Context tokens: claude is read from its resolved profile's own transcript
 	// root (bypassing the registry's default-root lookup) so a non-default

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -8,8 +8,39 @@ import (
 	"testing"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 )
+
+func stringPtr(s string) *string { return &s }
+
+func TestPaneCwdForUpdate_OMPPiPreferPaneCwdWithoutSession(t *testing.T) {
+	paneCwd := "/project"
+	foregroundCwd := "/project/.venv/lib"
+	for _, agent := range []string{"omp", "pi"} {
+		got := paneCwdForUpdate(herdrcli.PaneInfo{
+			Agent:         stringPtr(agent),
+			Cwd:           &paneCwd,
+			ForegroundCwd: &foregroundCwd,
+		})
+		if got == nil || *got != paneCwd {
+			t.Fatalf("%s: got %v want %q", agent, got, paneCwd)
+		}
+	}
+}
+
+func TestPaneCwdForUpdate_OtherAgentsPreferForegroundCwd(t *testing.T) {
+	paneCwd := "/project"
+	foregroundCwd := "/project/subdir"
+	got := paneCwdForUpdate(herdrcli.PaneInfo{
+		Agent:         stringPtr("codex"),
+		Cwd:           &paneCwd,
+		ForegroundCwd: &foregroundCwd,
+	})
+	if got == nil || *got != foregroundCwd {
+		t.Fatalf("got %v want %q", got, foregroundCwd)
+	}
+}
 
 func TestWriteMetadataTokenWith_SetSuccessDeduplicates(t *testing.T) {
 	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
@@ -105,15 +136,25 @@ func TestFormatSidebarProviderWith_EmptyAgentRendersNothing(t *testing.T) {
 	}
 }
 
-func TestFormatSidebarProviderWith_OMPPiKeepHarnessName(t *testing.T) {
+func TestFormatSidebarProviderWith_OMPPiNameCurrentBackend(t *testing.T) {
 	backendFor := func(providerID string, pane limits.OpenPaneSnapshot) string {
 		return "deepseek"
 	}
-	if got := formatSidebarProviderWith(backendFor, "omp", "omp", limits.OpenPaneSnapshot{}); got != "omp" {
-		t.Fatalf("omp: got %q want omp", got)
+	if got := formatSidebarProviderWith(backendFor, "omp", "omp", limits.OpenPaneSnapshot{}); got != "deepseek" {
+		t.Fatalf("omp: got %q want deepseek", got)
 	}
-	if got := formatSidebarProviderWith(backendFor, "pi", "pi", limits.OpenPaneSnapshot{}); got != "pi" {
-		t.Fatalf("pi: got %q want pi", got)
+	if got := formatSidebarProviderWith(backendFor, "pi", "pi", limits.OpenPaneSnapshot{}); got != "deepseek" {
+		t.Fatalf("pi: got %q want deepseek", got)
+	}
+}
+
+func TestFormatSidebarProviderWith_OMPPiWithoutBackendRendersNothing(t *testing.T) {
+	backendFor := func(providerID string, pane limits.OpenPaneSnapshot) string { return "" }
+	if got := formatSidebarProviderWith(backendFor, "omp", "omp", limits.OpenPaneSnapshot{}); got != "" {
+		t.Fatalf("omp: got %q want empty", got)
+	}
+	if got := formatSidebarProviderWith(backendFor, "pi", "pi", limits.OpenPaneSnapshot{}); got != "" {
+		t.Fatalf("pi: got %q want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve subscription ownership from harness session provider and credential kind
- route OMP, Pi, and OpenCode activity into Claude, Codex, OpenCode Go, or Grok collectors
- merge pay-as-you-go usage across harnesses into one block per backend
- share OMP/Pi cwd resolution between sidebar and Usage pane and document the billing identity matrix

## Validation

- `go test ./...`
- `git diff --check origin/main...HEAD`
- live OMP + OpenCode Go sidebar: `opencode-go · 5h 100%`
- live OMP + Grok sidebar: `grok · 7d`
- Usage pane shows one OpenCode Go block with OMP and OpenCode pane shares

## Notes

- OAuth providers without an implemented collector remain unknown instead of being misclassified as API usage.
- OpenCode Claude Pro/Max is intentionally not registered as a supported subscription route.