### PR TITLE
chore: Bump plugin version to 0.5.0

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.4.0"
+version = "0.5.0"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
## Summary

- bump the plugin manifest version from 0.4.0 to 0.5.0
- prepare the provider-first billing architecture from #18 for release

## Validation

- `git diff --check`
- full CI runs on this PR before merge

## Release

After merge, run `scripts/release.sh v0.5.0` from the exact passing `main` commit.