### PR TITLE
fix: Read OpenCode Go usage from opencode.ai by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ herdr plugin action invoke usagebar.setup
 | --- | --- | --- | --- |
 | Claude Code | Yes | Yes | Subscription windows from `~/.claude.json` / statusLine cache. Pay-as-you-go (API key, Bedrock, Vertex, Foundry, gateway) hides those windows and labels the backend from deployment env / settings |
 | Codex | Yes | Yes | Context + rate windows from local rollouts; custom `model_provider` panes are pay-as-you-go |
-| OpenCode | Yes | Yes | The `opencode-go` subscription uses official web usage when `OPENCODE_GO_COOKIE` is set, else local SQLite. Other backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
+| OpenCode | Yes | Yes | The `opencode-go` subscription keeps no usage numbers on disk, so its windows come from opencode.ai, authenticated by `OPENCODE_GO_COOKIE` or a browser session imported via the Keychain ([details](#opencode-go-official-usage)); without either it degrades to a local SQLite estimate. Other backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
 | Grok | Yes | Yes | Context from `signals.json`; SuperGrok credits when auth is present. Custom models (`~/.grok/config.toml` `[model.*]` with `base_url`) are pay-as-you-go and labelled from the endpoint host (openai, ollama, …) |
 | OMP (Oh My Pi) | Yes | Yes | Session jsonl plus its credential metadata. Subscription routes: OpenCode Go, Grok OAuth, Anthropic OAuth → Claude, and OpenAI Codex OAuth → Codex. API-key backends show backend-scoped session burn |
 | Pi coding agent | Yes | Yes | Session jsonl plus `~/.pi/agent/auth.json`; uses the same recognized OAuth/subscription routes and pay-as-you-go rules as OMP |
@@ -196,15 +196,77 @@ position = "bottom-left"
 
 `usagebar.enable-toast` **appends only when `[ui.toast]` is missing**. Existing toast settings are left alone.
 
-### OpenCode Go official usage (optional)
+### OpenCode Go official usage
 
-Set the Cookie request header if you want web-backed numbers from the OpenCode console:
+**OpenCode Go is the only supported subscription with no local source of usage
+truth, which is why it — and only it — needs the Keychain step below.**
+
+Every other provider's harness writes the server's own limit numbers to disk,
+so this plugin just reads them back:
+
+| provider | local source of truth |
+| --- | --- |
+| Claude | `~/.claude.json` `cachedUsageUtilization` (+ statusLine cache) |
+| Codex | `rate_limits` inside `event_msg` / `token_count` in the rollout jsonl |
+| Grok | agent stdio / `x.ai` billing |
+| **OpenCode Go** | **none** |
+
+`opencode.db` has no usage table at all, its `account` table is empty (auth is
+an API key in `auth.json`), and the OpenCode CLI never persists limit state.
+There is nothing on the machine to read. So the official 5h / 7d / 30d
+percentages can only come from opencode.ai over the network, and that request
+has to be authenticated — hence a browser session, and hence the Keychain,
+which is where the browser keeps the key to its own cookies.
+
+Anything else for this provider is an estimate, and an estimate cannot be made
+correct here: the amounts recorded locally are list-price arithmetic, not what
+opencode-go bills against the plan, and no set of caps reproduces the published
+percentages across all three windows.
+
+Two ways to authenticate that fetch, tried in this order:
+
+1. `OPENCODE_GO_COOKIE` — an explicit Cookie request header, which always wins:
+
+   ```bash
+   export OPENCODE_GO_COOKIE='auth=…'
+   ```
+
+2. **A local browser session**, imported automatically — the zero-setup path,
+   and the reason the Keychain is involved. If you are signed in to opencode.ai
+   in Chrome, Arc, Brave, Edge, or Chromium, the plugin reads that profile's
+   cookie for `opencode.ai` and reuses it. Chromium stores cookie values
+   encrypted, with the key held in the login Keychain as
+   `<Browser> Safe Storage`, so reading the cookie means reading that one
+   Keychain item:
+
+   - macOS asks for access the first time. Choose *Always Allow* to keep later
+     refreshes silent.
+   - The Keychain is only consulted for a profile that actually has an
+     opencode.ai cookie, so browsers where you are not signed in never raise a
+     prompt.
+   - The cookie database is opened read-only (`immutable=1`); nothing is ever
+     written back to the browser.
+   - The cookie itself is never persisted by this plugin. Only the resolved
+     usage snapshot is cached (2 min; 10 min after a fetch failure, 30 s when no
+     session was found so a fresh sign-in takes effect promptly).
+   - Opt out entirely with `USAGEBAR_DISABLE_BROWSER_COOKIES=1`, and use option
+     1 instead if you would rather paste a header than grant Keychain access.
+
+Without either, usage falls back to an estimate from local
+`~/.local/share/opencode/opencode.db` (5h rolling, UTC week, calendar month),
+labeled `est.` in the panel note. Be aware that this estimate only sees spend
+recorded by the OpenCode CLI itself: sessions billed to the same subscription
+through another harness (OMP / Pi) are not in that database, so a pane can look
+idle while the real window is nearly full.
+
+To see which stage is working:
 
 ```bash
-export OPENCODE_GO_COOKIE='auth=…'
+usagebar opencode-check
 ```
 
-Without it, usage is estimated from local `~/.local/share/opencode/opencode.db` (5h rolling, UTC week, calendar month).
+It prints the browser profiles found, which profile supplied the session (cookie
+names only, never values), and the fetched windows.
 
 ### Claude statusLine (optional)
 
@@ -282,7 +344,7 @@ Everything is computed from files that the agents already keep on your machine:
 | --- | --- |
 | Claude Code | `~/.claude.json`, statusLine cache under `~/.claude/herdr-usagebar/`, `settings.json` (deployment env) |
 | Codex | rollout files under `~/.codex/sessions/` |
-| OpenCode | `~/.local/share/opencode/opencode.db` (session usage), `~/.local/share/opencode/auth.json` (credential kind only) |
+| OpenCode | `~/.local/share/opencode/opencode.db` (session usage), `~/.local/share/opencode/auth.json` (credential kind only), and — for OpenCode Go's official windows — the `opencode.ai` cookie in a local Chromium profile plus that browser's Keychain "Safe Storage" password (read-only, never persisted; see [OpenCode Go official usage](#opencode-go-official-usage)) |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch), `~/.grok/config.toml` (custom-model base URLs) |
 | OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup), `~/.omp/agent/agent.db` (credential kind only) |
 | Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present, `~/.pi/agent/auth.json` (credential kind only) |
@@ -290,7 +352,9 @@ Everything is computed from files that the agents already keep on your machine:
 Pay-as-you-go detection is not tied to any one harness: it reads the same
 per-harness files above (the backend a session used is already recorded there —
 OpenCode's `providerID`, Codex's `model_provider`, Claude's deployment env,
-Grok's `config.toml`, OMP/Pi `message.provider`). No extra data sources, no network calls.
+Grok's `config.toml`, OMP/Pi `message.provider`). No extra data sources; the
+only network calls are the authenticated provider usage fetches (Grok credits,
+OpenCode Go usage), and each one is skipped when its credential is absent.
 
 ### Harness and billing identity
 
@@ -326,7 +390,7 @@ and usage observations.
 
 Network requests happen in the following cases:
 
-- `opencode.ai` — only when you set `OPENCODE_GO_COOKIE`
+- `opencode.ai` — only when a session is available: `OPENCODE_GO_COOKIE`, or an `opencode.ai` cookie in a local Chromium profile. Results are cached for 2 minutes (10 after a failure), so a sidebar refresh does not mean a request. Disable with `USAGEBAR_DISABLE_BROWSER_COOKIES=1`
 - `grok.com` — only when `~/.grok/auth.json` exists (you ran `grok login`)
 - `api.github.com` — on the first pane focus and then at most once every 24 hours, to check this plugin's latest public release. The request has no credentials and sends no usage or session data.
 

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -63,6 +63,9 @@ func main() {
 	case "collect":
 		// debug: print JSON of collected limits once
 		runCollectJSON(args)
+	case "opencode-check":
+		// debug: report each stage of the OpenCode Go usage path
+		runOpenCodeCheck()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
 		printUsage(os.Stderr)
@@ -85,6 +88,8 @@ Usage:
   usagebar statusline                Claude Code statusLine (stdin rate_limits)
   usagebar setup [--write-toast]     Seed plugin config / show snippets
   usagebar collect                   Debug: print collected limits as JSON
+  usagebar opencode-check            Debug: report the OpenCode Go usage path
+                                     (browser session import → opencode.ai fetch)
   usagebar version
 
 `)
@@ -499,6 +504,57 @@ func printStatusLineSummary(stdinJSON string) {
 	if summary != "" {
 		fmt.Println(summary)
 	}
+}
+
+// runOpenCodeCheck reports each stage of the OpenCode Go usage path so a
+// failure can be attributed to the browser session or to the fetch, without
+// printing any cookie value.
+func runOpenCodeCheck() {
+	nowMs := time.Now().UnixMilli()
+	cookie := ""
+
+	if env := strings.TrimSpace(os.Getenv("OPENCODE_GO_COOKIE")); env != "" {
+		cookie = env
+		fmt.Println("cookie: OPENCODE_GO_COOKIE is set (browser import skipped)")
+	} else {
+		imported, probes, ok := limits.ImportBrowserCookieHeaderWithProbes(limits.OpenCodeCookieDomain, nowMs)
+		fmt.Printf("browser profiles probed: %d\n", len(probes))
+		for _, p := range probes {
+			switch {
+			case p.Rows == 0:
+				fmt.Printf("  - %s / %s: no %s cookies\n", p.Browser, p.Profile, limits.OpenCodeCookieDomain)
+			case !p.KeychainOK:
+				fmt.Printf("  - %s / %s: %d cookies, but the Keychain password was unavailable"+
+					" (access denied, or the Safe Storage item is named differently)\n", p.Browser, p.Profile, p.Rows)
+			case p.Decrypted == 0:
+				fmt.Printf("  - %s / %s: %d cookies, none decrypted (unexpected encryption scheme)\n", p.Browser, p.Profile, p.Rows)
+			default:
+				fmt.Printf("  - %s / %s: %d cookies, %d decrypted\n", p.Browser, p.Profile, p.Rows, p.Decrypted)
+			}
+		}
+		if !ok {
+			fmt.Printf("cookie: no %s session imported\n", limits.OpenCodeCookieDomain)
+			fmt.Println("        sign in to opencode.ai in Chrome/Arc, allow Keychain access when macOS asks,")
+			fmt.Println("        or set OPENCODE_GO_COOKIE manually")
+			return
+		}
+		cookie = imported.Header
+		fmt.Printf("cookie: imported from %s / %s (%d cookies: %s)\n",
+			imported.Browser, imported.Profile, len(imported.Names), strings.Join(imported.Names, ", "))
+	}
+
+	// Deliberately bypasses the collector's usage cache: this command exists to
+	// exercise the live path, so it always makes the request.
+	snap := limits.FetchOpenCodeGoWebUsage(cookie, nowMs)
+	if snap == nil {
+		fmt.Println("fetch: opencode.ai returned no usage (session expired, or the page changed)")
+		return
+	}
+	fmt.Printf("fetch: workspace %s via %s\n", snap.WorkspaceID, snap.Source)
+	pl := limits.ProviderLimitsFromWebSnapshot(*snap, nowMs)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(pl)
 }
 
 func runCollectJSON(args []string) {

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -516,6 +516,11 @@ func runOpenCodeCheck() {
 	if env := strings.TrimSpace(os.Getenv("OPENCODE_GO_COOKIE")); env != "" {
 		cookie = env
 		fmt.Println("cookie: OPENCODE_GO_COOKIE is set (browser import skipped)")
+	} else if strings.TrimSpace(os.Getenv("USAGEBAR_DISABLE_BROWSER_COOKIES")) != "" {
+		// Distinguish "opted out" from "looked and found nothing".
+		fmt.Println("cookie: browser import is disabled by USAGEBAR_DISABLE_BROWSER_COOKIES")
+		fmt.Println("        unset it, or set OPENCODE_GO_COOKIE, to use official usage")
+		return
 	} else {
 		imported, probes, ok := limits.ImportBrowserCookieHeaderWithProbes(limits.OpenCodeCookieDomain, nowMs)
 		fmt.Printf("browser profiles probed: %d\n", len(probes))

--- a/internal/limits/chromiumcookies.go
+++ b/internal/limits/chromiumcookies.go
@@ -1,0 +1,171 @@
+/**
+ * Decrypts Chromium-family cookie values (macOS "v10" scheme) so the
+ * OpenCode Go collector can reuse a browser session instead of requiring a
+ * hand-pasted OPENCODE_GO_COOKIE. Pure helpers only: profile discovery,
+ * sqlite reads, and the Keychain lookup live in chromiumcookies_io.go.
+ */
+package limits
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/pbkdf2"
+	"crypto/sha1"
+	"crypto/sha256"
+	"errors"
+	"strings"
+)
+
+const (
+	// chromiumV10Prefix marks a value encrypted with the Keychain-derived key.
+	chromiumV10Prefix = "v10"
+	// chromiumSalt/Iterations/KeyLength are Chromium's fixed macOS parameters
+	// (components/os_crypt/sync/os_crypt_mac.mm).
+	chromiumSalt       = "saltysalt"
+	chromiumIterations = 1003
+	chromiumKeyLength  = 16
+)
+
+// chromiumIV is Chromium's fixed CBC IV: 16 spaces.
+func chromiumIV() []byte { return bytes.Repeat([]byte{' '}, aes.BlockSize) }
+
+// BrowserCookie is one cookie row after decryption.
+type BrowserCookie struct {
+	HostKey string
+	Name    string
+	Value   string
+}
+
+// DeriveChromiumKey derives the AES-128 key from a browser's
+// "<Browser> Safe Storage" Keychain password.
+func DeriveChromiumKey(password string) ([]byte, error) {
+	if password == "" {
+		return nil, errors.New("empty safe storage password")
+	}
+	return pbkdf2.Key(sha1.New, password, []byte(chromiumSalt), chromiumIterations, chromiumKeyLength)
+}
+
+// DecryptChromiumCookieValue decrypts one `encrypted_value` blob. hostKey is
+// needed because Chromium 127+ prefixes the plaintext with SHA256(host_key);
+// the prefix is stripped only when it actually matches, so a wrong key can
+// never silently truncate a real value. ok=false means the blob is not a v10
+// value, the key is wrong, or the plaintext is not a usable cookie value —
+// callers should fall back to the row's unencrypted `value` column.
+func DecryptChromiumCookieValue(key []byte, hostKey string, encrypted []byte) (string, bool) {
+	if len(key) != chromiumKeyLength || len(encrypted) <= len(chromiumV10Prefix) {
+		return "", false
+	}
+	if !bytes.HasPrefix(encrypted, []byte(chromiumV10Prefix)) {
+		return "", false
+	}
+	body := encrypted[len(chromiumV10Prefix):]
+	if len(body) == 0 || len(body)%aes.BlockSize != 0 {
+		return "", false
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", false
+	}
+	plain := make([]byte, len(body))
+	cipher.NewCBCDecrypter(block, chromiumIV()).CryptBlocks(plain, body)
+	plain, ok := stripPKCS7(plain)
+	if !ok {
+		return "", false
+	}
+	plain = stripChromiumDomainHash(plain, hostKey)
+	value := string(plain)
+	if !isPrintableCookieValue(value) {
+		return "", false
+	}
+	return value, true
+}
+
+// stripPKCS7 removes CBC padding, rejecting malformed padding (which is the
+// usual symptom of decrypting with the wrong key).
+func stripPKCS7(plain []byte) ([]byte, bool) {
+	if len(plain) == 0 || len(plain)%aes.BlockSize != 0 {
+		return nil, false
+	}
+	pad := int(plain[len(plain)-1])
+	if pad <= 0 || pad > aes.BlockSize || pad > len(plain) {
+		return nil, false
+	}
+	for _, b := range plain[len(plain)-pad:] {
+		if int(b) != pad {
+			return nil, false
+		}
+	}
+	return plain[:len(plain)-pad], true
+}
+
+// stripChromiumDomainHash removes the SHA256(host_key) prefix Chromium 127+
+// binds to the cookie value. Older browsers store the bare value, so the
+// prefix is removed only on an exact match.
+func stripChromiumDomainHash(plain []byte, hostKey string) []byte {
+	if len(plain) < sha256.Size {
+		return plain
+	}
+	want := sha256.Sum256([]byte(hostKey))
+	if !bytes.Equal(plain[:sha256.Size], want[:]) {
+		return plain
+	}
+	return plain[sha256.Size:]
+}
+
+// isPrintableCookieValue rejects control characters, which appear when the
+// derived key is wrong but the padding happens to validate.
+func isPrintableCookieValue(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+// CookieHostMatchesDomain reports whether a stored host_key covers domain or
+// one of its subdomains (".opencode.ai" and "app.opencode.ai" both match
+// "opencode.ai").
+func CookieHostMatchesDomain(hostKey, domain string) bool {
+	host := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(hostKey), "."))
+	domain = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(domain), "."))
+	if host == "" || domain == "" {
+		return false
+	}
+	return host == domain || strings.HasSuffix(host, "."+domain)
+}
+
+// ChromiumCookieExpired reports whether a row is past its expiry. expiresUTC
+// is Chromium's microseconds-since-1601 stamp; 0 marks a session cookie,
+// which never expires on disk.
+func ChromiumCookieExpired(expiresUTC int64, nowMs int64) bool {
+	if expiresUTC <= 0 {
+		return false
+	}
+	const epochOffsetMicros = 11644473600000000
+	return (expiresUTC-epochOffsetMicros)/1000 <= nowMs
+}
+
+// BuildCookieHeader joins cookies into a Cookie request header, keeping the
+// first occurrence of each name so a host-exact row wins over a domain-wide
+// duplicate when callers pass the more specific rows first.
+func BuildCookieHeader(cookies []BrowserCookie) string {
+	var parts []string
+	seen := map[string]struct{}{}
+	for _, c := range cookies {
+		name := strings.TrimSpace(c.Name)
+		if name == "" || c.Value == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		parts = append(parts, name+"="+c.Value)
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/limits/chromiumcookies_io.go
+++ b/internal/limits/chromiumcookies_io.go
@@ -1,0 +1,262 @@
+/**
+ * Locates Chromium-family cookie databases on macOS and reads one domain's
+ * rows, decrypting them with the browser's Keychain "<Browser> Safe Storage"
+ * password. Pure decryption/matching helpers live in chromiumcookies.go.
+ *
+ * The Keychain is only consulted after a profile actually yields rows for the
+ * domain, so browsers without that session never trigger an access prompt.
+ * Set USAGEBAR_DISABLE_BROWSER_COOKIES=1 to opt out entirely.
+ */
+package limits
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// chromiumBrowser is one installed Chromium-family browser.
+type chromiumBrowser struct {
+	Name string
+	// SupportDir is relative to ~/Library/Application Support.
+	SupportDir      string
+	KeychainService string
+	KeychainAccount string
+}
+
+// chromiumBrowsers are probed in this order; the first profile that yields a
+// usable session for the domain wins.
+var chromiumBrowsers = []chromiumBrowser{
+	{"Google Chrome", "Google/Chrome", "Chrome Safe Storage", "Chrome"},
+	{"Arc", "Arc/User Data", "Arc Safe Storage", "Arc"},
+	{"Brave", "BraveSoftware/Brave-Browser", "Brave Safe Storage", "Brave"},
+	{"Microsoft Edge", "Microsoft Edge", "Microsoft Edge Safe Storage", "Microsoft Edge"},
+	{"Chromium", "Chromium", "Chromium Safe Storage", "Chromium"},
+}
+
+// ChromiumCookieStore is one browser profile's cookie DB plus the Keychain
+// entry holding its encryption password.
+type ChromiumCookieStore struct {
+	Browser         string
+	Profile         string
+	DBPath          string
+	KeychainService string
+	KeychainAccount string
+}
+
+// chromiumCookieRow is one raw row before decryption.
+type chromiumCookieRow struct {
+	HostKey        string
+	Name           string
+	Value          string
+	EncryptedValue []byte
+	ExpiresUTC     int64
+}
+
+func chromiumSupportRoot() string {
+	return filepath.Join(userHome(), "Library", "Application Support")
+}
+
+// chromiumProfileDirs lists a browser's profile directories, "Default" first.
+func chromiumProfileDirs(browserRoot string) []string {
+	entries, err := os.ReadDir(browserRoot)
+	if err != nil {
+		return nil
+	}
+	var profiles []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name != "Default" && !strings.HasPrefix(name, "Profile ") {
+			continue
+		}
+		profiles = append(profiles, name)
+	}
+	sort.Slice(profiles, func(i, j int) bool {
+		if (profiles[i] == "Default") != (profiles[j] == "Default") {
+			return profiles[i] == "Default"
+		}
+		return profiles[i] < profiles[j]
+	})
+	return profiles
+}
+
+// ChromiumCookieStores returns every existing cookie DB on this machine.
+// Chromium moved the file to <profile>/Network/Cookies; the older
+// <profile>/Cookies location is still checked for long-lived installs.
+func ChromiumCookieStores() []ChromiumCookieStore {
+	root := chromiumSupportRoot()
+	var stores []ChromiumCookieStore
+	for _, b := range chromiumBrowsers {
+		browserRoot := filepath.Join(root, filepath.FromSlash(b.SupportDir))
+		for _, profile := range chromiumProfileDirs(browserRoot) {
+			for _, rel := range [][]string{{"Network", "Cookies"}, {"Cookies"}} {
+				path := filepath.Join(append([]string{browserRoot, profile}, rel...)...)
+				if st, err := os.Stat(path); err != nil || !st.Mode().IsRegular() {
+					continue
+				}
+				stores = append(stores, ChromiumCookieStore{
+					Browser:         b.Name,
+					Profile:         profile,
+					DBPath:          path,
+					KeychainService: b.KeychainService,
+					KeychainAccount: b.KeychainAccount,
+				})
+				break
+			}
+		}
+	}
+	return stores
+}
+
+// readChromiumCookieRows reads unexpired rows for domain. immutable=1 is
+// required because a running browser holds the DB with exclusive locking;
+// it also guarantees this never writes to the browser's file.
+func readChromiumCookieRows(dbPath, domain string, nowMs int64) ([]chromiumCookieRow, error) {
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&immutable=1")
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	// Longest host_key first so a host-exact cookie wins over a domain-wide
+	// duplicate of the same name in BuildCookieHeader.
+	rows, err := db.Query(`
+		SELECT host_key, name, value, encrypted_value, expires_utc
+		FROM cookies
+		WHERE host_key LIKE ?
+		ORDER BY LENGTH(host_key) DESC, name`, "%"+domain)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []chromiumCookieRow
+	for rows.Next() {
+		var r chromiumCookieRow
+		if err := rows.Scan(&r.HostKey, &r.Name, &r.Value, &r.EncryptedValue, &r.ExpiresUTC); err != nil {
+			continue
+		}
+		if !CookieHostMatchesDomain(r.HostKey, domain) {
+			continue
+		}
+		if ChromiumCookieExpired(r.ExpiresUTC, nowMs) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// chromiumSafeStoragePassword reads the browser's encryption password from the
+// login Keychain. The first read shows a macOS access prompt; granting it once
+// ("Always Allow") keeps later refreshes silent.
+func chromiumSafeStoragePassword(service, account string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "security", "find-generic-password", "-w", "-s", service, "-a", account).Output()
+	if err != nil {
+		return "", false
+	}
+	password := strings.TrimRight(string(out), "\r\n")
+	if password == "" {
+		return "", false
+	}
+	return password, true
+}
+
+// BrowserCookieImport is the result of a successful import, kept separate from
+// the header so callers can report which profile supplied the session without
+// logging the values.
+type BrowserCookieImport struct {
+	Header  string
+	Browser string
+	Profile string
+	Names   []string
+}
+
+// BrowserCookieProbe records what happened for one profile, so a failed
+// import can be attributed to the profile having no session, the Keychain
+// lookup being refused, or the values not decrypting. Diagnostics only — it
+// never carries a cookie value.
+type BrowserCookieProbe struct {
+	Browser    string
+	Profile    string
+	Rows       int
+	KeychainOK bool
+	Decrypted  int
+}
+
+// ImportBrowserCookieHeader builds a Cookie header for domain from the first
+// local Chromium profile that has a usable session for it.
+func ImportBrowserCookieHeader(domain string, nowMs int64) (BrowserCookieImport, bool) {
+	imported, _, ok := ImportBrowserCookieHeaderWithProbes(domain, nowMs)
+	return imported, ok
+}
+
+// ImportBrowserCookieHeaderWithProbes is ImportBrowserCookieHeader plus a
+// per-profile trace for the opencode-check diagnostic.
+func ImportBrowserCookieHeaderWithProbes(domain string, nowMs int64) (BrowserCookieImport, []BrowserCookieProbe, bool) {
+	if strings.TrimSpace(os.Getenv("USAGEBAR_DISABLE_BROWSER_COOKIES")) != "" {
+		return BrowserCookieImport{}, nil, false
+	}
+	var probes []BrowserCookieProbe
+	for _, store := range ChromiumCookieStores() {
+		probe := BrowserCookieProbe{Browser: store.Browser, Profile: store.Profile}
+		rows, err := readChromiumCookieRows(store.DBPath, domain, nowMs)
+		probe.Rows = len(rows)
+		if err != nil || len(rows) == 0 {
+			probes = append(probes, probe)
+			continue
+		}
+		password, ok := chromiumSafeStoragePassword(store.KeychainService, store.KeychainAccount)
+		probe.KeychainOK = ok
+		if !ok {
+			probes = append(probes, probe)
+			continue
+		}
+		key, err := DeriveChromiumKey(password)
+		if err != nil {
+			probes = append(probes, probe)
+			continue
+		}
+		var cookies []BrowserCookie
+		for _, r := range rows {
+			value, ok := DecryptChromiumCookieValue(key, r.HostKey, r.EncryptedValue)
+			if !ok {
+				// Rows written before encryption was available keep a plain value.
+				value = r.Value
+			}
+			if value == "" {
+				continue
+			}
+			cookies = append(cookies, BrowserCookie{HostKey: r.HostKey, Name: r.Name, Value: value})
+		}
+		probe.Decrypted = len(cookies)
+		probes = append(probes, probe)
+		header := BuildCookieHeader(cookies)
+		if header == "" {
+			continue
+		}
+		names := make([]string, 0, len(cookies))
+		for _, c := range cookies {
+			names = append(names, c.Name)
+		}
+		return BrowserCookieImport{
+			Header:  header,
+			Browser: store.Browser,
+			Profile: store.Profile,
+			Names:   names,
+		}, probes, true
+	}
+	return BrowserCookieImport{}, probes, false
+}

--- a/internal/limits/chromiumcookies_test.go
+++ b/internal/limits/chromiumcookies_test.go
@@ -1,0 +1,169 @@
+/**
+ * Tests for Chromium cookie decryption helpers.
+ */
+package limits
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"testing"
+)
+
+// encryptChromiumValue mirrors Chromium's macOS v10 encryption so the
+// decrypt path can be exercised without a real browser profile.
+func encryptChromiumValue(t *testing.T, key []byte, hostKey, value string, bindDomain bool) []byte {
+	t.Helper()
+	plain := []byte(value)
+	if bindDomain {
+		sum := sha256.Sum256([]byte(hostKey))
+		plain = append(sum[:], plain...)
+	}
+	pad := aes.BlockSize - len(plain)%aes.BlockSize
+	plain = append(plain, bytes.Repeat([]byte{byte(pad)}, pad)...)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	out := make([]byte, len(plain))
+	cipher.NewCBCEncrypter(block, chromiumIV()).CryptBlocks(out, plain)
+	return append([]byte(chromiumV10Prefix), out...)
+}
+
+func TestDeriveChromiumKey(t *testing.T) {
+	key, err := DeriveChromiumKey("safe-storage-password")
+	if err != nil {
+		t.Fatalf("DeriveChromiumKey: %v", err)
+	}
+	if len(key) != chromiumKeyLength {
+		t.Fatalf("key length: got %d want %d", len(key), chromiumKeyLength)
+	}
+	again, err := DeriveChromiumKey("safe-storage-password")
+	if err != nil || !bytes.Equal(key, again) {
+		t.Fatalf("derivation is not deterministic")
+	}
+	other, err := DeriveChromiumKey("different")
+	if err != nil {
+		t.Fatalf("DeriveChromiumKey(other): %v", err)
+	}
+	if bytes.Equal(key, other) {
+		t.Fatalf("different passwords produced the same key")
+	}
+	if _, err := DeriveChromiumKey(""); err == nil {
+		t.Fatalf("empty password should fail")
+	}
+}
+
+func TestDecryptChromiumCookieValueRoundTrip(t *testing.T) {
+	key, err := DeriveChromiumKey("safe-storage-password")
+	if err != nil {
+		t.Fatalf("DeriveChromiumKey: %v", err)
+	}
+	for _, tc := range []struct {
+		name       string
+		bindDomain bool
+	}{
+		{"legacy value", false},
+		{"domain-bound value (Chromium 127+)", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := encryptChromiumValue(t, key, ".opencode.ai", "session-token-abc123", tc.bindDomain)
+			got, ok := DecryptChromiumCookieValue(key, ".opencode.ai", enc)
+			if !ok {
+				t.Fatalf("decrypt failed")
+			}
+			if got != "session-token-abc123" {
+				t.Fatalf("got %q want %q", got, "session-token-abc123")
+			}
+		})
+	}
+}
+
+func TestDecryptChromiumCookieValueRejects(t *testing.T) {
+	key, _ := DeriveChromiumKey("safe-storage-password")
+	wrong, _ := DeriveChromiumKey("wrong-password")
+	enc := encryptChromiumValue(t, key, ".opencode.ai", "session-token-abc123", true)
+
+	if _, ok := DecryptChromiumCookieValue(wrong, ".opencode.ai", enc); ok {
+		t.Fatalf("wrong key should not decrypt")
+	}
+	if _, ok := DecryptChromiumCookieValue(key, ".opencode.ai", []byte("plain value")); ok {
+		t.Fatalf("non-v10 blob should be rejected")
+	}
+	if _, ok := DecryptChromiumCookieValue(key, ".opencode.ai", nil); ok {
+		t.Fatalf("empty blob should be rejected")
+	}
+	if _, ok := DecryptChromiumCookieValue(key[:8], ".opencode.ai", enc); ok {
+		t.Fatalf("short key should be rejected")
+	}
+	if _, ok := DecryptChromiumCookieValue(key, ".opencode.ai", append([]byte(chromiumV10Prefix), 1, 2, 3)); ok {
+		t.Fatalf("non-block-aligned body should be rejected")
+	}
+}
+
+// A value whose plaintext happens to start with 32 bytes that are not the
+// domain hash must survive intact.
+func TestDecryptChromiumCookieValueKeepsUnmatchedPrefix(t *testing.T) {
+	key, _ := DeriveChromiumKey("safe-storage-password")
+	long := "0123456789abcdef0123456789abcdef-tail"
+	enc := encryptChromiumValue(t, key, ".opencode.ai", long, false)
+	got, ok := DecryptChromiumCookieValue(key, ".opencode.ai", enc)
+	if !ok || got != long {
+		t.Fatalf("got %q ok=%v want %q", got, ok, long)
+	}
+}
+
+func TestCookieHostMatchesDomain(t *testing.T) {
+	for _, tc := range []struct {
+		host, domain string
+		want         bool
+	}{
+		{"opencode.ai", "opencode.ai", true},
+		{".opencode.ai", "opencode.ai", true},
+		{"app.opencode.ai", "opencode.ai", true},
+		{".app.opencode.ai", "opencode.ai", true},
+		{"OpenCode.ai", "opencode.ai", true},
+		{"notopencode.ai", "opencode.ai", false},
+		{"opencode.ai.evil.com", "opencode.ai", false},
+		{"", "opencode.ai", false},
+		{"opencode.ai", "", false},
+	} {
+		if got := CookieHostMatchesDomain(tc.host, tc.domain); got != tc.want {
+			t.Fatalf("CookieHostMatchesDomain(%q,%q) = %v want %v", tc.host, tc.domain, got, tc.want)
+		}
+	}
+}
+
+func TestChromiumCookieExpired(t *testing.T) {
+	const nowMs = 1784946198000
+	const epochOffsetMicros = 11644473600000000
+	future := (nowMs+3600_000)*1000 + epochOffsetMicros
+	past := (nowMs-3600_000)*1000 + epochOffsetMicros
+
+	if ChromiumCookieExpired(0, nowMs) {
+		t.Fatalf("session cookie should not be expired")
+	}
+	if ChromiumCookieExpired(int64(future), nowMs) {
+		t.Fatalf("future expiry should not be expired")
+	}
+	if !ChromiumCookieExpired(int64(past), nowMs) {
+		t.Fatalf("past expiry should be expired")
+	}
+}
+
+func TestBuildCookieHeader(t *testing.T) {
+	got := BuildCookieHeader([]BrowserCookie{
+		{HostKey: "opencode.ai", Name: "session", Value: "a"},
+		{HostKey: ".opencode.ai", Name: "session", Value: "duplicate-ignored"},
+		{HostKey: ".opencode.ai", Name: "", Value: "no-name"},
+		{HostKey: ".opencode.ai", Name: "empty", Value: ""},
+		{HostKey: ".opencode.ai", Name: "csrf", Value: "b"},
+	})
+	if got != "session=a; csrf=b" {
+		t.Fatalf("got %q", got)
+	}
+	if BuildCookieHeader(nil) != "" {
+		t.Fatalf("empty input should produce an empty header")
+	}
+}

--- a/internal/limits/opencodego.go
+++ b/internal/limits/opencodego.go
@@ -249,9 +249,12 @@ func ProviderLimitsFromGoCostEvents(events []CostEvent, nowMs int64) ProviderLim
 }
 
 // ProviderLimitsFromWebSnapshot maps web usagePercent to used% + resetsAt.
+// No note: the windows, their resets, and the plan label already say
+// everything the page offers, and the workspace id it used to carry meant
+// nothing to a reader. The local-estimate path keeps its own "est. spent …"
+// note, which is what makes an estimate distinguishable from these numbers.
 func ProviderLimitsFromWebSnapshot(snap OpenCodeGoWebSnapshot, nowMs int64) ProviderLimits {
 	plan := planlabels.OpencodePlanLabel(strPtr("go"))
-	note := "workspace " + snap.WorkspaceID
 	var weekly, monthly *LimitWindow
 	if snap.Weekly != nil {
 		weekly = windowFromUsed(snap.Weekly.UsedPercentage, 10080, resetsAtFromResetInSec(nowMs, int64(snap.Weekly.ResetInSec)))
@@ -268,7 +271,6 @@ func ProviderLimitsFromWebSnapshot(snap OpenCodeGoWebSnapshot, nowMs int64) Prov
 		Tertiary:    monthly,
 		Source:      snap.Source,
 		FetchedAtMs: nowMs,
-		Note:        &note,
 	}
 }
 

--- a/internal/limits/opencodego.go
+++ b/internal/limits/opencodego.go
@@ -391,10 +391,25 @@ func loadCostEventsFromDB(dbPath string) ([]CostEvent, error) {
 	return CostEventsFromMessageDataJSONs(list), nil
 }
 
-// CollectOpenCodeLimits prefers web (OPENCODE_GO_COOKIE) then local DB.
+// CollectOpenCodeLimits prefers opencode.ai's own usage (authenticated with
+// OPENCODE_GO_COOKIE or an imported browser session) then the local DB
+// estimate. The web result — success or failure — is cached, because the
+// sidebar collects on every pane status change.
 func CollectOpenCodeLimits(nowMs int64, dbPath string) ProviderLimits {
-	if web := FetchOpenCodeGoWebUsage("", nowMs); web != nil {
-		return ProviderLimitsFromWebSnapshot(*web, nowMs)
+	// A fresh cache entry with no limits is a recent unsuccessful attempt:
+	// fall through to the local estimate without retrying the network.
+	if cached, fresh := loadOpenCodeWebCache(nowMs); fresh {
+		if cached != nil {
+			return *cached
+		}
+	} else if cookie := ReadOpenCodeGoCookieHeader(); cookie == "" {
+		saveOpenCodeWebCache(nil, openCodeWebNoSession, nowMs)
+	} else if web := FetchOpenCodeGoWebUsage(cookie, nowMs); web != nil {
+		pl := ProviderLimitsFromWebSnapshot(*web, nowMs)
+		saveOpenCodeWebCache(&pl, openCodeWebFetched, nowMs)
+		return pl
+	} else {
+		saveOpenCodeWebCache(nil, openCodeWebFetchFailed, nowMs)
 	}
 	if dbPath == "" {
 		dbPath = ResolveOpenCodeLimitsDBPath()

--- a/internal/limits/opencodego_test.go
+++ b/internal/limits/opencodego_test.go
@@ -114,6 +114,12 @@ func TestProviderLimitsFromWebSnapshot(t *testing.T) {
 	if limits.Source != "web" {
 		t.Fatalf("source=%q", limits.Source)
 	}
+	// Official numbers carry no note: the workspace id it used to show meant
+	// nothing to a reader, and an empty note is what distinguishes these from
+	// the local path's "est. spent …" line.
+	if limits.Note != nil {
+		t.Fatalf("web snapshot should carry no note, got %q", *limits.Note)
+	}
 }
 
 func mustJSONCost(v any) string {

--- a/internal/limits/opencodeweb.go
+++ b/internal/limits/opencodeweb.go
@@ -92,9 +92,23 @@ func extractUsageBlock(text, name string) *OpenCodeGoWebWindow {
 	return &OpenCodeGoWebWindow{UsedPercentage: used, ResetInSec: resetInSec}
 }
 
-// ReadOpenCodeGoCookieHeader returns OPENCODE_GO_COOKIE if set.
+// OpenCodeCookieDomain is the domain whose browser session authenticates the
+// usage pages.
+const OpenCodeCookieDomain = "opencode.ai"
+
+// ReadOpenCodeGoCookieHeader returns the Cookie header to send to opencode.ai:
+// OPENCODE_GO_COOKIE when set, otherwise a session imported from a local
+// Chromium-family browser profile. The env var stays authoritative so a manual
+// header can always override (or stand in for) the browser import.
 func ReadOpenCodeGoCookieHeader() string {
-	return strings.TrimSpace(os.Getenv("OPENCODE_GO_COOKIE"))
+	if v := strings.TrimSpace(os.Getenv("OPENCODE_GO_COOKIE")); v != "" {
+		return v
+	}
+	imported, ok := ImportBrowserCookieHeader(OpenCodeCookieDomain, time.Now().UnixMilli())
+	if !ok {
+		return ""
+	}
+	return imported.Header
 }
 
 func randomServerInstance() string {

--- a/internal/limits/opencodewebcache.go
+++ b/internal/limits/opencodewebcache.go
@@ -1,0 +1,64 @@
+/**
+ * TTL rules for the last opencode.ai usage fetch.
+ *
+ * The sidebar collects OpenCode limits on every pane agent_status_changed, so
+ * an uncached web path would mean two HTTP requests (and a browser cookie
+ * import) per event. Unsuccessful attempts are cached too, but the back-off
+ * depends on why they failed: a real fetch failure waits out a long TTL, while
+ * "no session yet" only pauses briefly so signing in to opencode.ai takes
+ * effect on the next refresh instead of minutes later. Disk access lives in
+ * opencodewebcache_io.go.
+ */
+package limits
+
+// openCodeWebOutcome is why the last attempt ended the way it did.
+type openCodeWebOutcome string
+
+const (
+	// openCodeWebFetched means opencode.ai returned usage.
+	openCodeWebFetched openCodeWebOutcome = "fetched"
+	// openCodeWebFetchFailed means a session was available but the fetch or
+	// parse failed (expired cookie, changed page, network error).
+	openCodeWebFetchFailed openCodeWebOutcome = "fetch-failed"
+	// openCodeWebNoSession means no cookie header could be resolved at all.
+	openCodeWebNoSession openCodeWebOutcome = "no-session"
+)
+
+const (
+	openCodeWebCacheSuccessTTLMs   = 120_000
+	openCodeWebCacheFailureTTLMs   = 600_000
+	openCodeWebCacheNoSessionTTLMs = 30_000
+)
+
+// openCodeWebCacheEntry is the persisted result of the last web attempt.
+// Limits is nil unless Outcome is openCodeWebFetched, and a fresh entry with
+// nil Limits means "skip the network this cycle and use the local estimate".
+type openCodeWebCacheEntry struct {
+	FetchedAtMs int64              `json:"fetchedAtMs"`
+	Outcome     openCodeWebOutcome `json:"outcome"`
+	Limits      *ProviderLimits    `json:"limits,omitempty"`
+}
+
+// openCodeWebCacheTTLMs is how long an outcome suppresses another attempt.
+func openCodeWebCacheTTLMs(outcome openCodeWebOutcome) int64 {
+	switch outcome {
+	case openCodeWebFetched:
+		return openCodeWebCacheSuccessTTLMs
+	case openCodeWebNoSession:
+		return openCodeWebCacheNoSessionTTLMs
+	default:
+		return openCodeWebCacheFailureTTLMs
+	}
+}
+
+// openCodeWebCacheFresh reports whether an entry may still be reused. Clock
+// jumps backwards invalidate rather than pin a stale entry into the future.
+func openCodeWebCacheFresh(entry openCodeWebCacheEntry, nowMs int64) bool {
+	if entry.FetchedAtMs <= 0 || nowMs < entry.FetchedAtMs || entry.Outcome == "" {
+		return false
+	}
+	if entry.Outcome == openCodeWebFetched && entry.Limits == nil {
+		return false
+	}
+	return nowMs-entry.FetchedAtMs < openCodeWebCacheTTLMs(entry.Outcome)
+}

--- a/internal/limits/opencodewebcache_io.go
+++ b/internal/limits/opencodewebcache_io.go
@@ -1,0 +1,52 @@
+/**
+ * Persists the last opencode.ai usage fetch next to usage-history.json.
+ * Only the resolved ProviderLimits is stored — never the cookie header — so a
+ * stale cache file can never leak a browser session.
+ */
+package limits
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+func openCodeWebCachePath() string {
+	if v := os.Getenv("USAGEBAR_OPENCODE_WEB_CACHE_PATH"); v != "" {
+		return v
+	}
+	return filepath.Join(historyBaseDir(), "opencode-go-web.json")
+}
+
+// loadOpenCodeWebCache returns the cached limits when the last attempt is
+// still fresh. fresh=true with nil limits means a cached unsuccessful attempt:
+// skip the network and fall through to the local estimate.
+func loadOpenCodeWebCache(nowMs int64) (limits *ProviderLimits, fresh bool) {
+	raw, err := os.ReadFile(openCodeWebCachePath())
+	if err != nil {
+		return nil, false
+	}
+	var entry openCodeWebCacheEntry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return nil, false
+	}
+	if !openCodeWebCacheFresh(entry, nowMs) {
+		return nil, false
+	}
+	return entry.Limits, true
+}
+
+// saveOpenCodeWebCache records the outcome of an attempt. limits is nil for
+// every outcome other than openCodeWebFetched.
+func saveOpenCodeWebCache(limits *ProviderLimits, outcome openCodeWebOutcome, nowMs int64) {
+	entry := openCodeWebCacheEntry{FetchedAtMs: nowMs, Outcome: outcome, Limits: limits}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	path := openCodeWebCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, raw, 0o600)
+}

--- a/internal/limits/opencodewebcache_test.go
+++ b/internal/limits/opencodewebcache_test.go
@@ -1,0 +1,78 @@
+/**
+ * Tests for the opencode.ai usage fetch cache TTL rules.
+ */
+package limits
+
+import "testing"
+
+func TestOpenCodeWebCacheFresh(t *testing.T) {
+	const now = 1784946198000
+	limits := &ProviderLimits{ProviderID: "opencode"}
+
+	for _, tc := range []struct {
+		name  string
+		entry openCodeWebCacheEntry
+		want  bool
+	}{
+		{"fresh success", openCodeWebCacheEntry{FetchedAtMs: now - 1000, Outcome: openCodeWebFetched, Limits: limits}, true},
+		{"expired success", openCodeWebCacheEntry{FetchedAtMs: now - openCodeWebCacheSuccessTTLMs, Outcome: openCodeWebFetched, Limits: limits}, false},
+		{"success without limits", openCodeWebCacheEntry{FetchedAtMs: now - 1000, Outcome: openCodeWebFetched}, false},
+		{"fresh fetch failure", openCodeWebCacheEntry{FetchedAtMs: now - openCodeWebCacheSuccessTTLMs - 1, Outcome: openCodeWebFetchFailed}, true},
+		{"expired fetch failure", openCodeWebCacheEntry{FetchedAtMs: now - openCodeWebCacheFailureTTLMs, Outcome: openCodeWebFetchFailed}, false},
+		{"fresh no-session", openCodeWebCacheEntry{FetchedAtMs: now - 1000, Outcome: openCodeWebNoSession}, true},
+		// A sign-in must take effect promptly, so no-session backs off far less
+		// than a genuine fetch failure.
+		{"expired no-session", openCodeWebCacheEntry{FetchedAtMs: now - openCodeWebCacheNoSessionTTLMs, Outcome: openCodeWebNoSession}, false},
+		{"unset", openCodeWebCacheEntry{}, false},
+		{"missing outcome", openCodeWebCacheEntry{FetchedAtMs: now - 1000, Limits: limits}, false},
+		{"future stamp", openCodeWebCacheEntry{FetchedAtMs: now + 1000, Outcome: openCodeWebFetched, Limits: limits}, false},
+	} {
+		if got := openCodeWebCacheFresh(tc.entry, now); got != tc.want {
+			t.Fatalf("%s: got %v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestOpenCodeWebCacheNoSessionBacksOffLessThanFailure(t *testing.T) {
+	if openCodeWebCacheTTLMs(openCodeWebNoSession) >= openCodeWebCacheTTLMs(openCodeWebFetchFailed) {
+		t.Fatalf("no-session must retry sooner than a fetch failure")
+	}
+}
+
+// A cached unsuccessful attempt must keep the network out of the path while
+// still letting the caller fall back to the local estimate.
+func TestOpenCodeWebCacheRoundTrip(t *testing.T) {
+	const now = 1784946198000
+	t.Setenv("USAGEBAR_OPENCODE_WEB_CACHE_PATH", t.TempDir()+"/opencode-go-web.json")
+
+	if _, fresh := loadOpenCodeWebCache(now); fresh {
+		t.Fatalf("missing cache file should be a miss")
+	}
+
+	want := ProviderLimits{ProviderID: "opencode", Label: "OpenCode", Source: "opencode.ai web"}
+	saveOpenCodeWebCache(&want, openCodeWebFetched, now)
+	got, fresh := loadOpenCodeWebCache(now + 1000)
+	if !fresh || got == nil {
+		t.Fatalf("expected a cache hit, got fresh=%v limits=%v", fresh, got)
+	}
+	if got.Source != want.Source {
+		t.Fatalf("Source: got %q want %q", got.Source, want.Source)
+	}
+	if _, fresh := loadOpenCodeWebCache(now + openCodeWebCacheSuccessTTLMs); fresh {
+		t.Fatalf("entry should expire after the success TTL")
+	}
+
+	saveOpenCodeWebCache(nil, openCodeWebFetchFailed, now)
+	got, fresh = loadOpenCodeWebCache(now + 1000)
+	if !fresh {
+		t.Fatalf("cached failure should be fresh")
+	}
+	if got != nil {
+		t.Fatalf("cached failure should carry no limits, got %v", got)
+	}
+
+	saveOpenCodeWebCache(nil, openCodeWebNoSession, now)
+	if _, fresh := loadOpenCodeWebCache(now + openCodeWebCacheNoSessionTTLMs + 1); fresh {
+		t.Fatalf("no-session entry should expire after its own TTL")
+	}
+}


### PR DESCRIPTION
## Summary

OpenCode Go's limit windows did not reflect real subscription usage: on a
machine at **62% / 28% / 50%** used, the panel reported **0% / 2.6% / 34.5%**
and the sidebar sat at `5h 100%` remaining while two thirds of the 5h window
was spent.

It is the only supported subscription whose harness persists no server-reported
limit numbers — `opencode.db` has no usage table, its `account` table is empty
(auth is an API key in `auth.json`), and the CLI never writes limit state. The
official windows exist only on opencode.ai, but that fetch was gated behind a
hand-exported `OPENCODE_GO_COOKIE`, so in practice every pane fell through to
the local USD estimate.

**The estimate cannot be repaired**, which is why this PR replaces the default
rather than tuning it:

- It only sees spend recorded by the OpenCode CLI itself. Sessions billed to
  the same subscription through OMP / Pi live in `~/.omp/agent/sessions/**` and
  are invisible to it — the newest `opencode-go` row in `opencode.db` was 14
  hours old, so the 5h sum was `$0` → 0% used → 100% remaining.
- Folding those sessions in overshoots instead of converging. Their recorded
  `usage.cost.total` is the harness's list-price arithmetic, not what
  opencode-go bills against the plan: the 5h sum alone is 246% of the $12 cap.
  No triple of caps reproduces the published percentages across all three
  windows, so the percentages are not a function of locally recorded USD at all.

### What changed

1. **Automatic session resolution.** `OPENCODE_GO_COOKIE` remains the override
   and always wins. Otherwise the `opencode.ai` cookie is imported from a local
   Chromium-family profile (Chrome, Arc, Brave, Edge, Chromium) and decrypted
   with the browser's Keychain `<Browser> Safe Storage` password.
   - The `SHA256(host_key)` prefix Chromium 127+ binds to the plaintext is
     stripped **only on an exact match**, so a wrong key degrades to "no usable
     cookie" instead of silently truncating a real value.
   - The Keychain is consulted only for profiles that actually hold a matching
     cookie, so browsers without that session never raise an access prompt.
   - The cookie DB is opened `immutable=1` — required because a running browser
     holds it with exclusive locking, and it also guarantees nothing is written
     back to the browser.
   - The cookie is never persisted. Opt out with
     `USAGEBAR_DISABLE_BROWSER_COOKIES=1`.
2. **Outcome cache**, which also fixes a latent bug: the sidebar collects on
   every pane `agent_status_changed`, so the web path previously meant two HTTP
   requests per status change per pane. Back-off depends on why an attempt
   ended — 2 min after success, 10 min after a genuine fetch failure, but only
   30 s when no session was found, so a fresh sign-in lands on the next refresh.
   Only the resolved `ProviderLimits` is persisted (mode 0600), never the cookie.
3. **`usagebar opencode-check`** attributes a failure to the browser session or
   to the fetch, distinguishing "no cookies" from "Keychain unavailable" from
   "nothing decrypted", without printing cookie values.
4. **No note on the official path.** It previously read `workspace wrk_01K…`,
   an internal id that tells a reader nothing. Everything else the page exposes
   is either already displayed (percentages, resets, the `Go` plan label) or
   absent on a normal account (`balance` 0 unless auto-reload is funded,
   `monthlyLimit` null unless a cap is set, workspace name `"Default"`). Leaving
   it empty also makes the note a signal: only the local fallback writes one
   (`est. spent 5h=$…`), so its presence now means "this is an estimate". The id
   remains in `usagebar opencode-check`, where identifying the workspace is the
   point.
5. **Docs**: the README now states plainly that OpenCode Go has no local source
   of usage truth — with a table of where every other provider keeps its
   server-reported numbers — and that this is why the Keychain step exists and
   applies to this provider only.

## Related issue

Related issue: #24

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Tests were added or updated where appropriate

New unit tests:

- `chromiumcookies_test.go` — encrypt/decrypt round trip for both the legacy and
  the domain-bound (Chromium 127+) layouts, rejection of a wrong key, non-`v10`
  blobs, short keys and non-block-aligned bodies, plus a regression test that a
  plaintext whose first 32 bytes are *not* the domain hash survives intact.
- `opencodewebcache_test.go` — per-outcome TTLs, the invariant that a missing
  session retries sooner than a fetch failure, and a save/load round trip
  covering "cached unsuccessful attempt" vs "no cache file".

Manual verification on macOS (Arc signed in to opencode.ai, Chrome not):

```
$ usagebar opencode-check
browser profiles probed: 2
  - Google Chrome / Default: no opencode.ai cookies
  - Arc / Default: 3 cookies, 3 decrypted
cookie: imported from Arc / Default (3 cookies: auth, desktop_promo_dismissed, oc_locale)
fetch: workspace wrk_… via opencode.ai web
```

- Collector reports `Source: opencode.ai web` with 62 / 28 / 50 used, matching
  an independent reading of the same account.
- Repeated `usagebar collect` runs keep an identical `FetchedAtMs`, confirming
  the cache suppresses further requests; the cache file is mode 0600 and
  contains only `fetchedAtMs` / `outcome` / `limits`.
- Sidebar token for an OMP/Pi pane on this subscription moved from `5h 100%` to
  `5h 38%`.
- Panel render (`usagebar limits --once`) shows the OpenCode block as three
  windows with no note line:

  ```
   OpenCode · Go
     5h   ████▌░░░░░░░    37% left    2h 38m
     7d   ████████▋░░░    72% left    1d 20h
     30d  ██████░░░░░░    50% left    14d 7h
  ```

Limitations: macOS only (Keychain + `~/Library/Application Support` paths), and
Chromium-family browsers only — Safari and Firefox are not covered. The
`opencode.ai` scraping contract (server-fn id and the `rollingUsage` /
`weeklyUsage` / `monthlyUsage` regexes) is unchanged by this PR and remains
subject to the existing upstream-drift caveat.

## User and compatibility impact

- **Behavior**: OpenCode Go windows now show official usage without any setup
  when a local browser is signed in to opencode.ai. Previously such users saw a
  local estimate.
- **First-run prompt**: macOS asks once for Keychain access to the browser's
  Safe Storage item. Choosing *Always Allow* keeps later refreshes silent.
  Declining, or setting `USAGEBAR_DISABLE_BROWSER_COOKIES=1`, falls back to the
  previous estimate — no failure state.
- **Network**: `opencode.ai` is now contacted for users who never set
  `OPENCODE_GO_COOKIE`. Documented in the README's network-request list, capped
  by the new cache, and skipped entirely when no session exists.
- **Persisted state**: adds `~/.claude/herdr-usagebar/opencode-go-web.json`
  (mode 0600, no credentials). Safe to delete.
- **Panel note**: the OpenCode Go note line is gone on the official path. A note
  now appears only for the local estimate.
- **Config/compat**: no config changes; `OPENCODE_GO_COOKIE` keeps working and
  keeps priority. No changes to other providers.

## AI assistance

Written with Claude Code. The diagnosis was empirical rather than assumed: the
local cost data was aggregated from both `opencode.db` and the OMP/Pi session
jsonl to establish that no cap model reproduces the official percentages, and
the fetch contract was confirmed to be current before any cookie code was
written. Every claim in the Testing section was executed on the author's
machine.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpE1MhLTSV61FN5MyuHbyW
