### PR TITLE
ci: Detect upstream harness and provider contract drift

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -1,6 +1,6 @@
-# Weekly audit trigger for upstream harness releases. A new version is not
-# assumed broken; it opens or updates one issue listing the local/session/auth/
-# billing contracts that must be reverified before advancing the baseline.
+# Weekly audit trigger for upstream harness releases and public provider limit
+# semantics. Drift is not assumed broken; it opens or updates one issue listing
+# the local/session/auth/billing contracts that must be reverified.
 name: Upstream contract drift
 
 on:
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Check supported harness releases
+      - name: Check harness releases and provider semantics
         id: check
         run: |
           go build -o "$RUNNER_TEMP/contractdrift" ./scripts/contractdrift
@@ -44,7 +44,7 @@ jobs:
         run: |
           gh label create upstream-contract-drift \
             --color D93F0B \
-            --description "Supported harness release requires contract revalidation" \
+            --description "Harness or provider contract requires revalidation" \
             --force
           existing="$(gh issue list --label upstream-contract-drift --state open --json number --jq '.[0].number')"
           if [ -n "$existing" ]; then
@@ -53,7 +53,7 @@ jobs:
           else
             gh issue create \
               --label upstream-contract-drift \
-              --title "Upstream harness contract drift detected" \
+              --title "Upstream contract drift detected" \
               --body-file report.md
           fi
 

--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -1,0 +1,68 @@
+# Weekly audit trigger for upstream harness releases. A new version is not
+# assumed broken; it opens or updates one issue listing the local/session/auth/
+# billing contracts that must be reverified before advancing the baseline.
+name: Upstream contract drift
+
+on:
+  schedule:
+    - cron: "20 6 * * 1" # Mondays 06:20 UTC (15:20 JST)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.25"
+
+      - name: Check supported harness releases
+        id: check
+        run: |
+          go build -o "$RUNNER_TEMP/contractdrift" ./scripts/contractdrift
+          set +e
+          "$RUNNER_TEMP/contractdrift" > report.md
+          code=$?
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" -eq 1 ]; then
+            echo "::error::contract-drift checker failed; no drift conclusion can be drawn"
+            exit 1
+          fi
+          cat report.md
+
+      - name: Open or update drift issue
+        if: steps.check.outputs.code == '2'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create upstream-contract-drift \
+            --color D93F0B \
+            --description "Supported harness release requires contract revalidation" \
+            --force
+          existing="$(gh issue list --label upstream-contract-drift --state open --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file report.md
+            echo "Updated existing drift issue #$existing"
+          else
+            gh issue create \
+              --label upstream-contract-drift \
+              --title "Upstream harness contract drift detected" \
+              --body-file report.md
+          fi
+
+      - name: Close resolved drift issue
+        if: steps.check.outputs.code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing="$(gh issue list --label upstream-contract-drift --state open --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "All supported harness releases now match the tested contract baselines. Closing automatically."
+          fi

--- a/.github/workflows/model-drift.yml
+++ b/.github/workflows/model-drift.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Check for model-window drift
         id: check
         run: |
+          go build -o "$RUNNER_TEMP/modeldrift" ./scripts/modeldrift
           set +e
-          go run ./scripts/modeldrift > report.md
+          "$RUNNER_TEMP/modeldrift" > report.md
           code=$?
           set -e
           echo "code=$code" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,29 @@ The script waits for CI on that exact commit before it creates and pushes the
 tag. The tag-triggered Release workflow repeats vet, build, test, formatting,
 lint, and vulnerability checks before it creates a GitHub Release.
 
+## Upstream drift monitoring
+
+Agent Usage reads implementation details owned by the supported harnesses:
+session JSONL, SQLite schemas, auth credential kinds, model catalogs, and
+subscription-limit response shapes. Those are contracts in practice, but they
+are not stable APIs.
+
+Two scheduled workflows keep those dependencies visible:
+
+- **Model drift** compares the Claude context-window resolver with LiteLLM's
+  model catalog.
+- **Upstream contract drift** compares the latest official npm releases of
+  Claude Code, Codex CLI, OpenCode, Grok Build, OMP, and Pi with the versions
+  recorded in `scripts/contractdrift/contracts.json`.
+
+A harness version difference opens or updates one audit issue. It does not
+claim the plugin is broken. The issue lists the exact local/session/auth/limit
+contracts to recheck. After running the sanitized fixture tests and an
+authenticated live-pane smoke test, update the implementation if necessary or
+advance that harness's `testedVersion`. Provider responses that require a real
+subscription cannot be safely exercised by public CI, so the live smoke step
+remains mandatory before advancing those baselines.
+
 ## Data handling
 
 Everything is computed from files that the agents already keep on your machine:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,13 @@ Two scheduled workflows keep those dependencies visible:
   model catalog.
 - **Upstream contract drift** compares the latest official npm releases of
   Claude Code, Codex CLI, OpenCode, Grok Build, OMP, and Pi with the versions
-  recorded in `scripts/contractdrift/contracts.json`.
+  recorded in `scripts/contractdrift/contracts.json`. It also checks the
+  provider-owned limit semantics recorded in
+  `scripts/contractdrift/provider-contracts.json` against official Claude,
+  Codex, OpenCode Go, and Grok pages. These semantic checks cover the concepts
+  the implementation depends on (window units, used/left meaning, shared
+  provider ownership, and subscription/API separation), not brittle whole-page
+  hashes.
 
 A harness version difference opens or updates one audit issue. It does not
 claim the plugin is broken. The issue lists the exact local/session/auth/limit
@@ -260,6 +266,13 @@ authenticated live-pane smoke test, update the implementation if necessary or
 advance that harness's `testedVersion`. Provider responses that require a real
 subscription cannot be safely exercised by public CI, so the live smoke step
 remains mandatory before advancing those baselines.
+
+There are therefore three drift gates: a harness release signal, public
+provider-semantic assertions, and an authenticated live response check. The
+last gate is intentionally manual because CI must not contain personal
+subscription credentials. In particular, OpenCode Go's unauthenticated local
+fallback currently assumes fixed 5h / 7d / 30d USD caps; those constants must
+be revalidated whenever the published Go quota model changes.
 
 ## Data handling
 

--- a/scripts/contractdrift/contracts.json
+++ b/scripts/contractdrift/contracts.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "claude",
+    "label": "Claude Code",
+    "package": "@anthropic-ai/claude-code",
+    "testedVersion": "2.1.218",
+    "contracts": [
+      "assistant transcript message model and usage fields",
+      "~/.claude.json cachedUsageUtilization and oauthAccount fields",
+      "statusLine rate_limits five_hour and seven_day fields"
+    ]
+  },
+  {
+    "id": "codex",
+    "label": "Codex CLI",
+    "package": "@openai/codex",
+    "testedVersion": "0.145.0",
+    "contracts": [
+      "rollout event_msg token_count and model_context_window fields",
+      "rollout rate_limits primary secondary plan_type fields",
+      "session_meta model_provider billing identity"
+    ]
+  },
+  {
+    "id": "opencode",
+    "label": "OpenCode",
+    "package": "opencode-ai",
+    "testedVersion": "1.17.15",
+    "contracts": [
+      "opencode.db session and message tables plus message JSON fields",
+      "auth.json credential type fields",
+      "models catalog provider model limit.context fields"
+    ]
+  },
+  {
+    "id": "grok",
+    "label": "Grok Build",
+    "package": "@xai-official/grok",
+    "testedVersion": "0.2.111",
+    "contracts": [
+      "signals.json contextTokensUsed and contextWindowTokens fields",
+      "auth.json auth mode and access token fields",
+      "config.toml custom model endpoint fields",
+      "Grok credits and subscription response shapes"
+    ]
+  },
+  {
+    "id": "omp",
+    "label": "OMP",
+    "package": "@oh-my-pi/pi-coding-agent",
+    "testedVersion": "17.0.7",
+    "contracts": [
+      "assistant JSONL provider model contextSnapshot usage cost and timestamp fields",
+      "session directory and agent_session path conventions",
+      "models.db model_cache schema",
+      "agent.db auth_credentials credential_type schema"
+    ]
+  },
+  {
+    "id": "pi",
+    "label": "Pi coding agent",
+    "package": "@earendil-works/pi-coding-agent",
+    "testedVersion": "0.81.1",
+    "contracts": [
+      "assistant JSONL provider model contextSnapshot usage cost and timestamp fields",
+      "session directory and agent_session path conventions",
+      "models.db model_cache schema when present",
+      "auth.json credential type fields"
+    ]
+  }
+]

--- a/scripts/contractdrift/main.go
+++ b/scripts/contractdrift/main.go
@@ -1,0 +1,138 @@
+/**
+ * Reports supported harness releases newer than the versions whose local
+ * storage and billing contracts this repository has explicitly verified.
+ *
+ * A version change is an audit signal, not proof of breakage. The report names
+ * every external contract that must be rechecked before advancing the tested
+ * baseline. Fixture tests cover known shapes; this checker prevents a new
+ * upstream release from passing unnoticed.
+ *
+ * Exit codes (consumed by .github/workflows/contract-drift.yml):
+ *   0  every latest npm release matches its tested baseline
+ *   1  checker failure (network, manifest, or registry parse error)
+ *   2  one or more upstream versions differ from the tested baseline
+ */
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+//go:embed contracts.json
+var contractsJSON []byte
+
+const defaultRegistryURL = "https://registry.npmjs.org"
+
+type upstreamContract struct {
+	ID            string   `json:"id"`
+	Label         string   `json:"label"`
+	Package       string   `json:"package"`
+	TestedVersion string   `json:"testedVersion"`
+	Contracts     []string `json:"contracts"`
+}
+
+type drift struct {
+	Contract upstreamContract
+	Latest   string
+}
+
+func main() {
+	var contracts []upstreamContract
+	if err := json.Unmarshal(contractsJSON, &contracts); err != nil {
+		fmt.Fprintf(os.Stderr, "contract-drift: invalid manifest: %v\n", err)
+		os.Exit(1)
+	}
+	registryURL := strings.TrimRight(os.Getenv("NPM_REGISTRY_URL"), "/")
+	if registryURL == "" {
+		registryURL = defaultRegistryURL
+	}
+	drifts, err := check(&http.Client{Timeout: 30 * time.Second}, registryURL, contracts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "contract-drift: checker failed: %v\n", err)
+		os.Exit(1)
+	}
+	if len(drifts) == 0 {
+		fmt.Println("No upstream contract drift: all supported harness releases match their tested baselines.")
+		return
+	}
+	fmt.Print(report(drifts))
+	os.Exit(2)
+}
+
+func check(client *http.Client, registryURL string, contracts []upstreamContract) ([]drift, error) {
+	seen := make(map[string]bool, len(contracts))
+	var drifts []drift
+	for _, contract := range contracts {
+		if contract.ID == "" || contract.Label == "" || contract.Package == "" || contract.TestedVersion == "" || len(contract.Contracts) == 0 {
+			return nil, fmt.Errorf("incomplete contract manifest entry: %#v", contract)
+		}
+		if seen[contract.ID] {
+			return nil, fmt.Errorf("duplicate contract id %q", contract.ID)
+		}
+		seen[contract.ID] = true
+		latest, err := fetchLatest(client, registryURL, contract.Package)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", contract.ID, err)
+		}
+		if latest != contract.TestedVersion {
+			drifts = append(drifts, drift{Contract: contract, Latest: latest})
+		}
+	}
+	sort.Slice(drifts, func(i, j int) bool { return drifts[i].Contract.ID < drifts[j].Contract.ID })
+	return drifts, nil
+}
+
+func fetchLatest(client *http.Client, registryURL, packageName string) (string, error) {
+	endpoint := registryURL + "/" + url.PathEscape(packageName) + "/latest"
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: status %d", endpoint, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var payload struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("parse %s: %w", endpoint, err)
+	}
+	if payload.Version == "" {
+		return "", fmt.Errorf("%s returned no version", endpoint)
+	}
+	return payload.Version, nil
+}
+
+func report(drifts []drift) string {
+	var b strings.Builder
+	b.WriteString("## Upstream harness contract drift detected\n\n")
+	b.WriteString("A newer (or otherwise different) official harness release exists than the version whose local storage and billing contracts this repository has verified. A version difference is an audit signal, not proof that Agent Usage is broken.\n\n")
+	for _, d := range drifts {
+		fmt.Fprintf(&b, "### %s (`%s`)\n\n", d.Contract.Label, d.Contract.Package)
+		fmt.Fprintf(&b, "- Tested: `%s`\n- Latest: `%s`\n- Contracts to recheck:\n", d.Contract.TestedVersion, d.Latest)
+		for _, contract := range d.Contract.Contracts {
+			fmt.Fprintf(&b, "  - %s\n", contract)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("### Required follow-up\n\n")
+	b.WriteString("- Run the repository contract tests against sanitized artifacts produced by each new harness version.\n")
+	b.WriteString("- Verify subscription/API routing and every limit window on a real authenticated pane where public fixtures cannot cover the provider response.\n")
+	b.WriteString("- Update parser fixtures and implementation if shapes changed; otherwise advance `testedVersion` in `scripts/contractdrift/contracts.json`.\n\n")
+	b.WriteString("---\n_Automatically opened or updated by the weekly upstream-contract drift workflow._\n")
+	return b.String()
+}

--- a/scripts/contractdrift/main.go
+++ b/scripts/contractdrift/main.go
@@ -1,6 +1,6 @@
 /**
- * Reports supported harness releases newer than the versions whose local
- * storage and billing contracts this repository has explicitly verified.
+ * Reports supported harness releases and public provider limit semantics that
+ * differ from the contracts this repository has explicitly verified.
  *
  * A version change is an audit signal, not proof of breakage. The report names
  * every external contract that must be rechecked before advancing the tested
@@ -18,10 +18,12 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -29,6 +31,11 @@ import (
 
 //go:embed contracts.json
 var contractsJSON []byte
+
+//go:embed provider-contracts.json
+var providerContractsJSON []byte
+
+var htmlTagRE = regexp.MustCompile(`<[^>]+>`)
 
 const defaultRegistryURL = "https://registry.npmjs.org"
 
@@ -45,10 +52,28 @@ type drift struct {
 	Latest   string
 }
 
+type publicContract struct {
+	ID           string   `json:"id"`
+	Label        string   `json:"label"`
+	URL          string   `json:"url"`
+	RequiredText []string `json:"requiredText"`
+	Contracts    []string `json:"contracts"`
+}
+
+type publicDrift struct {
+	Contract publicContract
+	Missing  []string
+}
+
 func main() {
 	var contracts []upstreamContract
 	if err := json.Unmarshal(contractsJSON, &contracts); err != nil {
 		fmt.Fprintf(os.Stderr, "contract-drift: invalid manifest: %v\n", err)
+		os.Exit(1)
+	}
+	var publicContracts []publicContract
+	if err := json.Unmarshal(providerContractsJSON, &publicContracts); err != nil {
+		fmt.Fprintf(os.Stderr, "contract-drift: invalid provider manifest: %v\n", err)
 		os.Exit(1)
 	}
 	registryURL := strings.TrimRight(os.Getenv("NPM_REGISTRY_URL"), "/")
@@ -60,11 +85,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "contract-drift: checker failed: %v\n", err)
 		os.Exit(1)
 	}
-	if len(drifts) == 0 {
-		fmt.Println("No upstream contract drift: all supported harness releases match their tested baselines.")
+	publicDrifts, err := checkPublicContracts(&http.Client{Timeout: 30 * time.Second}, publicContracts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "contract-drift: provider checker failed: %v\n", err)
+		os.Exit(1)
+	}
+	if len(drifts) == 0 && len(publicDrifts) == 0 {
+		fmt.Println("No upstream contract drift: harness releases and public provider semantics match their tested baselines.")
 		return
 	}
-	fmt.Print(report(drifts))
+	fmt.Print(report(drifts, publicDrifts))
 	os.Exit(2)
 }
 
@@ -117,10 +147,70 @@ func fetchLatest(client *http.Client, registryURL, packageName string) (string, 
 	return payload.Version, nil
 }
 
-func report(drifts []drift) string {
+func checkPublicContracts(client *http.Client, contracts []publicContract) ([]publicDrift, error) {
+	seen := make(map[string]bool, len(contracts))
+	var drifts []publicDrift
+	for _, contract := range contracts {
+		if contract.ID == "" || contract.Label == "" || contract.URL == "" || len(contract.RequiredText) == 0 || len(contract.Contracts) == 0 {
+			return nil, fmt.Errorf("incomplete provider contract manifest entry: %#v", contract)
+		}
+		if seen[contract.ID] {
+			return nil, fmt.Errorf("duplicate provider contract id %q", contract.ID)
+		}
+		seen[contract.ID] = true
+		body, err := fetchText(client, contract.URL)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", contract.ID, err)
+		}
+		normalized := normalizeText(body)
+		var missing []string
+		for _, required := range contract.RequiredText {
+			if !strings.Contains(normalized, normalizeText(required)) {
+				missing = append(missing, required)
+			}
+		}
+		if len(missing) > 0 {
+			drifts = append(drifts, publicDrift{Contract: contract, Missing: missing})
+		}
+	}
+	sort.Slice(drifts, func(i, j int) bool { return drifts[i].Contract.ID < drifts[j].Contract.ID })
+	return drifts, nil
+}
+
+func fetchText(client *http.Client, endpoint string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "herdr-agent-usage-contract-drift/1")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: status %d", endpoint, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func normalizeText(value string) string {
+	value = html.UnescapeString(value)
+	value = htmlTagRE.ReplaceAllString(value, " ")
+	return strings.ToLower(strings.Join(strings.Fields(value), " "))
+}
+
+func report(drifts []drift, publicDrifts []publicDrift) string {
 	var b strings.Builder
-	b.WriteString("## Upstream harness contract drift detected\n\n")
-	b.WriteString("A newer (or otherwise different) official harness release exists than the version whose local storage and billing contracts this repository has verified. A version difference is an audit signal, not proof that Agent Usage is broken.\n\n")
+	b.WriteString("## Upstream contract drift detected\n\n")
+	b.WriteString("A supported harness release or public provider semantic contract differs from the baseline this repository has verified. This is an audit signal, not proof that Agent Usage is broken.\n\n")
+	if len(drifts) > 0 {
+		b.WriteString("## Harness releases\n\n")
+	}
 	for _, d := range drifts {
 		fmt.Fprintf(&b, "### %s (`%s`)\n\n", d.Contract.Label, d.Contract.Package)
 		fmt.Fprintf(&b, "- Tested: `%s`\n- Latest: `%s`\n- Contracts to recheck:\n", d.Contract.TestedVersion, d.Latest)
@@ -129,10 +219,26 @@ func report(drifts []drift) string {
 		}
 		b.WriteString("\n")
 	}
+	if len(publicDrifts) > 0 {
+		b.WriteString("## Public provider semantics\n\n")
+	}
+	for _, d := range publicDrifts {
+		fmt.Fprintf(&b, "### %s\n\n", d.Contract.Label)
+		fmt.Fprintf(&b, "- Source: %s\n- Expected text no longer found:\n", d.Contract.URL)
+		for _, missing := range d.Missing {
+			fmt.Fprintf(&b, "  - `%s`\n", missing)
+		}
+		b.WriteString("- Contracts to recheck:\n")
+		for _, contract := range d.Contract.Contracts {
+			fmt.Fprintf(&b, "  - %s\n", contract)
+		}
+		b.WriteString("\n")
+	}
 	b.WriteString("### Required follow-up\n\n")
 	b.WriteString("- Run the repository contract tests against sanitized artifacts produced by each new harness version.\n")
+	b.WriteString("- Compare provider documentation changes with the collector's window units, used/left semantics, reset handling, and subscription/API routing.\n")
 	b.WriteString("- Verify subscription/API routing and every limit window on a real authenticated pane where public fixtures cannot cover the provider response.\n")
-	b.WriteString("- Update parser fixtures and implementation if shapes changed; otherwise advance `testedVersion` in `scripts/contractdrift/contracts.json`.\n\n")
+	b.WriteString("- Update parser fixtures and implementation if shapes changed; otherwise advance the relevant baseline manifest.\n\n")
 	b.WriteString("---\n_Automatically opened or updated by the weekly upstream-contract drift workflow._\n")
 	return b.String()
 }

--- a/scripts/contractdrift/main_test.go
+++ b/scripts/contractdrift/main_test.go
@@ -44,11 +44,54 @@ func TestCheckCleanAndDrift(t *testing.T) {
 	if len(drifts) != 1 || drifts[0].Contract.ID != "b" || drifts[0].Latest != "2.1.0" {
 		t.Fatalf("drifts = %#v", drifts)
 	}
-	out := report(drifts)
-	for _, want := range []string{"Upstream harness contract drift", "Tested: `2.0.0`", "Latest: `2.1.0`", "limit schema", "real authenticated pane"} {
+	out := report(drifts, nil)
+	for _, want := range []string{"Upstream contract drift", "Harness releases", "Tested: `2.0.0`", "Latest: `2.1.0`", "limit schema", "real authenticated pane"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+func TestCheckPublicContractsCleanAndDrift(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/clean":
+			return response(http.StatusOK, "<p>Shared WEEKLY usage&nbsp;pool resets every week</p>"), nil
+		case "/drift":
+			return response(http.StatusOK, "<p>A new quota system</p>"), nil
+		default:
+			return response(http.StatusNotFound, "nope"), nil
+		}
+	})}
+	contracts := []publicContract{
+		{ID: "a", Label: "A", URL: "https://docs.test/clean", RequiredText: []string{"shared weekly usage pool", "resets every week"}, Contracts: []string{"weekly reset"}},
+		{ID: "b", Label: "B", URL: "https://docs.test/drift", RequiredText: []string{"five hour"}, Contracts: []string{"shortest window"}},
+	}
+	drifts, err := checkPublicContracts(client, contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drifts) != 1 || drifts[0].Contract.ID != "b" || len(drifts[0].Missing) != 1 {
+		t.Fatalf("drifts = %#v", drifts)
+	}
+	out := report(nil, drifts)
+	for _, want := range []string{"Public provider semantics", "https://docs.test/drift", "`five hour`", "shortest window"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestCheckPublicContractsRejectsManifestAndHTTPError(t *testing.T) {
+	if _, err := checkPublicContracts(&http.Client{}, []publicContract{{ID: "a"}}); err == nil {
+		t.Fatal("expected incomplete manifest error")
+	}
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return response(http.StatusBadGateway, "nope"), nil
+	})}
+	contracts := []publicContract{{ID: "a", Label: "A", URL: "https://docs.test/a", RequiredText: []string{"x"}, Contracts: []string{"y"}}}
+	if _, err := checkPublicContracts(client, contracts); err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("expected provider status error, got %v", err)
 	}
 }
 

--- a/scripts/contractdrift/main_test.go
+++ b/scripts/contractdrift/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func registryClient(t *testing.T, versions map[string]string) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		name, err := url.PathUnescape(strings.TrimSuffix(strings.TrimPrefix(req.URL.EscapedPath(), "/"), "/latest"))
+		if err != nil {
+			return nil, err
+		}
+		version, ok := versions[name]
+		if !ok {
+			return response(http.StatusNotFound, `{"error":"not found"}`), nil
+		}
+		return response(http.StatusOK, `{"version":"`+version+`"}`), nil
+	})}
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+}
+
+func TestCheckCleanAndDrift(t *testing.T) {
+	contracts := []upstreamContract{
+		{ID: "a", Label: "A", Package: "@scope/a", TestedVersion: "1.0.0", Contracts: []string{"session schema"}},
+		{ID: "b", Label: "B", Package: "b", TestedVersion: "2.0.0", Contracts: []string{"limit schema"}},
+	}
+	client := registryClient(t, map[string]string{"@scope/a": "1.0.0", "b": "2.1.0"})
+	drifts, err := check(client, "https://registry.test", contracts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drifts) != 1 || drifts[0].Contract.ID != "b" || drifts[0].Latest != "2.1.0" {
+		t.Fatalf("drifts = %#v", drifts)
+	}
+	out := report(drifts)
+	for _, want := range []string{"Upstream harness contract drift", "Tested: `2.0.0`", "Latest: `2.1.0`", "limit schema", "real authenticated pane"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestCheckRejectsIncompleteAndDuplicateManifest(t *testing.T) {
+	client := &http.Client{}
+	if _, err := check(client, "http://unused", []upstreamContract{{ID: "a"}}); err == nil {
+		t.Fatal("expected incomplete manifest error")
+	}
+	contracts := []upstreamContract{
+		{ID: "a", Label: "A", Package: "a", TestedVersion: "1", Contracts: []string{"x"}},
+		{ID: "a", Label: "B", Package: "b", TestedVersion: "1", Contracts: []string{"y"}},
+	}
+	client = registryClient(t, map[string]string{"a": "1"})
+	if _, err := check(client, "https://registry.test", contracts); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+}
+
+func TestCheckFailsOnRegistryError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return response(http.StatusBadGateway, "nope"), nil
+	})}
+	contracts := []upstreamContract{{ID: "a", Label: "A", Package: "a", TestedVersion: "1", Contracts: []string{"x"}}}
+	if _, err := check(client, "https://registry.test", contracts); err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("expected registry status error, got %v", err)
+	}
+}

--- a/scripts/contractdrift/provider-contracts.json
+++ b/scripts/contractdrift/provider-contracts.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "claude",
+    "label": "Claude subscription limits",
+    "url": "https://support.anthropic.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan",
+    "requiredText": [
+      "shared across claude and claude code",
+      "every 5 hours",
+      "api credits"
+    ],
+    "contracts": [
+      "subscription usage is shared by Claude and Claude Code",
+      "the shortest documented subscription window remains five hours",
+      "subscription allowance and pay-as-you-go API credits remain distinct"
+    ]
+  },
+  {
+    "id": "codex",
+    "label": "Codex subscription limits",
+    "url": "https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan",
+    "requiredText": [
+      "usage limits vary by plan",
+      "codex limit",
+      "credits"
+    ],
+    "contracts": [
+      "Codex subscription limits remain plan-owned rather than API rate limits",
+      "the provider can expose remaining allowance and reset behavior",
+      "included subscription usage and additional credits remain distinguishable"
+    ]
+  },
+  {
+    "id": "opencode-go",
+    "label": "OpenCode Go limits",
+    "url": "https://dev.opencode.ai/go",
+    "requiredText": [
+      "requests per 5 hour",
+      "use with any agent",
+      "subscription"
+    ],
+    "contracts": [
+      "the documented shortest window remains five hours",
+      "OpenCode Go remains a provider subscription usable from multiple harnesses",
+      "local fallback caps and windows must be revalidated whenever the published quota model changes"
+    ]
+  },
+  {
+    "id": "grok",
+    "label": "SuperGrok limits",
+    "url": "https://docs.x.ai/grok/faq",
+    "requiredText": [
+      "shared weekly usage pool",
+      "percentage used",
+      "resets every week"
+    ],
+    "contracts": [
+      "SuperGrok remains one provider-owned weekly pool shared across products",
+      "the reported percentage is used percentage and must be converted to percent left for display",
+      "the provider continues to expose a weekly reset schedule"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- record verified implementation contracts for Claude Code, Codex, OpenCode, Grok Build, OMP, and Pi
- run a weekly official-package version audit for harness-owned storage, auth, model, and billing shapes
- check provider-owned limit semantics against official Claude, Codex, OpenCode Go, and Grok pages without brittle whole-page hashes
- open or update one actionable drift issue, and close it after every baseline is revalidated
- fix the existing model-drift workflow so exit code 2 survives execution instead of being collapsed by go run
- document the three gates: public fixtures, provider semantic assertions, and authenticated live-pane verification

## Currently detected

Harness releases:

- OpenCode: 1.17.15 -> 1.18.4
- OMP: 17.0.7 -> 17.1.1
- Pi: 0.81.1 -> 0.82.0

Provider semantics:

- the current Claude subscription help page no longer documents the five-hour window; the CLI statusLine contract and shortest-window behavior therefore require revalidation

A difference is treated as an audit signal, not proof of breakage. OpenCode Go, Codex, and Grok public semantic checks currently pass.

## Validation

- go test ./... -count=1
- go vet ./...
- gofmt, JSON parse, YAML parse, and git diff --check
- live official-registry and provider-page run returns exit 2 and reports only the three release drifts plus the Claude semantic drift