### PR TITLE
chore: Release v0.5.1

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.0"
+version = "0.5.1"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
## Summary

- bump the plugin manifest version from 0.5.0 to 0.5.1 for the merged sidebar shortest-window fix and upstream contract-drift monitoring

## Validation

- go test ./... -count=1
- go vet ./...
- git diff --check