### PR TITLE
chore: Release v0.5.3

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.2"
+version = "0.5.3"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
Bumps the plugin manifest to v0.5.3 for #27 (sidebar $title fallback token).

## Testing
- [x] gofmt -l . produces no output
- [x] go vet ./...
- [x] go test ./...
- [x] go build ./...

## User and compatibility impact
Version bump only; behavior already reviewed in #27.

## AI assistance
Version bump commit created by an AI coding agent (Claude) as part of the maintainer-directed release flow for #27.