### PR TITLE
fix: Fall back to the space name when a tab keeps its default label

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,25 +137,32 @@ herdr plugin action invoke usagebar.open-limits
 
 ## Configuration
 
-### Sidebar limit row (Herdr 0.7.4+)
+### Sidebar rows (Herdr 0.7.4+)
 
-Add `$provider` and `$limit` as their own row so the existing context text remains unchanged:
+Add `$title`, `$provider`, and `$limit` as their own rows so the existing
+context text remains unchanged:
 
 ```toml
 [ui.sidebar.agents]
 row_gap = 0
 rows = [
-  ["state_icon", "tab", "pane"],
+  ["state_icon", "$title"],
   ["$provider", "$limit"],
   ["$context"],
 ]
 ```
 
+`$title` replaces Herdr's built-in `tab`/`pane` tokens, which render blank
+whenever a tab still carries its auto-assigned numeric label (e.g. a
+never-renamed tab 1 reports `"1"`) and the pane itself was never renamed.
+`$title` falls back to the workspace ("space") name in that case, then
+appends a pane rename when present: `tab` → `space` → `space・pane`.
+
 `$provider` replaces Herdr's built-in `agent` token: it renders the quota
 provider (`opencode-go`, `grok`, `claude`, …) on a subscription pane, and the
 backend (`deepseek`) on a pay-as-you-go pane. Herdr joins row tokens with `·`
 and has no separator setting, so the harness and billing identity are not
-shown side by side. This makes the standard display `tab · pane`,
+shown side by side. This makes the standard display `title`,
 `provider · limit`, then context. Run `herdr server reload-config` after
 editing. The limit disappears automatically when the matching provider has no
 limit data.

--- a/docs/LLM-SETUP.md
+++ b/docs/LLM-SETUP.md
@@ -145,7 +145,7 @@ Read the active Herdr config first. The target Agent layout is:
 [ui.sidebar.agents]
 row_gap = 0
 rows = [
-  ["state_icon", "tab", "pane"],
+  ["state_icon", "$title"],
   ["agent", "$limit"],
   ["$context"],
 ]
@@ -153,8 +153,13 @@ rows = [
 
 - If `[ui.sidebar.agents]` is absent, append the block above.
 - If it exists, do not append another table. Preserve its existing layout,
-  add `$limit` to the row containing `agent`, and add `$context` as the next
-  row. Do not remove unrelated tokens or rows.
+  replace a `["state_icon", "tab", "pane"]`-style row with
+  `["state_icon", "$title"]` (Herdr's built-in `tab`/`pane` tokens render
+  blank whenever a tab keeps its auto-assigned numeric label and the pane
+  was never renamed; `$title` falls back to the workspace/space name, then
+  appends a pane rename when present), add `$limit` to the row containing
+  `agent`, and add `$context` as the next row. Do not remove unrelated
+  tokens or rows.
 - If `[ui.sidebar.agents.rows_by_agent]` contains overrides for Claude,
   Codex, OpenCode, or Grok, merge `$limit` and `$context` into each relevant
   override too; an override replaces the default `rows`.

--- a/internal/core/sidebartitle.go
+++ b/internal/core/sidebartitle.go
@@ -1,0 +1,38 @@
+/**
+ * Resolves the sidebar's row-1 identity: a stand-in for Herdr's built-in
+ * `tab`/`pane` row tokens, which go blank whenever a tab keeps its
+ * auto-assigned numeric label (e.g. a fresh tab defaults to "1") and the
+ * pane itself was never renamed.
+ */
+package core
+
+import "strconv"
+
+// TabLabelIsDefault reports whether label is the auto-assigned label Herdr
+// gives an un-renamed tab: its own number as a string (a fresh tab 1 reports
+// label "1", not ""). Exported so a caller can skip fetching the workspace
+// name — the fallback source — when the tab already names itself.
+func TabLabelIsDefault(label string, number int) bool {
+	return label == "" || label == strconv.Itoa(number)
+}
+
+// ResolveSidebarTitle composes the sidebar's row-1 text.
+//
+//   - tabLabel is treated as unset per TabLabelIsDefault.
+//   - When tabLabel is unset, workspaceLabel (the "space" name) fills in.
+//   - paneLabel (a pane rename) is appended after "・" when set; with no
+//     base label it stands alone rather than leaving a stray separator.
+func ResolveSidebarTitle(paneLabel, tabLabel string, tabNumber int, workspaceLabel string) string {
+	base := tabLabel
+	if TabLabelIsDefault(base, tabNumber) {
+		base = workspaceLabel
+	}
+	switch {
+	case paneLabel == "":
+		return base
+	case base == "":
+		return paneLabel
+	default:
+		return base + "・" + paneLabel
+	}
+}

--- a/internal/core/sidebartitle_test.go
+++ b/internal/core/sidebartitle_test.go
@@ -1,0 +1,85 @@
+/**
+ * Tests for ResolveSidebarTitle's tab/space/pane fallback composition.
+ */
+package core
+
+import "testing"
+
+func TestResolveSidebarTitle_NamedTabNoPane(t *testing.T) {
+	got := ResolveSidebarTitle("", "Task A", 1, "herdr-agent-usage")
+	if got != "Task A" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_DefaultNumericTabFallsBackToSpace(t *testing.T) {
+	// Herdr defaults a fresh tab's label to its own number ("1").
+	got := ResolveSidebarTitle("", "1", 1, "logosyncs")
+	if got != "logosyncs" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_EmptyTabFallsBackToSpace(t *testing.T) {
+	got := ResolveSidebarTitle("", "", 1, "logosyncs")
+	if got != "logosyncs" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_DefaultTabWithPaneJoinsSpaceAndPane(t *testing.T) {
+	got := ResolveSidebarTitle("worker", "1", 1, "logosyncs")
+	if got != "logosyncs・worker" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_NamedTabWithPaneJoinsTabAndPane(t *testing.T) {
+	got := ResolveSidebarTitle("worker", "Task A", 1, "herdr-agent-usage")
+	if got != "Task A・worker" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_PaneOnlyWhenBaseEmpty(t *testing.T) {
+	got := ResolveSidebarTitle("worker", "", 1, "")
+	if got != "worker" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_NumberBoundaryNotMistakenForDefault(t *testing.T) {
+	// A tab genuinely renamed to the literal string "2" while it happens to
+	// be tab number 1 must NOT be treated as unset (edge case: only the
+	// matching number counts as the auto-assigned default).
+	got := ResolveSidebarTitle("", "2", 1, "space")
+	if got != "2" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSidebarTitle_AllEmpty(t *testing.T) {
+	got := ResolveSidebarTitle("", "", 0, "")
+	if got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestTabLabelIsDefault(t *testing.T) {
+	for _, tc := range []struct {
+		label  string
+		number int
+		want   bool
+	}{
+		{"", 1, true},        // no label at all
+		{"1", 1, true},       // Herdr's auto-assigned label for tab 1
+		{"12", 12, true},     // two-digit tab number
+		{"2", 1, false},      // renamed to a number that is not its own
+		{"Task A", 1, false}, // ordinary rename
+		{"01", 1, false},     // zero-padded is not the canonical form
+	} {
+		if got := TabLabelIsDefault(tc.label, tc.number); got != tc.want {
+			t.Fatalf("TabLabelIsDefault(%q, %d) = %v, want %v", tc.label, tc.number, got, tc.want)
+		}
+	}
+}

--- a/internal/herdrcli/herdr.go
+++ b/internal/herdrcli/herdr.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 )
 
@@ -48,6 +49,9 @@ type PaneInfo struct {
 	RowLabel      *string
 	Cwd           *string
 	ForegroundCwd *string
+	Label         *string // raw pane rename (unlike RowLabel, no agent/displayAgent fallback)
+	TabID         *string
+	WorkspaceID   *string
 }
 
 // RawPaneListEntry is a pane list row from herdr (for pure buildOpenAgentPanes).
@@ -151,6 +155,8 @@ func GetPaneInfo(paneID string) PaneInfo {
 				DisplayAgent  *string `json:"display_agent"`
 				Cwd           *string `json:"cwd"`
 				ForegroundCwd *string `json:"foreground_cwd"`
+				TabID         *string `json:"tab_id"`
+				WorkspaceID   *string `json:"workspace_id"`
 				AgentSession  *struct {
 					Kind  *string `json:"kind"`
 					Value *string `json:"value"`
@@ -179,7 +185,119 @@ func GetPaneInfo(paneID string) PaneInfo {
 		RowLabel:      rowLabel,
 		Cwd:           p.Cwd,
 		ForegroundCwd: p.ForegroundCwd,
+		Label:         p.Label,
+		TabID:         p.TabID,
+		WorkspaceID:   p.WorkspaceID,
 	}
+}
+
+// TabInfo is a tab's rename label and its auto-assigned number. Herdr
+// defaults a fresh tab's label to its own number as a string (e.g. tab 1
+// starts out labeled "1"), which callers use to detect an un-renamed tab.
+type TabInfo struct {
+	Label  string
+	Number int
+}
+
+// parseTabInfo is the pure core of GetTabInfo.
+func parseTabInfo(stdout string) TabInfo {
+	var parsed struct {
+		Result *struct {
+			Tab *struct {
+				Label  *string `json:"label"`
+				Number *int    `json:"number"`
+			} `json:"tab"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil || parsed.Result == nil || parsed.Result.Tab == nil {
+		return TabInfo{}
+	}
+	t := parsed.Result.Tab
+	info := TabInfo{Label: deref(t.Label)}
+	if t.Number != nil {
+		info.Number = *t.Number
+	}
+	return info
+}
+
+// GetTabInfo fetches tab get JSON for tabID.
+func GetTabInfo(tabID string) TabInfo {
+	if tabID == "" {
+		return TabInfo{}
+	}
+	stdout, ok := spawnHerdr("tab", "get", tabID)
+	if !ok || stdout == "" {
+		return TabInfo{}
+	}
+	return parseTabInfo(stdout)
+}
+
+// WorkspaceInfo is a workspace's ("space") rename label.
+type WorkspaceInfo struct {
+	Label string
+}
+
+// parseWorkspaceInfo is the pure core of GetWorkspaceInfo.
+func parseWorkspaceInfo(stdout string) WorkspaceInfo {
+	var parsed struct {
+		Result *struct {
+			Workspace *struct {
+				Label *string `json:"label"`
+			} `json:"workspace"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil || parsed.Result == nil || parsed.Result.Workspace == nil {
+		return WorkspaceInfo{}
+	}
+	return WorkspaceInfo{Label: deref(parsed.Result.Workspace.Label)}
+}
+
+// GetWorkspaceInfo fetches workspace get JSON for workspaceID.
+func GetWorkspaceInfo(workspaceID string) WorkspaceInfo {
+	if workspaceID == "" {
+		return WorkspaceInfo{}
+	}
+	stdout, ok := spawnHerdr("workspace", "get", workspaceID)
+	if !ok || stdout == "" {
+		return WorkspaceInfo{}
+	}
+	return parseWorkspaceInfo(stdout)
+}
+
+// PaneNaming is the naming context behind a pane's sidebar row-1 title,
+// flattened out of PaneInfo's pointers so callers compose plain strings.
+type PaneNaming struct {
+	PaneLabel      string
+	TabLabel       string
+	TabNumber      int
+	WorkspaceLabel string
+}
+
+// buildPaneNaming is the pure core of GetPaneNaming: the fetchers are
+// injected so the round-trip skip below is testable without a live herdr.
+func buildPaneNaming(
+	pane PaneInfo,
+	getTab func(string) TabInfo,
+	getWorkspace func(string) WorkspaceInfo,
+) PaneNaming {
+	tab := getTab(deref(pane.TabID))
+	naming := PaneNaming{
+		PaneLabel: deref(pane.Label),
+		TabLabel:  tab.Label,
+		TabNumber: tab.Number,
+	}
+	// The workspace name only ever serves as the tab name's fallback, so a
+	// tab that names itself costs one CLI round-trip here instead of two.
+	if core.TabLabelIsDefault(tab.Label, tab.Number) {
+		naming.WorkspaceLabel = getWorkspace(deref(pane.WorkspaceID)).Label
+	}
+	return naming
+}
+
+// GetPaneNaming resolves the pane's own label plus the tab and workspace
+// labels its sidebar title falls back through.
+func GetPaneNaming(pane PaneInfo) PaneNaming {
+	return buildPaneNaming(pane, GetTabInfo, GetWorkspaceInfo)
 }
 
 func deref(s *string) string {

--- a/internal/herdrcli/herdr_test.go
+++ b/internal/herdrcli/herdr_test.go
@@ -62,3 +62,90 @@ func TestBuildOpenAgentPanes_SharedTab(t *testing.T) {
 		}
 	}
 }
+
+// Real `herdr tab get` / `herdr workspace get` payloads, kept verbatim so the
+// parsers fail loudly if the upstream JSON shape drifts.
+const liveTabJSON = `{"id":"cli:tab:get","result":{"tab":{"agent_status":"idle","focused":true,` +
+	`"label":"herdr-agent-usage","number":1,"pane_count":3,"tab_id":"w6:t1","workspace_id":"w6"},` +
+	`"type":"tab_info"}}`
+
+const liveWorkspaceJSON = `{"id":"cli:workspace:get","result":{"type":"workspace_info","workspace":{` +
+	`"active_tab_id":"w6:t1","agent_status":"idle","focused":true,"label":"herdr-agent-usage",` +
+	`"number":1,"pane_count":3,"tab_count":1,"workspace_id":"w6"}}}`
+
+func TestParseTabInfo_LivePayload(t *testing.T) {
+	got := parseTabInfo(liveTabJSON)
+	if got != (TabInfo{Label: "herdr-agent-usage", Number: 1}) {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestParseTabInfo_MalformedYieldsZero(t *testing.T) {
+	for _, in := range []string{"", "not json", `{"result":{}}`, `{"result":null}`} {
+		if got := parseTabInfo(in); got != (TabInfo{}) {
+			t.Fatalf("input %q: %+v", in, got)
+		}
+	}
+}
+
+func TestParseWorkspaceInfo_LivePayload(t *testing.T) {
+	if got := parseWorkspaceInfo(liveWorkspaceJSON); got.Label != "herdr-agent-usage" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestParseWorkspaceInfo_MalformedYieldsZero(t *testing.T) {
+	for _, in := range []string{"", "not json", `{"result":{}}`} {
+		if got := parseWorkspaceInfo(in); got != (WorkspaceInfo{}) {
+			t.Fatalf("input %q: %+v", in, got)
+		}
+	}
+}
+
+func namingPane(label, tabID, workspaceID string) PaneInfo {
+	return PaneInfo{Label: &label, TabID: &tabID, WorkspaceID: &workspaceID}
+}
+
+func TestBuildPaneNaming_RenamedTabSkipsWorkspaceRoundTrip(t *testing.T) {
+	workspaceCalls := 0
+	got := buildPaneNaming(
+		namingPane("Task A", "w6:t1", "w6"),
+		func(string) TabInfo { return TabInfo{Label: "herdr-agent-usage", Number: 1} },
+		func(string) WorkspaceInfo { workspaceCalls++; return WorkspaceInfo{Label: "unused"} },
+	)
+	if workspaceCalls != 0 {
+		t.Fatalf("workspace fetched %d times for a self-naming tab", workspaceCalls)
+	}
+	want := PaneNaming{PaneLabel: "Task A", TabLabel: "herdr-agent-usage", TabNumber: 1}
+	if got != want {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestBuildPaneNaming_DefaultTabFetchesWorkspace(t *testing.T) {
+	var gotWorkspaceID string
+	got := buildPaneNaming(
+		namingPane("", "wA:t1", "wA"),
+		func(string) TabInfo { return TabInfo{Label: "1", Number: 1} },
+		func(id string) WorkspaceInfo { gotWorkspaceID = id; return WorkspaceInfo{Label: "logosyncs"} },
+	)
+	if gotWorkspaceID != "wA" {
+		t.Fatalf("workspace id %q", gotWorkspaceID)
+	}
+	want := PaneNaming{TabLabel: "1", TabNumber: 1, WorkspaceLabel: "logosyncs"}
+	if got != want {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestBuildPaneNaming_NilPointersDoNotPanic(t *testing.T) {
+	var gotTabID string
+	got := buildPaneNaming(
+		PaneInfo{},
+		func(id string) TabInfo { gotTabID = id; return TabInfo{} },
+		func(string) WorkspaceInfo { return WorkspaceInfo{} },
+	)
+	if gotTabID != "" || got != (PaneNaming{}) {
+		t.Fatalf("tabID=%q naming=%+v", gotTabID, got)
+	}
+}

--- a/internal/setup/herdrconfig.go
+++ b/internal/setup/herdrconfig.go
@@ -46,6 +46,12 @@ func ToastConfigSnippet() string {
 // an existing [ui.sidebar.agents] section must merge these tokens into it
 // instead of appending a duplicate TOML table.
 //
+// $title replaces the built-in `tab`/`pane` tokens: Herdr leaves that row
+// blank whenever a tab keeps its auto-assigned numeric label (e.g. "1")
+// and the pane was never renamed. $title falls back to the workspace
+// ("space") name in that case, then appends a pane rename when present
+// ("space・pane").
+//
 // $provider replaces the built-in `agent` token: it renders the subscription
 // provider ("opencode-go", "grok", "claude") when one owns the pane's
 // limit, and the backend name ("deepseek") on a pay-as-you-go pane.
@@ -54,7 +60,7 @@ func SidebarRowsSnippet() string {
 		"[ui.sidebar.agents]",
 		"row_gap = 0",
 		"rows = [",
-		`  ["state_icon", "tab", "pane"],`,
+		`  ["state_icon", "$title"],`,
 		`  ["$provider", "$limit"],`,
 		`  ["$context"],`,
 		"]",

--- a/internal/setup/runsetup_test.go
+++ b/internal/setup/runsetup_test.go
@@ -31,7 +31,7 @@ func TestRunSetup_SeedsAndSnippets(t *testing.T) {
 	text := strings.Join(report.Lines, "\n")
 	for _, want := range []string{
 		"seeded plugin config", "toast: NOT configured", "[ui.toast]",
-		"[ui.sidebar.agents]", `["state_icon", "tab", "pane"]`,
+		"[ui.sidebar.agents]", `["state_icon", "$title"]`,
 		`"$limit"`, `"$context"`,
 		"usagebar.open-limits", "--write-toast",
 	} {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -190,6 +190,14 @@ func RunUpdate(force bool) {
 		return
 	}
 
+	// Row 1 stands in for Herdr's built-in `tab`/`pane` tokens, which render
+	// blank whenever a tab keeps its auto-assigned numeric label and the
+	// pane was never renamed. Fall back through the workspace ("space")
+	// name so the row is never empty.
+	naming := herdrcli.GetPaneNaming(pane)
+	title := core.ResolveSidebarTitle(naming.PaneLabel, naming.TabLabel, naming.TabNumber, naming.WorkspaceLabel)
+	writeMetadataToken(paneID, "title", title, force)
+
 	cwd := paneCwdForUpdate(pane)
 	nowMs := time.Now().UnixMilli()
 	// Subscription limits only apply when the pane's session is billed against


### PR DESCRIPTION
## Summary

Herdr's built-in `tab`/`pane` sidebar row tokens render blank whenever a tab
still carries its auto-assigned numeric label (e.g. a never-renamed tab 1
reports label `"1"`) and the pane itself was never renamed — leaving row 1
of the sidebar empty by default.

Adds a `$title` metadata token that replaces both built-in tokens:
- falls back to the workspace ("space") name when the tab has no custom name
- appends a pane rename when present: `tab` → `space` → `space・pane`

## Related issue

Related issue: N/A (small bug fix, reported directly by the maintainer)

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Tests were added or updated where appropriate

New tests: `internal/core/sidebartitle_test.go` (title composition +
`TabLabelIsDefault` boundary cases), `internal/herdrcli/herdr_test.go`
(JSON parsers against real `herdr tab get`/`herdr workspace get` payloads,
plus `buildPaneNaming` asserting the workspace round-trip is skipped
whenever the tab already names itself). `internal/setup/runsetup_test.go`
updated for the new snippet.

Manual/live verification against a running Herdr session (binary built
from this branch, `HERDR_PANE_ID=<pane> ./bin/usagebar status --force`,
then `herdr pane get <pane>`):

| Pane state | `$title` |
|---|---|
| tab renamed, pane renamed | `herdr-agent-usage・Task A` |
| tab default (`"1"`), pane not renamed | `logosyncs` (space fallback) |
| tab default (`"1"`), pane not renamed | `harness-bench` (space fallback) |

Also measured actual `herdr` CLI subprocess spawns via a spy wrapper:
a self-naming tab costs 1 extra spawn (`tab get` only); a default-labeled
tab costs 2 (`tab get` + `workspace get`, since the fallback is only
needed then).

## User and compatibility impact

- New `$title` sidebar token (same `--token NAME=VALUE` mechanism as the
  existing `$limit`/`$provider`/`$context` tokens — no `min_herdr_version`
  bump needed).
- Recommended sidebar rows snippet (README, `docs/LLM-SETUP.md`,
  `setup.SidebarRowsSnippet`) changed from `["state_icon", "tab", "pane"]`
  to `["state_icon", "$title"]`. Existing users must edit their
  `~/.config/herdr/config.toml` and run `herdr server reload-config` to
  pick up the new row (documented in both docs).
- No persisted-state or provider-detection changes.

## AI assistance

Implemented end-to-end (design, code, tests, docs) by an AI coding agent
(Claude) working interactively with the maintainer, including a live
code-review pass by a second AI agent instance in a separate Herdr pane
whose findings (subprocess-spawn cost, a `deref` helper duplicated across
packages) drove the `TabLabelIsDefault`/`GetPaneNaming` refactor in this
PR. The maintainer directed the work, reviewed the diff, and ran/verified
`gofmt`/`go vet`/`go test`/`go build`/`golangci-lint` and the live smoke
tests described above.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
