### PR TITLE
hotfix: Keep the shortest limit window in the sidebar

### DIFF
--- a/internal/limits/display_contract_test.go
+++ b/internal/limits/display_contract_test.go
@@ -1,0 +1,95 @@
+package limits
+
+import (
+	"strings"
+	"testing"
+)
+
+func contractWindow(minutes int, used float64, resetInMinutes int64) *LimitWindow {
+	reset := int64(1_800_000_000 + resetInMinutes*60)
+	return &LimitWindow{UsedPercentage: used, WindowMinutes: &minutes, ResetsAt: &reset}
+}
+
+func TestUsagePaneSubscriptionContract_RendersEveryProviderWindowWithLeftAndReset(t *testing.T) {
+	const nowMs int64 = 1_800_000_000_000
+	tests := []struct {
+		name     string
+		provider ProviderLimits
+		want     []string
+	}{
+		{
+			name: "Claude 5h and 7d",
+			provider: ProviderLimits{ProviderID: "claude", Label: "Claude",
+				Primary: contractWindow(300, 13, 90), Secondary: contractWindow(10080, 79, 2*24*60)},
+			want: []string{"Claude", "5h", "87% left", "1h 30m", "7d", "21% left", "2d 0h"},
+		},
+		{
+			name: "Codex provider supplied 7d",
+			provider: ProviderLimits{ProviderID: "codex", Label: "Codex",
+				Primary: contractWindow(10080, 67, 3*24*60)},
+			want: []string{"Codex", "7d", "33% left", "3d 0h"},
+		},
+		{
+			name: "OpenCode Go 5h 7d and 30d",
+			provider: ProviderLimits{ProviderID: "opencode", Label: "OpenCode Go",
+				Primary: contractWindow(300, 0, 60), Secondary: contractWindow(10080, 20, 4*24*60), Tertiary: contractWindow(43200, 40, 10*24*60)},
+			want: []string{"OpenCode Go", "5h", "100% left", "1h 0m", "7d", "80% left", "4d 0h", "30d", "60% left", "10d 0h"},
+		},
+		{
+			name: "Grok Lite 7d",
+			provider: ProviderLimits{ProviderID: "grok", Label: "Grok",
+				Primary: contractWindow(10080, 86, 5*24*60)},
+			want: []string{"Grok", "7d", "14% left", "5d 0h"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := FormatUsagePanel([]ProviderLimits{tt.provider}, nil, nowMs, PanelLayout{Columns: 100, Rows: 40})
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Fatalf("missing %q in:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestUsagePaneProviderFirstContract_SubscriptionAcrossHarnessesIsOneBlock(t *testing.T) {
+	provider := ProviderLimits{
+		ProviderID: "opencode", Label: "OpenCode Go",
+		Primary: contractWindow(300, 10, 60),
+		PaneActivity: &ProviderPaneActivity{WindowMinutes: 300, TotalTokens: 1000, Panes: []PaneActivityShare{
+			{PaneID: "omp", Label: "OMP", Tokens: 600, SharePercent: 60},
+			{PaneID: "opencode", Label: "OpenCode", Tokens: 400, SharePercent: 40},
+		}},
+	}
+	out := FormatUsagePanel([]ProviderLimits{provider}, nil, 1_800_000_000_000, PanelLayout{Columns: 100, Rows: 40})
+	if strings.Count(out, "OpenCode Go") != 1 {
+		t.Fatalf("billing provider must render once:\n%s", out)
+	}
+	for _, want := range []string{"OMP 60%", "OpenCode 40%"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing harness activity %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestUsagePaneProviderFirstContract_APIAcrossHarnessesIsOneBlock(t *testing.T) {
+	blocks := []APIProviderUsage{
+		{BackendID: "deepseek", Label: "DeepSeek", Windows: []APIUsageWindow{{WindowMinutes: 1440, Tokens: 600, CostUSD: 0.06}}, PaneActivity: &ProviderPaneActivity{WindowMinutes: 1440, TotalTokens: 600, Panes: []PaneActivityShare{{PaneID: "omp", Label: "OMP", Tokens: 600, SharePercent: 100}}}},
+		{BackendID: "deepseek", Label: "DeepSeek", Windows: []APIUsageWindow{{WindowMinutes: 1440, Tokens: 400, CostUSD: 0.04}}, PaneActivity: &ProviderPaneActivity{WindowMinutes: 1440, TotalTokens: 400, Panes: []PaneActivityShare{{PaneID: "opencode", Label: "OpenCode", Tokens: 400, SharePercent: 100}}}},
+	}
+	merged := MergeAPIProviderUsage(blocks)
+	if len(merged) != 1 {
+		t.Fatalf("got %d provider blocks, want 1", len(merged))
+	}
+	out := FormatUsagePanel(nil, merged, 1_800_000_000_000, PanelLayout{Columns: 100, Rows: 40})
+	if strings.Count(out, "DeepSeek · API") != 1 {
+		t.Fatalf("backend provider must render once:\n%s", out)
+	}
+	for _, want := range []string{"1.0k", "$0.10", "OMP 60%", "OpenCode 40%"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing merged usage %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/limits/formatsidebar.go
+++ b/internal/limits/formatsidebar.go
@@ -64,9 +64,13 @@ func formatCompactTokens(tokens float64) string {
 	}
 }
 
-// FormatSidebarLimit returns the shortest unexpired provider window as a
-// standalone sidebar row. Context usage remains in its own $context row.
-func FormatSidebarLimit(provider ProviderLimits, nowMs int64) string {
+// FormatSidebarLimit returns the shortest available provider window as a
+// standalone sidebar row. A window is not displaced merely because its last
+// recorded reset time has passed: providers may refresh that window shortly
+// after the boundary, and switching to a longer window makes the sidebar
+// unstable. Collection freshness is handled by the provider adapters.
+// Context usage remains in its own $context row.
+func FormatSidebarLimit(provider ProviderLimits, _ int64) string {
 	candidates := []struct {
 		window   *LimitWindow
 		fallback string
@@ -78,9 +82,6 @@ func FormatSidebarLimit(provider ProviderLimits, nowMs int64) string {
 	for _, candidate := range candidates {
 		window := candidate.window
 		if window == nil {
-			continue
-		}
-		if window.ResetsAt != nil && *window.ResetsAt > 0 && *window.ResetsAt <= nowMs/1000 {
 			continue
 		}
 		return fmt.Sprintf("%s %d%%", windowTag(window, candidate.fallback), remainingOf(window.UsedPercentage))

--- a/internal/limits/formatsidebar.go
+++ b/internal/limits/formatsidebar.go
@@ -79,12 +79,35 @@ func FormatSidebarLimit(provider ProviderLimits, _ int64) string {
 		{provider.Secondary, "7d"},
 		{provider.Tertiary, "30d"},
 	}
+	var fallback *struct {
+		window   *LimitWindow
+		fallback string
+	}
+	var shortest *struct {
+		window   *LimitWindow
+		fallback string
+	}
 	for _, candidate := range candidates {
 		window := candidate.window
 		if window == nil {
 			continue
 		}
-		return fmt.Sprintf("%s %d%%", windowTag(window, candidate.fallback), remainingOf(window.UsedPercentage))
+		candidate := candidate
+		if fallback == nil {
+			fallback = &candidate
+		}
+		if window.WindowMinutes == nil || *window.WindowMinutes <= 0 {
+			continue
+		}
+		if shortest == nil || *window.WindowMinutes < *shortest.window.WindowMinutes {
+			shortest = &candidate
+		}
 	}
-	return ""
+	if shortest == nil {
+		shortest = fallback
+	}
+	if shortest == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s %d%%", windowTag(shortest.window, shortest.fallback), remainingOf(shortest.window.UsedPercentage))
 }

--- a/internal/limits/formatsidebar_test.go
+++ b/internal/limits/formatsidebar_test.go
@@ -52,6 +52,25 @@ func TestFormatSidebarLimit_KeepsShortestWindowAcrossResetBoundary(t *testing.T)
 	}
 }
 
+func TestFormatSidebarLimit_ClaudeKeepsFiveHourAtResetBoundary(t *testing.T) {
+	raw := `{
+		"cachedUsageUtilization": {
+			"fetchedAtMs": 1799999999000,
+			"utilization": {
+				"five_hour": {"utilization": 13, "resets_at": "2027-01-15T07:59:59Z"},
+				"seven_day": {"utilization": 79, "resets_at": "2027-01-20T08:00:00Z"}
+			}
+		}
+	}`
+	provider := ProviderLimitsFromClaudeJSON(raw, sidebarNowMs)
+	if provider == nil {
+		t.Fatal("expected Claude limits")
+	}
+	if got := FormatSidebarLimit(*provider, sidebarNowMs); got != "5h 87%" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestFormatSidebarLimit_ReturnsShortestWhenAllWindowsPassedReset(t *testing.T) {
 	expired := sidebarNowMs/1000 - 1
 	p := ProviderLimits{Primary: &LimitWindow{UsedPercentage: 97, ResetsAt: &expired}}

--- a/internal/limits/formatsidebar_test.go
+++ b/internal/limits/formatsidebar_test.go
@@ -30,7 +30,7 @@ func TestFormatSidebarLimit_NoWindows(t *testing.T) {
 	}
 }
 
-func TestFormatSidebarLimit_SkipsExpiredWindow(t *testing.T) {
+func TestFormatSidebarLimit_KeepsShortestWindowAcrossResetBoundary(t *testing.T) {
 	five := 300
 	seven := 10080
 	expired := sidebarNowMs / 1000
@@ -47,15 +47,15 @@ func TestFormatSidebarLimit_SkipsExpiredWindow(t *testing.T) {
 			ResetsAt:       &future,
 		},
 	}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "7d 58%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 3%" {
 		t.Fatalf("got %q", got)
 	}
 }
 
-func TestFormatSidebarLimit_AllWindowsExpired(t *testing.T) {
+func TestFormatSidebarLimit_ReturnsShortestWhenAllWindowsPassedReset(t *testing.T) {
 	expired := sidebarNowMs/1000 - 1
 	p := ProviderLimits{Primary: &LimitWindow{UsedPercentage: 97, ResetsAt: &expired}}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "" {
+	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 3%" {
 		t.Fatalf("got %q", got)
 	}
 }

--- a/internal/limits/formatsidebar_test.go
+++ b/internal/limits/formatsidebar_test.go
@@ -16,6 +16,28 @@ func TestFormatSidebarLimit_PrefersShortestAvailableWindow(t *testing.T) {
 	}
 }
 
+func TestFormatSidebarLimit_UsesWindowDurationInsteadOfSlotOrder(t *testing.T) {
+	five := 300
+	seven := 10080
+	p := ProviderLimits{
+		Primary:   &LimitWindow{UsedPercentage: 70, WindowMinutes: &seven},
+		Secondary: &LimitWindow{UsedPercentage: 28.4, WindowMinutes: &five},
+	}
+	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 72%" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatSidebarLimit_UsesSlotOrderWhenDurationsAreMissing(t *testing.T) {
+	p := ProviderLimits{
+		Primary:   &LimitWindow{UsedPercentage: 28.4},
+		Secondary: &LimitWindow{UsedPercentage: 70},
+	}
+	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 72%" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestFormatSidebarLimit_FallsBackToNextWindow(t *testing.T) {
 	seven := 10080
 	p := ProviderLimits{Secondary: &LimitWindow{UsedPercentage: 41.6, WindowMinutes: &seven}}

--- a/internal/providers/omp/context_contract_test.go
+++ b/internal/providers/omp/context_contract_test.go
@@ -1,0 +1,57 @@
+package omp
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+)
+
+// OMP and Pi share this adapter. The sidebar percentage must use the latest
+// assistant turn's model, not an earlier model from the same session.
+func TestSidebarContextContract_UsesLatestModelWindow(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "models.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE model_cache (provider_id TEXT, models TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	models := `[
+		{"id":"small-model","contextWindow":200000},
+		{"id":"large-model","contextWindow":1000000}
+	]`
+	if _, err := db.Exec(`INSERT INTO model_cache(provider_id, models) VALUES (?, ?)`, "deepseek", models); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"small-model","contextSnapshot":{"promptTokens":100000},"usage":{"totalTokens":100000}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"large-model","contextSnapshot":{"promptTokens":250000},"usage":{"totalTokens":250000}}}`,
+	}
+	if err := os.WriteFile(sessionPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("OMP_MODELS_DB", dbPath)
+	globalModelWindows = modelWindowCache{}
+	t.Cleanup(func() { globalModelWindows = modelWindowCache{} })
+
+	usage := ResolveUsageForPath(sessionPath)
+	if usage == nil || usage.ContextTokens != 250_000 || usage.WindowTokens == nil || *usage.WindowTokens != 1_000_000 {
+		t.Fatalf("latest model usage = %+v", usage)
+	}
+	status := core.FormatUsageStatus(*usage, core.FormatUsageOptions{})
+	if !strings.Contains(status, "25%") || !strings.Contains(status, "250k") {
+		t.Fatalf("status %q does not reflect 250k / 1M", status)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -111,6 +111,34 @@ func formatSidebarProviderWith(
 	return agentName
 }
 
+// formatSidebarBillingTokens renders the sidebar's provider/limit pair after
+// billing identity and usage have been resolved. Subscription panes name the
+// quota provider and show its numerically shortest limit window. Pay-as-you-go
+// panes keep the resolved backend name and show backend-scoped session burn,
+// including USD only when the harness supplied a non-zero cost.
+func formatSidebarBillingTokens(
+	billingMode limits.BillingMode,
+	fallbackProviderText, displayProviderID string,
+	providerLimits *limits.ProviderLimits,
+	totalTokens, totalCostUSD float64,
+	nowMs int64,
+) (providerText, limitText string) {
+	providerText = fallbackProviderText
+	if billingMode != limits.BillingPayAsYouGo {
+		if billingMode == limits.BillingSubscription {
+			providerText = displayProviderID
+		}
+		if providerLimits != nil {
+			limitText = limits.FormatSidebarLimit(*providerLimits, nowMs)
+		}
+		return providerText, limitText
+	}
+	if billingMode == limits.BillingPayAsYouGo {
+		limitText = limits.FormatSidebarBurn(totalTokens, totalCostUSD)
+	}
+	return providerText, limitText
+}
+
 type metadataTokenWriter struct {
 	set   func(paneID, source, name, value string) bool
 	clear func(paneID, source, name string) bool
@@ -164,7 +192,6 @@ func RunUpdate(force bool) {
 
 	cwd := paneCwdForUpdate(pane)
 	nowMs := time.Now().UnixMilli()
-	limitText := ""
 	// Subscription limits only apply when the pane's session is billed against
 	// a subscription plan; a pay-as-you-go backend (API key, custom base_url)
 	// has no plan window to report against, so the row shows the pane's
@@ -193,19 +220,25 @@ func RunUpdate(force bool) {
 	billingMode := limits.PaneBillingMode(providerID, snapshot, limits.DefaultBillingDeps())
 	limitsProviderID := limits.SubscriptionLimitsProviderID(providerID, snapshot)
 	displayProviderID := limits.SubscriptionDisplayProviderID(providerID, snapshot)
+	var providerLimits *limits.ProviderLimits
+	var totalTokens, totalCostUSD float64
 	if billingMode == limits.BillingPayAsYouGo {
-		totalTokens, totalCostUSD := limits.PaneTotalUsage(providerID, snapshot, nowMs)
-		limitText = limits.FormatSidebarBurn(totalTokens, totalCostUSD)
+		totalTokens, totalCostUSD = limits.PaneTotalUsage(providerID, snapshot, nowMs)
 	} else {
 		collectOptions := limits.DefaultCollectOptions()
 		// Sidebar refresh deliberately collects only this pane's provider and leaves
 		// Attach nil, avoiding the heavier cross-pane activity aggregation path.
 		collectOptions.Only = map[string]bool{limitsProviderID: true}
-		providerLimits := limits.CollectAllProviderLimits(cwd, nowMs, collectOptions)
-		if len(providerLimits) > 0 {
-			limitText = limits.FormatSidebarLimit(providerLimits[0], nowMs)
+		collected := limits.CollectAllProviderLimits(cwd, nowMs, collectOptions)
+		if len(collected) > 0 {
+			providerLimits = &collected[0]
 		}
 	}
+	fallbackProviderText := formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot)
+	providerText, limitText := formatSidebarBillingTokens(
+		billingMode, fallbackProviderText, displayProviderID,
+		providerLimits, totalTokens, totalCostUSD, nowMs,
+	)
 
 	// With 2+ configured Claude accounts, the $limit row's job shifts from
 	// "show the limit" to "show which account this pane is" (joined with
@@ -227,10 +260,6 @@ func RunUpdate(force bool) {
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
-	providerText := formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot)
-	if billingMode == limits.BillingSubscription {
-		providerText = displayProviderID
-	}
 	writeMetadataToken(paneID, "provider", providerText, force)
 
 	// Context tokens: claude is read from its resolved profile's own transcript

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -158,6 +158,83 @@ func TestFormatSidebarProviderWith_OMPPiWithoutBackendRendersNothing(t *testing.
 	}
 }
 
+func TestSidebarSecondRowContract(t *testing.T) {
+	five, seven := 300, 10080
+	tests := []struct {
+		name                  string
+		mode                  limits.BillingMode
+		fallback, display     string
+		providerLimits        *limits.ProviderLimits
+		tokens, cost          float64
+		wantProvider, wantLim string
+	}{
+		{
+			name: "Claude subscription uses provider and shortest numeric window",
+			mode: limits.BillingSubscription, fallback: "claude", display: "claude",
+			providerLimits: &limits.ProviderLimits{
+				Primary:   &limits.LimitWindow{UsedPercentage: 66, WindowMinutes: &seven},
+				Secondary: &limits.LimitWindow{UsedPercentage: 13, WindowMinutes: &five},
+			},
+			wantProvider: "claude", wantLim: "5h 87%",
+		},
+		{
+			name: "routed harness subscription names billing provider",
+			mode: limits.BillingSubscription, fallback: "omp", display: "opencode-go",
+			providerLimits: &limits.ProviderLimits{
+				Primary: &limits.LimitWindow{UsedPercentage: 0, WindowMinutes: &five},
+			},
+			wantProvider: "opencode-go", wantLim: "5h 100%",
+		},
+		{
+			name: "Codex subscription keeps provider supplied seven day minimum",
+			mode: limits.BillingSubscription, fallback: "codex", display: "codex",
+			providerLimits: &limits.ProviderLimits{
+				Primary: &limits.LimitWindow{UsedPercentage: 67, WindowMinutes: &seven},
+			},
+			wantProvider: "codex", wantLim: "7d 33%",
+		},
+		{
+			name: "Grok subscription uses its seven day provider window",
+			mode: limits.BillingSubscription, fallback: "omp", display: "grok",
+			providerLimits: &limits.ProviderLimits{
+				Primary: &limits.LimitWindow{UsedPercentage: 86, WindowMinutes: &seven},
+			},
+			wantProvider: "grok", wantLim: "7d 14%",
+		},
+		{
+			name: "unknown billing preserves fail open subscription display",
+			mode: limits.BillingUnknown, fallback: "opencode", display: "",
+			providerLimits: &limits.ProviderLimits{
+				Primary: &limits.LimitWindow{UsedPercentage: 20, WindowMinutes: &five},
+			},
+			wantProvider: "opencode", wantLim: "5h 80%",
+		},
+		{
+			name: "token only API burn omits dollars",
+			mode: limits.BillingPayAsYouGo, fallback: "deepseek", display: "",
+			tokens:       425_000,
+			wantProvider: "deepseek", wantLim: "Σ 425k",
+		},
+		{
+			name: "cost capable harness includes dollars",
+			mode: limits.BillingPayAsYouGo, fallback: "deepseek", display: "",
+			tokens: 425_000, cost: 0.04,
+			wantProvider: "deepseek", wantLim: "Σ 425k $0.04",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerText, limitText := formatSidebarBillingTokens(
+				tt.mode, tt.fallback, tt.display, tt.providerLimits,
+				tt.tokens, tt.cost, 1_800_000_000_000,
+			)
+			if providerText != tt.wantProvider || limitText != tt.wantLim {
+				t.Fatalf("got provider=%q limit=%q, want provider=%q limit=%q", providerText, limitText, tt.wantProvider, tt.wantLim)
+			}
+		})
+	}
+}
+
 func TestResolveSidebarAccountLabel_PrefersEmailOverLabel(t *testing.T) {
 	dir := t.TempDir()
 	jsonPath := dir + "/.claude.json"


### PR DESCRIPTION
## Summary

- always keep the shortest available subscription window in the sidebar
- do not switch from 5h to 7d solely because the recorded 5h reset timestamp has passed
- leave freshness handling to provider collection instead of changing the displayed window

## Regression

Claude can briefly retain the previous 5h snapshot across its reset boundary. The sidebar previously skipped that window and displayed 7d, violating its shortest-window contract.

## Validation

- `go test ./...`
- `git diff --check`
- regression coverage for an expired 5h timestamp alongside an active 7d window