### PR TITLE
fix: share subscription windows across harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ so this plugin just reads them back:
 
 | provider | local source of truth |
 | --- | --- |
-| Claude | `~/.claude.json` `cachedUsageUtilization` (+ statusLine cache) |
-| Codex | `rate_limits` inside `event_msg` / `token_count` in the rollout jsonl |
-| Grok | agent stdio / `x.ai` billing |
-| **OpenCode Go** | **none** |
+| Claude | `~/.claude.json` `cachedUsageUtilization` (+ statusLine cache), or another agent's observation of the same account |
+| Codex | `rate_limits` inside `event_msg` / `token_count` in the rollout jsonl, or another agent's observation of the same account |
+| Grok | agent stdio / `x.ai` billing, or another agent's observation of the same account |
+| **OpenCode Go** | **none of its own** (an observation by another agent still counts) |
 
 `opencode.db` has no usage table at all, its `account` table is empty (auth is
 an API key in `auth.json`), and the OpenCode CLI never persists limit state.
@@ -353,7 +353,7 @@ Everything is computed from files that the agents already keep on your machine:
 | Codex | rollout files under `~/.codex/sessions/` |
 | OpenCode | `~/.local/share/opencode/opencode.db` (session usage), `~/.local/share/opencode/auth.json` (credential kind only), and — for OpenCode Go's official windows — the `opencode.ai` cookie in a local Chromium profile plus that browser's Keychain "Safe Storage" password (read-only, never persisted; see [OpenCode Go official usage](#opencode-go-official-usage)) |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch), `~/.grok/config.toml` (custom-model base URLs) |
-| OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup), `~/.omp/agent/agent.db` (credential kind only) |
+| OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup), `~/.omp/agent/agent.db` (credential kind, and the `usage_history` windows OMP records for the accounts it drives) |
 | Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present, `~/.pi/agent/auth.json` (credential kind only) |
 
 Pay-as-you-go detection is not tied to any one harness: it reads the same
@@ -362,6 +362,45 @@ OpenCode's `providerID`, Codex's `model_provider`, Claude's deployment env,
 Grok's `config.toml`, OMP/Pi `message.provider`). No extra data sources; the
 only network calls are the authenticated provider usage fetches (Grok credits,
 OpenCode Go usage), and each one is skipped when its credential is absent.
+
+### Where a window comes from
+
+A rate-limit window belongs to the **account**, not to the agent that observed
+it. Every collector already treats windows as account-wide, so the plugin
+treats the observer as interchangeable too: when a provider's own artifacts
+are absent, the account's newest observation by any agent on the machine is
+used instead.
+
+That is what makes a subscription driven entirely through another harness
+report real numbers. A Claude Team account driven by OMP writes no
+`~/.claude.json` utilization and no statusLine cache, because the Claude CLI
+never runs — but OMP records the same windows in `~/.omp/agent/agent.db`
+(`usage_history`), and those are the account's windows regardless of who
+asked for them.
+
+Borrowing is deliberately conservative:
+
+- **The freshest reading wins, not the closest one.** A provider's own
+  artifacts are consulted first, but `~/.claude.json` and a Codex rollout are
+  caches with a timestamp, not live truth. When another agent observed the
+  same window more recently, that number is shown — otherwise an idle CLI's
+  old snapshot would under-report usage right as a limit approaches. Live
+  authenticated fetches (Grok, OpenCode Go) are by definition current, so
+  nothing outranks them.
+- **The account must match.** If identities are known and none is the pane's
+  account, nothing is borrowed — showing another account's numbers is worse
+  than showing none. When no observer named the account, a borrow happens only
+  if exactly one account was observed for that provider.
+- **A borrowed row says so.** It carries the account (or `account unverified`),
+  the observer, and the age of the observation, e.g.
+  `account you@example.com · via OMP · ~3m ago`.
+
+A combination with no observer left is reported honestly rather than guessed:
+Pi never persists windows of its own, so a Claude or Codex account used
+exclusively through Pi, on a machine where neither the vendor CLI nor OMP has
+ever touched that account, still shows its "no data" note. Grok and OpenCode Go
+are unaffected either way — their usage fetches are authenticated over the
+network and need no local observer at all.
 
 ### Harness and billing identity
 
@@ -375,7 +414,8 @@ the matching quota collector. Today the supported subscription routes are:
 | Codex | ChatGPT login | Codex |
 | OpenCode | `opencode-go` | OpenCode Go |
 | OpenCode | OpenAI / Codex OAuth | Codex |
-| Grok | Grok OAuth | Grok |
+| OpenCode | `xai-oauth` | Grok |
+| OpenCode | `anthropic` + OAuth | Claude |
 | OMP / Pi | `opencode-go` | OpenCode Go |
 | OMP / Pi | `xai-oauth` | Grok |
 | OMP / Pi | `anthropic` + OAuth | Claude |
@@ -384,9 +424,11 @@ the matching quota collector. Today the supported subscription routes are:
 The same provider id with an API key is pay-as-you-go, so it is never routed
 to a subscription limit by name alone. A subscription whose collector is not
 implemented (for example Copilot) is intentionally not presented as API
-spend; add its collector and an explicit route first. OpenCode's official
-documentation does not support routing Claude Pro/Max through OpenCode, so it
-is not a supported Claude subscription route here.
+spend; add its collector and an explicit route first. The two OpenCode rows
+for Grok and Claude fire only when OpenCode's own `auth.json` holds a real
+OAuth credential for that provider; OpenCode's documentation does not offer
+those subscriptions, so most installs never hit them. A credential filed
+under one provider is never accepted as evidence for another.
 
 The Usage pane keys both subscription and API blocks by billing provider, not
 by harness. For example, OpenCode and OMP using OpenCode Go produce one

--- a/internal/limits/agentdb_test.go
+++ b/internal/limits/agentdb_test.go
@@ -1,0 +1,74 @@
+/**
+ * Fixture builder for OMP's agent.db, shared by the window-pool tests.
+ */
+package limits
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// usageRow is one usage_history row for a fixture DB. Field shapes mirror
+// OMP's own schema, including epoch-millisecond timestamps.
+type usageRow struct {
+	RecordedAtMs int64
+	Provider     string
+	AccountKey   string
+	Email        string
+	AccountID    string
+	LimitID      string
+	Label        string
+	WindowLabel  string
+	UsedFraction float64
+	Status       string
+	ResetsAtMs   int64
+}
+
+// writeAgentDB builds an OMP agent.db holding rows and returns its path.
+func writeAgentDB(t *testing.T, rows ...usageRow) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE usage_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		recorded_at INTEGER NOT NULL,
+		provider TEXT NOT NULL,
+		account_key TEXT NOT NULL,
+		email TEXT,
+		account_id TEXT,
+		limit_id TEXT NOT NULL,
+		label TEXT NOT NULL,
+		window_label TEXT,
+		used_fraction REAL,
+		status TEXT,
+		resets_at INTEGER)`); err != nil {
+		t.Fatalf("create fixture table: %v", err)
+	}
+	for _, r := range rows {
+		if _, err := db.Exec(`INSERT INTO usage_history
+			(recorded_at, provider, account_key, email, account_id, limit_id,
+			 label, window_label, used_fraction, status, resets_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+			r.RecordedAtMs, r.Provider, r.AccountKey, r.Email, r.AccountID,
+			r.LimitID, r.Label, r.WindowLabel, r.UsedFraction, r.Status,
+			r.ResetsAtMs); err != nil {
+			t.Fatalf("insert fixture row: %v", err)
+		}
+	}
+	return path
+}
+
+// useAgentDB points the window pool at a fixture DB for one test.
+func useAgentDB(t *testing.T, rows ...usageRow) string {
+	t.Helper()
+	path := writeAgentDB(t, rows...)
+	t.Setenv("USAGEBAR_OMP_AGENT_DB", path)
+	return path
+}

--- a/internal/limits/claudecache.go
+++ b/internal/limits/claudecache.go
@@ -1,6 +1,7 @@
 /**
- * Rate-limit collection for Claude Code.
- * Priority: ~/.claude.json cachedUsageUtilization -> statusLine cache
+ * Rate-limit collection for Claude.
+ * Priority: ~/.claude.json cachedUsageUtilization -> statusLine cache ->
+ * another agent's observation of the same account (see windowpool.go).
  */
 package limits
 
@@ -126,7 +127,11 @@ func collectFromStatusLineCache(nowMs int64, path string) *ProviderLimits {
 	return &out
 }
 
-// CollectClaudeLimits prefers claude.json; falls back to the statusLine cache.
+// CollectClaudeLimits returns the freshest observation of this account's
+// windows. Claude Code's own artifacts are consulted first, but they are
+// caches with a timestamp, not live truth: when another agent has observed
+// the same account's same window more recently, that reading wins. Provenance
+// does not make a snapshot current — only its timestamp does.
 func CollectClaudeLimits(nowMs int64, options CollectClaudeLimitsOptions) ProviderLimits {
 	statusPath := options.StatusLineCachePath
 	if statusPath == "" {
@@ -137,11 +142,20 @@ func CollectClaudeLimits(nowMs int64, options CollectClaudeLimitsOptions) Provid
 		jsonPath = ResolveClaudeJSONPath()
 	}
 
-	if fromJSON := CollectClaudeLimitsFromJSON(nowMs, jsonPath); fromJSON != nil {
-		return *fromJSON
+	native := CollectClaudeLimitsFromJSON(nowMs, jsonPath)
+	if native == nil {
+		native = collectFromStatusLineCache(nowMs, statusPath)
 	}
-	if fromCache := collectFromStatusLineCache(nowMs, statusPath); fromCache != nil {
-		return *fromCache
+	// The windows belong to the account, so any agent's reading of them
+	// counts — including when Claude Code wrote nothing at all.
+	account, _ := AccountEmailFromJSONPath(jsonPath)
+	if borrowed := borrowWindows("claude", "Claude", account, nowMs); borrowed != nil {
+		if native == nil || borrowed.FetchedAtMs > native.FetchedAtMs {
+			return *borrowed
+		}
+	}
+	if native != nil {
+		return *native
 	}
 	note := "no ~/.claude.json utilization and no statusLine cache"
 	return ProviderLimits{

--- a/internal/limits/claudecache_test.go
+++ b/internal/limits/claudecache_test.go
@@ -5,6 +5,7 @@ package limits
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -151,5 +152,282 @@ func TestWriteClaudeLimitsCacheGuarded_SeparateProfilePaths(t *testing.T) {
 	}
 	if b.Primary == nil || b.Primary.UsedPercentage != 90 {
 		t.Fatalf("profile B = %+v", b.Primary)
+	}
+}
+
+// Two distinct Claude accounts as OMP records them. The composed account_key
+// is the shape OMP writes; it is deliberately not an identity (see
+// AccountWindows.identity), so the strict-join tests below must key off the
+// email/account id inside it.
+const (
+	claudeObsEmailA = "asrsena3302@gmail.com"
+	claudeObsIDA    = "f3a39003-3c6f-438d-8b25-cf345f085528"
+	claudeObsKeyA   = "oauth|account:f3a39003-3c6f-438d-8b25-cf345f085528|email:asrsena3302@gmail.com|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+
+	claudeObsEmailB = "second.account@example.com"
+	claudeObsIDB    = "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+	claudeObsKeyB   = "oauth|account:0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9|email:second.account@example.com|org:7c6b5a49-3821-4f0e-9d1c-2b3a4958e6f7"
+)
+
+// claudeObservationRows is the pair of usage_history rows OMP writes for one
+// Claude account: the 5h and 7d windows the server reported. Fractions are
+// binary-exact so the ×100 conversion is comparable without a tolerance.
+func claudeObservationRows(recordedAtMs int64, accountKey, email, accountID string, fiveHour, sevenDay float64) []usageRow {
+	return []usageRow{
+		{
+			RecordedAtMs: recordedAtMs, Provider: "anthropic", AccountKey: accountKey,
+			Email: email, AccountID: accountID, LimitID: "anthropic:5h",
+			Label: "Claude", WindowLabel: "5h", UsedFraction: fiveHour,
+			Status: "ok", ResetsAtMs: recordedAtMs + 3_600_000,
+		},
+		{
+			RecordedAtMs: recordedAtMs, Provider: "anthropic", AccountKey: accountKey,
+			Email: email, AccountID: accountID, LimitID: "anthropic:7d",
+			Label: "Claude", WindowLabel: "7d", UsedFraction: sevenDay,
+			Status: "ok", ResetsAtMs: recordedAtMs + 86_400_000,
+		},
+	}
+}
+
+func writeClaudeJSONFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mustHaveBorrowableObservation asserts the pool really holds an observation
+// this collector could borrow. A test that expects borrowing NOT to happen is
+// worthless without it: it would pass just as happily when the fixture DB
+// never loaded at all.
+func mustHaveBorrowableObservation(t *testing.T, providerID string) {
+	t.Helper()
+	if SelectAccountWindows(ObserveAccountWindows(), providerID, "") == nil {
+		t.Fatalf("fixture holds no borrowable %s observation", providerID)
+	}
+}
+
+// Issue #29: a Claude subscription driven entirely through another harness
+// writes neither Claude Code artifact, so both first-hand tiers are empty.
+// The windows still belong to the account, and OMP observed them — reporting
+// "no data" here was the regression.
+func TestClaudeLimitsCache_BorrowsObservationWhenNoArtifacts(t *testing.T) {
+	const nowMs = int64(1_800_000_000_000)
+	const observedAtMs = nowMs - 5*60_000
+	dir := t.TempDir()
+	useAgentDB(t, claudeObservationRows(observedAtMs, claudeObsKeyA, claudeObsEmailA, claudeObsIDA, 0.25, 0.75)...)
+
+	got := CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{
+		StatusLineCachePath: filepath.Join(dir, "missing-cache.json"),
+		ClaudeJSONPath:      filepath.Join(dir, "missing-claude.json"),
+	})
+
+	if got.Source != "omp usage_history" {
+		t.Fatalf("source = %q, want borrowed observation", got.Source)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 25 {
+		t.Fatalf("primary = %+v, want the borrowed 5h window at 25%%", got.Primary)
+	}
+	if got.Secondary == nil || got.Secondary.UsedPercentage != 75 {
+		t.Fatalf("secondary = %+v, want the borrowed 7d window at 75%%", got.Secondary)
+	}
+	if got.Note == nil {
+		t.Fatal("borrowed windows must be attributed, got no note")
+	}
+	if !containsStr(*got.Note, "via OMP") {
+		t.Fatalf("note = %q, want observer attribution", *got.Note)
+	}
+	if !containsStr(*got.Note, claudeObsEmailA) {
+		t.Fatalf("note = %q, want the observed account named", *got.Note)
+	}
+	if got.FetchedAtMs != observedAtMs {
+		t.Fatalf("fetchedAtMs = %d, want the observation time %d", got.FetchedAtMs, observedAtMs)
+	}
+}
+
+// A first-hand Claude artifact always outranks a borrowed observation: the
+// account's own CLI wrote its numbers, the pool only relayed someone else's.
+func TestClaudeLimitsCache_FirstHandOutranksBorrowed(t *testing.T) {
+	const nowMs = int64(1_800_000_000_000)
+	cases := []struct {
+		name       string
+		writeJSON  bool
+		writeCache bool
+		wantPct    float64
+		wantSource string
+	}{
+		{"claude.json utilization wins", true, false, 8, "claude.json cachedUsageUtilization"},
+		{"statusLine cache wins", false, true, 61, "claude statusLine cache"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			jsonPath := filepath.Join(dir, "claude.json")
+			cachePath := filepath.Join(dir, "cache.json")
+			// An observation is available and must lose to either artifact.
+			useAgentDB(t, claudeObservationRows(nowMs-5*60_000, claudeObsKeyA, claudeObsEmailA, claudeObsIDA, 0.5, 0.5)...)
+			mustHaveBorrowableObservation(t, "claude")
+
+			if tc.writeJSON {
+				writeClaudeJSONFile(t, jsonPath, `{
+					"cachedUsageUtilization": {
+						"fetchedAtMs": 1799999940000,
+						"utilization": {
+							"five_hour": { "utilization": 8, "resets_at": "2027-01-15T12:00:00.000Z" },
+							"seven_day": { "utilization": 21, "resets_at": "2027-01-20T00:00:00.000Z" }
+						}
+					},
+					"oauthAccount": { "emailAddress": "`+claudeObsEmailA+`" }
+				}`)
+			}
+			if tc.writeCache {
+				if err := WriteClaudeLimitsCache(fiveHourInput(61), nowMs, cachePath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{
+				StatusLineCachePath: cachePath,
+				ClaudeJSONPath:      jsonPath,
+			})
+
+			if got.Source != tc.wantSource {
+				t.Fatalf("source = %q, want %q (first-hand must outrank borrowed)", got.Source, tc.wantSource)
+			}
+			if got.Primary == nil || got.Primary.UsedPercentage != tc.wantPct {
+				t.Fatalf("primary = %+v, want the first-hand %v%%", got.Primary, tc.wantPct)
+			}
+			if got.Note != nil {
+				t.Fatalf("note = %q, want none for a fresh first-hand read", *got.Note)
+			}
+		})
+	}
+}
+
+// ~/.claude.json names the account this pane bills to even when it carries no
+// utilization. Borrowing is then a strict join: another account's numbers are
+// worse than no numbers, because they look first-hand once rendered.
+func TestClaudeLimitsCache_BorrowRequiresMatchingAccount(t *testing.T) {
+	const nowMs = int64(1_800_000_000_000)
+	cases := []struct {
+		name                           string
+		obsKey, obsEmail, obsAccountID string
+		wantBorrow                     bool
+	}{
+		{"observation belongs to another account", claudeObsKeyB, claudeObsEmailB, claudeObsIDB, false},
+		{"observation belongs to this account", claudeObsKeyA, claudeObsEmailA, claudeObsIDA, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			jsonPath := filepath.Join(dir, "claude.json")
+			// Logged in as account A, but Claude Code never cached a window.
+			writeClaudeJSONFile(t, jsonPath, `{"oauthAccount": {"emailAddress": "`+claudeObsEmailA+`"}}`)
+			useAgentDB(t, claudeObservationRows(nowMs-5*60_000, tc.obsKey, tc.obsEmail, tc.obsAccountID, 0.25, 0.75)...)
+			mustHaveBorrowableObservation(t, "claude")
+
+			got := CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{
+				StatusLineCachePath: filepath.Join(dir, "missing-cache.json"),
+				ClaudeJSONPath:      jsonPath,
+			})
+
+			if !tc.wantBorrow {
+				if got.Primary != nil || got.Secondary != nil {
+					t.Fatalf("borrowed another account's windows: %+v / %+v", got.Primary, got.Secondary)
+				}
+				if got.Source != "none" {
+					t.Fatalf("source = %q, want none", got.Source)
+				}
+				if got.Note == nil || !containsStr(*got.Note, "no ~/.claude.json utilization") {
+					t.Fatalf("note = %v, want the no-utilization fallback", got.Note)
+				}
+				return
+			}
+			if got.Source != "omp usage_history" {
+				t.Fatalf("source = %q, want borrowed observation", got.Source)
+			}
+			if got.Primary == nil || got.Primary.UsedPercentage != 25 {
+				t.Fatalf("primary = %+v, want the borrowed 5h window at 25%%", got.Primary)
+			}
+			if got.Note == nil || !containsStr(*got.Note, "via OMP") {
+				t.Fatalf("note = %v, want observer attribution", got.Note)
+			}
+		})
+	}
+}
+
+// claudeJSONWithFetchedAt is a ~/.claude.json whose cached utilization carries
+// an explicit observation time, so recency can be pitted against provenance.
+func claudeJSONWithFetchedAt(fetchedAtMs int64, fiveHourUsed float64) string {
+	return fmt.Sprintf(`{
+		"oauthAccount": {"emailAddress": %q},
+		"cachedUsageUtilization": {
+			"fetchedAtMs": %d,
+			"utilization": {
+				"five_hour": {"utilization": %v, "resets_at": "2026-07-15T00:00:00.000Z"},
+				"seven_day": {"utilization": 5, "resets_at": "2026-07-20T00:00:00.000Z"}
+			}
+		}
+	}`, claudeObsEmailA, fetchedAtMs, fiveHourUsed)
+}
+
+// TestClaudeLimitsCache_FreshestObservationWins pins the rule that provenance
+// does not decide the reading — the timestamp does.
+//
+// Observed live: ~/.claude.json reported 43% used while OMP reported 80% for
+// the SAME 5h window (identical resets_at), because the Claude CLI had been
+// idle while OMP kept working. Preferring the first-hand cache there
+// under-reports usage right up against a limit, which is the failure this
+// guards.
+func TestClaudeLimitsCache_FreshestObservationWins(t *testing.T) {
+	const nowMs = 1_800_000_000_000
+	const minute = 60_000
+
+	cases := []struct {
+		name           string
+		jsonFetchedAt  int64
+		observedAt     int64
+		wantSource     string
+		wantPrimaryPct float64
+	}{
+		{
+			name:           "stale claude.json loses to a fresher observation",
+			jsonFetchedAt:  nowMs - 60*minute,
+			observedAt:     nowMs - 1*minute,
+			wantSource:     "omp usage_history",
+			wantPrimaryPct: 80,
+		},
+		{
+			name:           "fresh claude.json beats an older observation",
+			jsonFetchedAt:  nowMs - 1*minute,
+			observedAt:     nowMs - 60*minute,
+			wantSource:     "claude.json cachedUsageUtilization",
+			wantPrimaryPct: 43,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			jsonPath := filepath.Join(dir, "claude.json")
+			writeClaudeJSONFile(t, jsonPath, claudeJSONWithFetchedAt(tc.jsonFetchedAt, 43))
+			useAgentDB(t, claudeObservationRows(
+				tc.observedAt, claudeObsKeyA, claudeObsEmailA, claudeObsIDA, 0.8, 0.25)...)
+			mustHaveBorrowableObservation(t, "claude")
+
+			got := CollectClaudeLimits(nowMs, CollectClaudeLimitsOptions{
+				StatusLineCachePath: filepath.Join(dir, "missing-cache.json"),
+				ClaudeJSONPath:      jsonPath,
+			})
+			if got.Source != tc.wantSource {
+				t.Fatalf("source = %q, want %q (note=%v)", got.Source, tc.wantSource, got.Note)
+			}
+			if got.Primary == nil {
+				t.Fatal("expected a primary window")
+			}
+			if got.Primary.UsedPercentage != tc.wantPrimaryPct {
+				t.Fatalf("primary used = %v%%, want %v%%", got.Primary.UsedPercentage, tc.wantPrimaryPct)
+			}
+		})
 	}
 }

--- a/internal/limits/codexlimits.go
+++ b/internal/limits/codexlimits.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/senna-lang/herdr-agent-usage/internal/fsutil"
 	"github.com/senna-lang/herdr-agent-usage/internal/planlabels"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 )
 
 const codexTailScanBytes = 512 * 1024
@@ -22,6 +23,11 @@ const codexTailScanBytes = 512 * 1024
 // active session, so the first file almost always has it; the cap only guards
 // the pathological case of many just-opened sessions with no token_count yet.
 const codexMaxRolloutsToScan = 25
+
+// codexStaleAfterMinutes matches the statusLine cache tolerance in
+// claudecache.go. Past it the snapshot is labeled rather than trusted
+// silently — a rollout is only as current as the turn that wrote it.
+const codexStaleAfterMinutes = 30
 
 // ExtractedCodexRateLimits is the raw extract result (planType still raw).
 type ExtractedCodexRateLimits struct {
@@ -196,12 +202,13 @@ func codexHome() string {
 // matching the Claude/OpenCode/Grok collectors. Assumes a single Codex account
 // (~/.codex is single-auth); with multiple accounts this reports whichever
 // session turned most recently.
+//
+// A rollout snapshot is a cache with a timestamp, not live truth. When
+// another agent has observed this same account's windows more recently, that
+// reading wins (see windowpool.go) — which is also what makes a Codex
+// subscription driven through another harness report real numbers at all.
 func CollectCodexLimits(_ *string, nowMs int64) ProviderLimits {
 	paths := ListNewestRolloutPaths(codexMaxRolloutsToScan)
-	if len(paths) == 0 {
-		note := "no rollout jsonl under ~/.codex/sessions"
-		return ProviderLimits{ProviderID: "codex", Label: "Codex", Source: "none", FetchedAtMs: nowMs, Note: &note}
-	}
 	// Newest-first: take the first rollout that carries a rate_limits snapshot.
 	// A just-opened session has session_meta but no token_count yet, so the
 	// newest file is not always the one with data.
@@ -214,17 +221,58 @@ func CollectCodexLimits(_ *string, nowMs int64) ProviderLimits {
 		if extracted == nil {
 			continue
 		}
-		plan := planlabels.CodexPlanLabel(extracted.PlanType)
-		return ProviderLimits{
+		observedMs := rolloutObservedAtMs(path)
+		out := ProviderLimits{
 			ProviderID:  "codex",
 			Label:       "Codex",
 			Primary:     extracted.Primary,
 			Secondary:   extracted.Secondary,
-			PlanType:    plan,
+			PlanType:    planlabels.CodexPlanLabel(extracted.PlanType),
 			Source:      "codex rollout",
 			FetchedAtMs: nowMs,
 		}
+		if age := minutesBetween(observedMs, nowMs); age > codexStaleAfterMinutes {
+			note := "stale ~" + itoa(age) + "m ago"
+			out.Note = &note
+		}
+		if borrowed := borrowCodexWindows(nowMs); borrowed != nil && borrowed.FetchedAtMs > observedMs {
+			return *borrowed
+		}
+		return out
+	}
+	if borrowed := borrowCodexWindows(nowMs); borrowed != nil {
+		return *borrowed
+	}
+	if len(paths) == 0 {
+		note := "no rollout jsonl under ~/.codex/sessions"
+		return ProviderLimits{ProviderID: "codex", Label: "Codex", Source: "none", FetchedAtMs: nowMs, Note: &note}
 	}
 	note := "rollout found but no rate_limits in recent token_count"
 	return ProviderLimits{ProviderID: "codex", Label: "Codex", Source: "codex rollout", FetchedAtMs: nowMs, Note: &note}
+}
+
+// borrowCodexWindows takes another agent's observation of this Codex account.
+// Signed in locally? Then the observation must belong to that same account.
+// Signed out, there is no identity to contradict, and the pool's own
+// single-account rule is what keeps the borrow honest.
+func borrowCodexWindows(nowMs int64) *ProviderLimits {
+	return borrowWindows("codex", "Codex", codex.AccountID(), nowMs)
+}
+
+// rolloutObservedAtMs is when the rollout last recorded a turn, i.e. when its
+// rate-limit snapshot was taken. 0 when the file cannot be stat'd.
+func rolloutObservedAtMs(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixMilli()
+}
+
+// minutesBetween is whole elapsed minutes, never negative.
+func minutesBetween(fromMs, toMs int64) int {
+	if fromMs <= 0 || toMs <= fromMs {
+		return 0
+	}
+	return int((toMs - fromMs) / 60_000)
 }

--- a/internal/limits/codexlimits_test.go
+++ b/internal/limits/codexlimits_test.go
@@ -153,3 +153,209 @@ func TestCollectCodexLimits_SkipsSnapshotlessNewest(t *testing.T) {
 		t.Fatalf("expected fallback to older snapshot 7, got %+v (note=%v)", got.Primary, got.Note)
 	}
 }
+
+// codexObservationRows is the pair of usage_history rows OMP writes for one
+// Codex account. Fractions are binary-exact so the ×100 conversion compares
+// without a tolerance.
+func codexObservationRows(recordedAtMs int64, primary, secondary float64) []usageRow {
+	const (
+		accountKey = "oauth|account:9f8e7d6c-5b4a-4392-8170-6e5d4c3b2a19|email:asrsena3302@gmail.com"
+		email      = "asrsena3302@gmail.com"
+		accountID  = "9f8e7d6c-5b4a-4392-8170-6e5d4c3b2a19"
+	)
+	return []usageRow{
+		{
+			RecordedAtMs: recordedAtMs, Provider: "openai-codex", AccountKey: accountKey,
+			Email: email, AccountID: accountID, LimitID: "openai-codex:primary",
+			Label: "Codex", WindowLabel: "5h", UsedFraction: primary,
+			Status: "ok", ResetsAtMs: recordedAtMs + 3_600_000,
+		},
+		{
+			RecordedAtMs: recordedAtMs, Provider: "openai-codex", AccountKey: accountKey,
+			Email: email, AccountID: accountID, LimitID: "openai-codex:secondary",
+			Label: "Codex", WindowLabel: "weekly", UsedFraction: secondary,
+			Status: "ok", ResetsAtMs: recordedAtMs + 86_400_000,
+		},
+	}
+}
+
+// Issue #29: a Codex subscription driven through another harness leaves
+// ~/.codex/sessions empty, so the only local record of the account's windows
+// is another agent's observation.
+func TestCollectCodexLimits_BorrowsObservationWhenNoRollouts(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+	nowMs := base.UnixMilli()
+	observedAtMs := nowMs - 5*60_000
+	t.Setenv("CODEX_HOME", t.TempDir())
+	useAgentDB(t, codexObservationRows(observedAtMs, 0.25, 0.75)...)
+
+	got := CollectCodexLimits(nil, nowMs)
+
+	if got.Source != "omp usage_history" {
+		t.Fatalf("source = %q, want borrowed observation", got.Source)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 25 {
+		t.Fatalf("primary = %+v, want the borrowed primary window at 25%%", got.Primary)
+	}
+	if got.Secondary == nil || got.Secondary.UsedPercentage != 75 {
+		t.Fatalf("secondary = %+v, want the borrowed secondary window at 75%%", got.Secondary)
+	}
+	if got.Note == nil || !containsStr(*got.Note, "via OMP") {
+		t.Fatalf("note = %v, want observer attribution", got.Note)
+	}
+	if got.FetchedAtMs != observedAtMs {
+		t.Fatalf("fetchedAtMs = %d, want the observation time %d", got.FetchedAtMs, observedAtMs)
+	}
+}
+
+// A rollout snapshot is first-hand and must outrank a borrowed observation.
+func TestCollectCodexLimits_RolloutOutranksBorrowed(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+	nowMs := base.UnixMilli()
+	root := t.TempDir()
+	t.Setenv("CODEX_HOME", root)
+	useAgentDB(t, codexObservationRows(nowMs-5*60_000, 0.25, 0.75)...)
+	mustHaveBorrowableObservation(t, "codex")
+	writeRollout(t, root, "has-data", "/repo/a", 8, base)
+
+	got := CollectCodexLimits(nil, nowMs)
+
+	if got.Source != "codex rollout" {
+		t.Fatalf("source = %q, want the first-hand rollout", got.Source)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 8 {
+		t.Fatalf("primary = %+v, want the rollout's 8%%, not the borrowed 25%%", got.Primary)
+	}
+}
+
+// Sessions exist but none ever recorded a token_count, so there is no
+// first-hand snapshot to prefer — the observation is all there is.
+func TestCollectCodexLimits_BorrowsWhenRolloutsCarryNoRateLimits(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+	nowMs := base.UnixMilli()
+	root := t.TempDir()
+	t.Setenv("CODEX_HOME", root)
+	useAgentDB(t, codexObservationRows(nowMs-5*60_000, 0.25, 0.75)...)
+	writeRollout(t, root, "meta-only-a", "/repo/a", -1, base.Add(-time.Minute))
+	writeRollout(t, root, "meta-only-b", "/repo/b", -1, base)
+
+	got := CollectCodexLimits(nil, nowMs)
+
+	if got.Source != "omp usage_history" {
+		t.Fatalf("source = %q, want borrowed observation", got.Source)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 25 {
+		t.Fatalf("primary = %+v, want the borrowed primary window at 25%%", got.Primary)
+	}
+}
+
+// With neither a rollout nor an observation the collector still reports the
+// plain "no data" row rather than inventing one.
+func TestCollectCodexLimits_NoRolloutsAndNoObservation(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+
+	got := CollectCodexLimits(nil, time.Now().UnixMilli())
+
+	if got.Source != "none" {
+		t.Fatalf("source = %q, want none", got.Source)
+	}
+	if got.Primary != nil || got.Secondary != nil {
+		t.Fatalf("expected no windows, got %+v / %+v", got.Primary, got.Secondary)
+	}
+	if got.Note == nil || *got.Note != "no rollout jsonl under ~/.codex/sessions" {
+		t.Fatalf("note = %v, want the missing-rollout explanation", got.Note)
+	}
+}
+
+// A rollout is only as current as the turn that wrote it. Past
+// codexStaleAfterMinutes the snapshot is labeled rather than rendered as if it
+// were live; a fresh one must carry no warning at all.
+func TestCollectCodexLimits_StaleRolloutIsLabeled(t *testing.T) {
+	base := time.Now().Truncate(time.Second)
+	nowMs := base.UnixMilli()
+	cases := []struct {
+		name     string
+		mtime    time.Time
+		wantNote string // "" means the note must be absent
+	}{
+		{"two-hour-old snapshot is labeled stale", base.Add(-2 * time.Hour), "stale ~120m ago"},
+		{"snapshot from this turn is not labeled", base, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("CODEX_HOME", root)
+			writeRollout(t, root, "only", "/repo/a", 12, tc.mtime)
+
+			got := CollectCodexLimits(nil, nowMs)
+
+			if got.Primary == nil || got.Primary.UsedPercentage != 12 {
+				t.Fatalf("primary = %+v, want the rollout snapshot regardless of age", got.Primary)
+			}
+			if tc.wantNote == "" {
+				if got.Note != nil {
+					t.Fatalf("note = %q, want none for a current snapshot", *got.Note)
+				}
+				return
+			}
+			if got.Note == nil {
+				t.Fatalf("want note %q, got none", tc.wantNote)
+			}
+			if *got.Note != tc.wantNote {
+				t.Fatalf("note = %q, want %q", *got.Note, tc.wantNote)
+			}
+		})
+	}
+}
+
+// TestCollectCodexLimits_FreshestObservationWins pins recency over provenance
+// for Codex: a rollout is a snapshot stamped at the turn that wrote it, so an
+// account since driven by another agent has a newer reading elsewhere.
+func TestCollectCodexLimits_FreshestObservationWins(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	nowMs := now.UnixMilli()
+
+	cases := []struct {
+		name           string
+		rolloutMtime   time.Time
+		observedAt     int64
+		wantSource     string
+		wantPrimaryPct float64
+	}{
+		{
+			name:           "stale rollout loses to a fresher observation",
+			rolloutMtime:   now.Add(-2 * time.Hour),
+			observedAt:     nowMs - 60_000,
+			wantSource:     "omp usage_history",
+			wantPrimaryPct: 75,
+		},
+		{
+			name:           "fresh rollout beats an older observation",
+			rolloutMtime:   now,
+			observedAt:     nowMs - 2*60*60_000,
+			wantSource:     "codex rollout",
+			wantPrimaryPct: 12,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("CODEX_HOME", root)
+			writeRollout(t, root, "has-data", "/repo/a", 12, tc.rolloutMtime)
+			useAgentDB(t, codexObservationRows(tc.observedAt, 0.75, 0.5)...)
+			mustHaveBorrowableObservation(t, "codex")
+
+			got := CollectCodexLimits(nil, nowMs)
+			if got.Source != tc.wantSource {
+				t.Fatalf("source = %q, want %q (note=%v)", got.Source, tc.wantSource, got.Note)
+			}
+			if got.Primary == nil {
+				t.Fatal("expected a primary window")
+			}
+			if got.Primary.UsedPercentage != tc.wantPrimaryPct {
+				t.Fatalf("primary used = %v%%, want %v%%", got.Primary.UsedPercentage, tc.wantPrimaryPct)
+			}
+		})
+	}
+}

--- a/internal/limits/groklimits.go
+++ b/internal/limits/groklimits.go
@@ -220,6 +220,9 @@ func TryGrokBillingRPC(nowMs int64, email *string) *ProviderLimits {
 
 // CollectGrokLimits reads auth and applies identity / web billing.
 // When opts fetchers are nil, production HTTP implementations are used.
+// Every dead end falls back to another agent's observation of the same xAI
+// account (see windowpool.go): Grok's meters need a fresh `grok login`, which
+// a subscription driven through another harness never performs.
 func CollectGrokLimits(nowMs int64, opts CollectGrokLimitsOptions) ProviderLimits {
 	path := opts.AuthPath
 	if path == "" {
@@ -227,17 +230,26 @@ func CollectGrokLimits(nowMs int64, opts CollectGrokLimitsOptions) ProviderLimit
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
+		if b := borrowGrokWindows(nil, nil, nowMs); b != nil {
+			return *b
+		}
 		note := "no ~/.grok/auth.json — run `grok login`"
 		return ProviderLimits{ProviderID: "grok", Label: "Grok", Source: "none", FetchedAtMs: nowMs, Note: &note}
 	}
 	auth := ParseGrokAuthJSON(string(raw))
 	if auth == nil {
+		if b := borrowGrokWindows(nil, nil, nowMs); b != nil {
+			return *b
+		}
 		note := "no ~/.grok/auth.json — run `grok login`"
 		return ProviderLimits{ProviderID: "grok", Label: "Grok", Source: "none", FetchedAtMs: nowMs, Note: &note}
 	}
 
 	if auth.ExpiresAt != nil {
 		if t, err := time.Parse(time.RFC3339, *auth.ExpiresAt); err == nil && t.UnixMilli() < nowMs {
+			if b := borrowGrokWindows(auth.Email, nil, nowMs); b != nil {
+				return *b
+			}
 			note := "token expired"
 			if auth.Email != nil {
 				note = fmt.Sprintf("token expired (%s) — run `grok login`", *auth.Email)
@@ -295,6 +307,9 @@ func CollectGrokLimits(nowMs int64, opts CollectGrokLimitsOptions) ProviderLimit
 		return *fromRPC
 	}
 
+	if b := borrowGrokWindows(auth.Email, plan, nowMs); b != nil {
+		return *b
+	}
 	email := "signed in"
 	if auth.Email != nil {
 		email = *auth.Email
@@ -304,4 +319,19 @@ func CollectGrokLimits(nowMs int64, opts CollectGrokLimitsOptions) ProviderLimit
 		ProviderID: "grok", Label: "Grok", PlanType: plan,
 		Source: "grok auth.json (identity only)", FetchedAtMs: nowMs, Note: &note,
 	}
+}
+
+// borrowGrokWindows takes another agent's observation of this xAI account
+// when Grok's own meters are unavailable. A plan tier already resolved from
+// grok.com is kept: it is first-hand even when the windows are not.
+func borrowGrokWindows(email *string, plan *string, nowMs int64) *ProviderLimits {
+	account := ""
+	if email != nil {
+		account = *email
+	}
+	borrowed := borrowWindows("grok", "Grok", account, nowMs)
+	if borrowed != nil && plan != nil {
+		borrowed.PlanType = plan
+	}
+	return borrowed
 }

--- a/internal/limits/groklimits_test.go
+++ b/internal/limits/groklimits_test.go
@@ -5,6 +5,9 @@ package limits
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -52,5 +55,266 @@ func TestProviderLimitsFromBillingResult(t *testing.T) {
 	}
 	if ProviderLimitsFromBillingResult(map[string]any{}, 0, nil) != nil {
 		t.Fatal("expected nil")
+	}
+}
+
+// The xAI account OMP observed. `grok login` names the same one, when a
+// usable login exists at all.
+const (
+	grokAccountEmail = "asrsena3302@gmail.com"
+	grokAccountID    = "f3a39003-3c6f-438d-8b25-cf345f085528"
+	grokNowMs        = int64(1_784_946_198_000)
+	// Half an hour before now, so the borrowed note carries a stable age.
+	grokObservedAtMs    = grokNowMs - 30*60_000
+	grokCreditsResetMs  = grokNowMs + 3*3_600_000
+	grokIncludedResetMs = grokNowMs + 20*24*3_600_000
+	grokBorrowedNote    = "account " + grokAccountEmail + " · via OMP · ~30m ago"
+)
+
+// grokObservationRows is OMP's record of one xAI account's plan meters.
+func grokObservationRows(email, accountID string) []usageRow {
+	key := "oauth|account:" + accountID + "|email:" + email + "|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+	row := func(limitID string, fraction float64, resetsAtMs int64) usageRow {
+		return usageRow{
+			RecordedAtMs: grokObservedAtMs, Provider: "xai-oauth", AccountKey: key,
+			Email: email, AccountID: accountID, LimitID: limitID, Label: "Grok",
+			UsedFraction: fraction, Status: "ok", ResetsAtMs: resetsAtMs,
+		}
+	}
+	return []usageRow{
+		row("xai-oauth:credits:1w", 0.5, grokCreditsResetMs),
+		row("xai-oauth:included:1mo", 0.25, grokIncludedResetMs),
+	}
+}
+
+// grokAuthJSON is a SuperGrok entry in the shape `grok login` writes.
+func grokAuthJSON(email, expiresAt string) string {
+	return fmt.Sprintf(
+		`{"https://auth.x.ai::supergrok":{"email":%q,"auth_mode":"oidc","key":"sk-grok-fixture","expires_at":%q}}`,
+		email, expiresAt)
+}
+
+// grokDeadEnd is one path through CollectGrokLimits that yields no first-hand
+// windows. Each must prefer another agent's observation of the same account,
+// and keep its own honest note when there is nothing to borrow.
+type grokDeadEnd struct {
+	name string
+	// authJSON is written to opts.AuthPath; empty leaves the file absent.
+	authJSON string
+	// knowsAccount is true when the collector got far enough to read the
+	// login's email, which is what makes the join to an observation strict.
+	knowsAccount bool
+	// planTier is what FetchPlanTier answers on the paths that reach it.
+	planTier   string
+	wantPlan   string
+	wantNote   string
+	wantSource string
+}
+
+// options writes this dead end's auth.json and pins every network helper, so
+// no test touches grok.com or spawns `grok agent stdio`.
+func (d grokDeadEnd) options(t *testing.T) CollectGrokLimitsOptions {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if d.authJSON != "" {
+		if err := os.WriteFile(path, []byte(d.authJSON), 0o600); err != nil {
+			t.Fatalf("write auth.json: %v", err)
+		}
+	}
+	tier := d.planTier
+	return CollectGrokLimitsOptions{
+		AuthPath: path,
+		FetchPlanTier: func(string) *string {
+			if tier == "" {
+				return nil
+			}
+			return &tier
+		},
+		FetchWebBilling: func(string) *LimitWindow { return nil },
+		TryBillingRPC:   func(int64, *string) *ProviderLimits { return nil },
+	}
+}
+
+func grokDeadEnds() []grokDeadEnd {
+	future := time.UnixMilli(grokNowMs).Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	past := time.UnixMilli(grokNowMs).Add(-time.Hour).UTC().Format(time.RFC3339)
+	const missingAuthNote = "no ~/.grok/auth.json — run `grok login`"
+	return []grokDeadEnd{
+		{
+			name:       "auth file missing",
+			wantNote:   missingAuthNote,
+			wantSource: "none",
+		},
+		{
+			name:       "auth file unparseable",
+			authJSON:   "{not json",
+			wantNote:   missingAuthNote,
+			wantSource: "none",
+		},
+		{
+			name:       "auth file holds no entry",
+			authJSON:   "{}",
+			wantNote:   missingAuthNote,
+			wantSource: "none",
+		},
+		{
+			// The real-world driver: the vendor CLI's token lapses while the
+			// same subscription keeps being driven — and stays live —
+			// through another harness.
+			name:         "token expired",
+			authJSON:     grokAuthJSON(grokAccountEmail, past),
+			knowsAccount: true,
+			wantNote:     "token expired (" + grokAccountEmail + ") — run `grok login`",
+			wantSource:   "grok auth.json",
+		},
+		{
+			name:         "no rate meters",
+			authJSON:     grokAuthJSON(grokAccountEmail, future),
+			knowsAccount: true,
+			planTier:     "SUBSCRIPTION_TIER_SUPER_GROK_HEAVY",
+			wantPlan:     "Heavy",
+			wantNote: grokAccountEmail +
+				" · rate meters unavailable (web billing failed; x.ai/billing not on agent stdio)",
+			wantSource: "grok auth.json (identity only)",
+		},
+	}
+}
+
+func checkGrokPlan(t *testing.T, got *string, want string) {
+	t.Helper()
+	switch {
+	case want == "" && got != nil:
+		t.Fatalf("PlanType: got %q, want unset", *got)
+	case want != "" && (got == nil || *got != want):
+		t.Fatalf("PlanType: got %v, want %q", got, want)
+	}
+}
+
+// Grok's meters need a fresh `grok login`, which a subscription driven only
+// through another harness never performs. Every dead end must therefore fall
+// back to that harness's observation of the same account.
+func TestCollectGrokLimits_BorrowsAtEveryDeadEnd(t *testing.T) {
+	for _, tc := range grokDeadEnds() {
+		t.Run(tc.name, func(t *testing.T) {
+			useAgentDB(t, grokObservationRows(grokAccountEmail, grokAccountID)...)
+			got := CollectGrokLimits(grokNowMs, tc.options(t))
+
+			if got.Source != "omp usage_history" {
+				t.Fatalf("Source: got %q, want the borrowed observation", got.Source)
+			}
+			if got.ProviderID != "grok" || got.Label != "Grok" {
+				t.Fatalf("borrowed row must still be Grok's, got %q/%q", got.ProviderID, got.Label)
+			}
+			if got.Note == nil || *got.Note != grokBorrowedNote {
+				t.Fatalf("Note: got %v, want %q", got.Note, grokBorrowedNote)
+			}
+			if got.FetchedAtMs != grokObservedAtMs {
+				t.Fatalf("FetchedAtMs: got %d, want the observation time %d", got.FetchedAtMs, grokObservedAtMs)
+			}
+			checkGrokPlan(t, got.PlanType, tc.wantPlan)
+
+			if got.Primary == nil || got.Primary.UsedPercentage != 50 {
+				t.Fatalf("Primary: got %+v, want 50%% used", got.Primary)
+			}
+			if got.Primary.WindowMinutes == nil || *got.Primary.WindowMinutes != 10080 {
+				t.Fatalf("Primary window minutes: got %v, want the 1w credits meter", got.Primary.WindowMinutes)
+			}
+			if got.Primary.ResetsAt == nil || *got.Primary.ResetsAt != grokCreditsResetMs/1000 {
+				t.Fatalf("Primary ResetsAt: got %v, want epoch seconds %d", got.Primary.ResetsAt, grokCreditsResetMs/1000)
+			}
+			if got.Secondary == nil || got.Secondary.UsedPercentage != 25 {
+				t.Fatalf("Secondary: got %+v, want 25%% used", got.Secondary)
+			}
+			if got.Secondary.WindowMinutes == nil || *got.Secondary.WindowMinutes != 43200 {
+				t.Fatalf("Secondary window minutes: got %v, want the 1mo included meter", got.Secondary.WindowMinutes)
+			}
+		})
+	}
+}
+
+// The fallback must not swallow the honest message: with nothing observed,
+// every dead end still says exactly why it has no numbers.
+func TestCollectGrokLimits_DeadEndNotesSurviveWithoutObservation(t *testing.T) {
+	for _, tc := range grokDeadEnds() {
+		t.Run(tc.name, func(t *testing.T) {
+			useAgentDB(t)
+			got := CollectGrokLimits(grokNowMs, tc.options(t))
+
+			if got.Note == nil || *got.Note != tc.wantNote {
+				t.Fatalf("Note: got %v, want %q", got.Note, tc.wantNote)
+			}
+			if got.Source != tc.wantSource {
+				t.Fatalf("Source: got %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.FetchedAtMs != grokNowMs {
+				t.Fatalf("FetchedAtMs: got %d, want %d", got.FetchedAtMs, grokNowMs)
+			}
+			checkGrokPlan(t, got.PlanType, tc.wantPlan)
+			if got.Primary != nil || got.Secondary != nil || got.Tertiary != nil {
+				t.Fatalf("dead end must carry no windows, got %+v", got)
+			}
+		})
+	}
+}
+
+// An observation is the last resort, never a shortcut past grok.com's own
+// answer.
+func TestCollectGrokLimits_FetchedWindowOutranksObservation(t *testing.T) {
+	useAgentDB(t, grokObservationRows(grokAccountEmail, grokAccountID)...)
+	future := time.UnixMilli(grokNowMs).Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(grokAuthJSON(grokAccountEmail, future)), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+
+	got := CollectGrokLimits(grokNowMs, CollectGrokLimitsOptions{
+		AuthPath:        authPath,
+		FetchPlanTier:   func(string) *string { return nil },
+		FetchWebBilling: func(string) *LimitWindow { return &LimitWindow{UsedPercentage: 7} },
+		TryBillingRPC:   func(int64, *string) *ProviderLimits { return nil },
+	})
+
+	if got.Source != "grok.com GetGrokCreditsConfig" {
+		t.Fatalf("Source: got %q, want the first-hand web billing source", got.Source)
+	}
+	if got.Primary == nil || got.Primary.UsedPercentage != 7 {
+		t.Fatalf("Primary: got %+v, want the fetched 7%% window", got.Primary)
+	}
+	if got.Secondary != nil {
+		t.Fatalf("the observation's weekly meter must not leak in: %+v", got.Secondary)
+	}
+	if got.FetchedAtMs != grokNowMs {
+		t.Fatalf("FetchedAtMs: got %d, want the fetch time %d", got.FetchedAtMs, grokNowMs)
+	}
+	if want := "account " + grokAccountEmail; got.Note == nil || *got.Note != want {
+		t.Fatalf("Note: got %v, want %q", got.Note, want)
+	}
+}
+
+// Showing account A's numbers on a pane billing account B is worse than
+// showing nothing, so a named mismatch refuses to borrow.
+func TestCollectGrokLimits_RefusesAnotherAccountsObservation(t *testing.T) {
+	const (
+		otherEmail     = "someone-else@example.com"
+		otherAccountID = "0f0c6a4e-2a51-4b1f-9f42-9c1a0d2f77aa"
+	)
+	for _, tc := range grokDeadEnds() {
+		if !tc.knowsAccount {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			useAgentDB(t, grokObservationRows(otherEmail, otherAccountID)...)
+			got := CollectGrokLimits(grokNowMs, tc.options(t))
+
+			if got.Source == "omp usage_history" {
+				t.Fatalf("borrowed %s's windows onto %s's pane", otherEmail, grokAccountEmail)
+			}
+			if got.Note == nil || *got.Note != tc.wantNote {
+				t.Fatalf("Note: got %v, want %q", got.Note, tc.wantNote)
+			}
+			if got.Primary != nil || got.Secondary != nil {
+				t.Fatalf("no window may come from a foreign account, got %+v", got)
+			}
+		})
 	}
 }

--- a/internal/limits/main_test.go
+++ b/internal/limits/main_test.go
@@ -1,0 +1,21 @@
+/**
+ * Package-wide test defaults.
+ */
+package limits
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain points the window pool at a path that cannot exist.
+//
+// Collectors now fall back to another agent's observations, so without this a
+// developer's real ~/.omp/agent/agent.db would leak into every "no data"
+// assertion and the suite would pass or fail depending on whose machine ran
+// it. A test that wants observations overrides the variable with t.Setenv.
+func TestMain(m *testing.M) {
+	_ = os.Setenv("USAGEBAR_OMP_AGENT_DB", filepath.Join(os.TempDir(), "usagebar-absent-agent.db"))
+	os.Exit(m.Run())
+}

--- a/internal/limits/opencodego.go
+++ b/internal/limits/opencodego.go
@@ -397,6 +397,8 @@ func loadCostEventsFromDB(dbPath string) ([]CostEvent, error) {
 // OPENCODE_GO_COOKIE or an imported browser session) then the local DB
 // estimate. The web result — success or failure — is cached, because the
 // sidebar collects on every pane status change.
+// When that fetch is unavailable, another agent's observation of the same
+// account (see windowpool.go) is preferred over the local estimate.
 func CollectOpenCodeLimits(nowMs int64, dbPath string) ProviderLimits {
 	// A fresh cache entry with no limits is a recent unsuccessful attempt:
 	// fall through to the local estimate without retrying the network.
@@ -412,6 +414,12 @@ func CollectOpenCodeLimits(nowMs int64, dbPath string) ProviderLimits {
 		return pl
 	} else {
 		saveOpenCodeWebCache(nil, openCodeWebFetchFailed, nowMs)
+	}
+	// The web fetch is the only first-hand source of the official windows and
+	// the local DB below is list-price arithmetic. Another agent's observation
+	// of this opencode-go account is real server data, so it outranks it.
+	if borrowed := borrowWindows("opencode", "OpenCode", "", nowMs); borrowed != nil {
+		return *borrowed
 	}
 	if dbPath == "" {
 		dbPath = ResolveOpenCodeLimitsDBPath()

--- a/internal/limits/opencodego_test.go
+++ b/internal/limits/opencodego_test.go
@@ -4,8 +4,11 @@
 package limits
 
 import (
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -128,4 +131,228 @@ func mustJSONCost(v any) string {
 		panic(err)
 	}
 	return string(b)
+}
+
+const (
+	openCodeNowMs = int64(1_784_946_198_000)
+	// Three quarters of an hour before now, for a stable borrowed age.
+	openCodeObservedAtMs = openCodeNowMs - 45*60_000
+	openCodeEmail        = "asrsena3302@gmail.com"
+	openCodeAccountID    = "f3a39003-3c6f-438d-8b25-cf345f085528"
+	openCodeRollingReset = openCodeNowMs + 2*3_600_000
+	openCodeWeeklyReset  = openCodeNowMs + 3*24*3_600_000
+	openCodeMonthlyReset = openCodeNowMs + 12*24*3_600_000
+	// One assistant message an hour ago: $4.50 of the $12 five-hour cap.
+	openCodeLocalCostUSD  = 4.5
+	openCodeLocalUsedPct  = 37.5
+	openCodeLocalSource   = "opencode.db local cost (Go caps, calendar week/month)"
+	openCodeBorrowedNote  = "account " + openCodeEmail + " · via OMP · ~45m ago"
+	openCodeUnverifiedNot = "account unverified · via OMP · ~45m ago"
+)
+
+// neutralizeOpenCodeWeb keeps opencode.ai out of the collector: a private
+// cache file, no pasted cookie header, and no browser session import. What
+// remains is the borrow-vs-local-estimate decision under test.
+func neutralizeOpenCodeWeb(t *testing.T) {
+	t.Helper()
+	t.Setenv("USAGEBAR_OPENCODE_WEB_CACHE_PATH", filepath.Join(t.TempDir(), "opencode-go-web.json"))
+	t.Setenv("USAGEBAR_DISABLE_BROWSER_COOKIES", "1")
+	t.Setenv("OPENCODE_GO_COOKIE", "")
+}
+
+// openCodeObservationRows is OMP's record of one opencode-go account's three
+// official windows.
+func openCodeObservationRows(accountKey, email, accountID string) []usageRow {
+	row := func(limitID string, fraction float64, resetsAtMs int64) usageRow {
+		return usageRow{
+			RecordedAtMs: openCodeObservedAtMs, Provider: "opencode-go", AccountKey: accountKey,
+			Email: email, AccountID: accountID, LimitID: limitID, Label: "OpenCode",
+			UsedFraction: fraction, Status: "ok", ResetsAtMs: resetsAtMs,
+		}
+	}
+	return []usageRow{
+		row("rolling-5h", 0.5, openCodeRollingReset),
+		row("weekly", 0.25, openCodeWeeklyReset),
+		row("monthly", 0.125, openCodeMonthlyReset),
+	}
+}
+
+// openCodeOAuthRows is the identified account, keyed the way OMP composes an
+// OAuth key.
+func openCodeOAuthRows() []usageRow {
+	key := "oauth|account:" + openCodeAccountID + "|email:" + openCodeEmail +
+		"|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+	return openCodeObservationRows(key, openCodeEmail, openCodeAccountID)
+}
+
+// writeOpenCodeCostDB builds a minimal opencode.db holding one assistant
+// message per cost, an hour before openCodeNowMs.
+func writeOpenCodeCostDB(t *testing.T, providerID string, costs ...float64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "opencode.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture opencode.db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE message (
+		id TEXT PRIMARY KEY, data TEXT, time_created INTEGER)`); err != nil {
+		t.Fatalf("create fixture message table: %v", err)
+	}
+	created := openCodeNowMs - 3_600_000
+	for i, cost := range costs {
+		data, err := json.Marshal(map[string]any{
+			"role":       "assistant",
+			"providerID": providerID,
+			"cost":       cost,
+			"time":       map[string]any{"created": created},
+		})
+		if err != nil {
+			t.Fatalf("marshal fixture message: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO message (id, data, time_created) VALUES (?,?,?)`,
+			fmt.Sprintf("msg-%d", i), string(data), created); err != nil {
+			t.Fatalf("insert fixture message: %v", err)
+		}
+	}
+	return path
+}
+
+func checkOpenCodeWindow(t *testing.T, name string, got *LimitWindow, wantUsed float64, wantMinutes int, wantResetsAtMs int64) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s: missing window", name)
+	}
+	if got.UsedPercentage != wantUsed {
+		t.Fatalf("%s used: got %v, want %v", name, got.UsedPercentage, wantUsed)
+	}
+	if got.WindowMinutes == nil || *got.WindowMinutes != wantMinutes {
+		t.Fatalf("%s window minutes: got %v, want %d", name, got.WindowMinutes, wantMinutes)
+	}
+	if got.ResetsAt == nil || *got.ResetsAt != wantResetsAtMs/1000 {
+		t.Fatalf("%s ResetsAt: got %v, want epoch seconds %d", name, got.ResetsAt, wantResetsAtMs/1000)
+	}
+}
+
+// opencode-go keeps no usage numbers on disk, so without a web session
+// another agent's observation is the only real server data available.
+func TestCollectOpenCodeLimits_BorrowsWhenWebUnavailable(t *testing.T) {
+	neutralizeOpenCodeWeb(t)
+	useAgentDB(t, openCodeOAuthRows()...)
+
+	got := CollectOpenCodeLimits(openCodeNowMs, filepath.Join(t.TempDir(), "absent.db"))
+
+	if got.Source != "omp usage_history" {
+		t.Fatalf("Source: got %q, want the borrowed observation", got.Source)
+	}
+	if got.ProviderID != "opencode" || got.Label != "OpenCode" {
+		t.Fatalf("borrowed row must still be OpenCode's, got %q/%q", got.ProviderID, got.Label)
+	}
+	if got.Note == nil || *got.Note != openCodeBorrowedNote {
+		t.Fatalf("Note: got %v, want %q", got.Note, openCodeBorrowedNote)
+	}
+	if got.FetchedAtMs != openCodeObservedAtMs {
+		t.Fatalf("FetchedAtMs: got %d, want the observation time %d", got.FetchedAtMs, openCodeObservedAtMs)
+	}
+	checkOpenCodeWindow(t, "Primary", got.Primary, 50, 300, openCodeRollingReset)
+	checkOpenCodeWindow(t, "Secondary", got.Secondary, 25, 10080, openCodeWeeklyReset)
+	checkOpenCodeWindow(t, "Tertiary", got.Tertiary, 12.5, 43200, openCodeMonthlyReset)
+}
+
+// The precedence that matters. The local DB is list-price arithmetic over
+// message costs; an observation is what the server actually reported. With
+// both on disk the observation must win, or correct numbers silently
+// downgrade to an estimate. The second case proves the local DB really would
+// have answered — and answered differently — so the first is not vacuous.
+func TestCollectOpenCodeLimits_ObservationOutranksLocalEstimate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		rows       []usageRow
+		wantSource string
+		wantUsed   float64
+	}{
+		{"observed", openCodeOAuthRows(), "omp usage_history", 50},
+		{"not observed", nil, openCodeLocalSource, openCodeLocalUsedPct},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			neutralizeOpenCodeWeb(t)
+			useAgentDB(t, tc.rows...)
+			dbPath := writeOpenCodeCostDB(t, "opencode-go", openCodeLocalCostUSD)
+
+			got := CollectOpenCodeLimits(openCodeNowMs, dbPath)
+
+			if got.Source != tc.wantSource {
+				t.Fatalf("Source: got %q, want %q", got.Source, tc.wantSource)
+			}
+			if got.Primary == nil || got.Primary.UsedPercentage != tc.wantUsed {
+				t.Fatalf("Primary: got %+v, want %v%% used", got.Primary, tc.wantUsed)
+			}
+		})
+	}
+}
+
+// With nothing observed the collector keeps its pre-existing local behaviour.
+func TestCollectOpenCodeLimits_LocalFallbackWithoutObservation(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.db")
+	for _, tc := range []struct {
+		name       string
+		dbPath     func(t *testing.T) string
+		wantSource func(dbPath string) string
+		wantNote   func(dbPath string) string
+	}{
+		{
+			name:       "db missing",
+			dbPath:     func(*testing.T) string { return missing },
+			wantSource: func(string) string { return "none" },
+			wantNote:   func(p string) string { return "db not found: " + p },
+		},
+		{
+			name: "db holds no opencode-go costs",
+			dbPath: func(t *testing.T) string {
+				return writeOpenCodeCostDB(t, "deepseek", openCodeLocalCostUSD)
+			},
+			wantSource: func(p string) string { return p },
+			wantNote:   func(string) string { return "no opencode-go assistant costs in local db" },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			neutralizeOpenCodeWeb(t)
+			useAgentDB(t)
+			dbPath := tc.dbPath(t)
+
+			got := CollectOpenCodeLimits(openCodeNowMs, dbPath)
+
+			if got.Source != tc.wantSource(dbPath) {
+				t.Fatalf("Source: got %q, want %q", got.Source, tc.wantSource(dbPath))
+			}
+			if got.Note == nil || *got.Note != tc.wantNote(dbPath) {
+				t.Fatalf("Note: got %v, want %q", got.Note, tc.wantNote(dbPath))
+			}
+			if got.Primary != nil || got.Secondary != nil || got.Tertiary != nil {
+				t.Fatalf("no windows may be invented, got %+v", got)
+			}
+			if got.FetchedAtMs != openCodeNowMs {
+				t.Fatalf("FetchedAtMs: got %d, want %d", got.FetchedAtMs, openCodeNowMs)
+			}
+		})
+	}
+}
+
+// OMP records some opencode-go accounts by opaque key alone. A single such
+// account is still borrowable — labelled unverified, never as a confirmed
+// identity.
+func TestCollectOpenCodeLimits_BorrowsUnverifiedAccount(t *testing.T) {
+	neutralizeOpenCodeWeb(t)
+	useAgentDB(t, openCodeObservationRows("api_key|secret:e9554082fe7595c1", "", "")...)
+
+	got := CollectOpenCodeLimits(openCodeNowMs, filepath.Join(t.TempDir(), "absent.db"))
+
+	if got.Source != "omp usage_history" {
+		t.Fatalf("Source: got %q, want the borrowed observation", got.Source)
+	}
+	if got.Note == nil || *got.Note != openCodeUnverifiedNot {
+		t.Fatalf("Note: got %v, want %q", got.Note, openCodeUnverifiedNot)
+	}
+	checkOpenCodeWindow(t, "Primary", got.Primary, 50, 300, openCodeRollingReset)
+	checkOpenCodeWindow(t, "Tertiary", got.Tertiary, 12.5, 43200, openCodeMonthlyReset)
 }

--- a/internal/limits/windowpool.go
+++ b/internal/limits/windowpool.go
@@ -1,0 +1,347 @@
+/**
+ * Account-keyed pool of rate-limit window observations.
+ *
+ * A rate-limit window belongs to the ACCOUNT, not to the agent that happened
+ * to observe it. codexlimits.go already states this for Codex ("rate limits
+ * are account-wide: every session records the same primary/secondary
+ * window"), and it holds for every provider here. Yet each collector binds
+ * its data source to one vendor CLI's private files, so an account driven
+ * through another harness reports "no data" even when its real windows sit
+ * on disk, recorded by whoever did make the request.
+ *
+ * This pool closes that gap: observations are keyed by (provider, account),
+ * and a collector whose own sources are empty borrows the newest observation
+ * for ITS account from any observer.
+ *
+ * Two rules are load-bearing, because a wrong borrow is worse than an honest
+ * blank:
+ *   1. The account join is strict — a borrow that cannot be shown to concern
+ *      the same account is refused (SelectAccountWindows).
+ *   2. A borrowed row always names its observer, its account (or says the
+ *      account is unverified), and its age (BorrowedProviderLimits). It must
+ *      never render as first-hand current data.
+ */
+package limits
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
+)
+
+// AccountWindows is one agent's observation of one account's windows.
+type AccountWindows struct {
+	// ProviderID is the collector id this observation feeds (claude, codex,
+	// grok, opencode) — not the harness that recorded it.
+	ProviderID string
+	// AccountKey is the observer's raw account key. It is NOT an identity:
+	// OMP composes it from the credential shape, so one account appears under
+	// several keys ("oauth|account:…|email:…" and "oauth|secret:…").
+	AccountKey string
+	// AccountID and Email are the stable identity, when the observer has one.
+	AccountID string
+	Email     string
+	Primary   *LimitWindow
+	Secondary *LimitWindow
+	Tertiary  *LimitWindow
+	// ObservedAtMs is when the observing agent saw these numbers.
+	ObservedAtMs int64
+	// Observer names who recorded it, for display attribution.
+	Observer string
+}
+
+// hasWindow reports whether the observation carries anything displayable.
+func (a AccountWindows) hasWindow() bool {
+	return a.Primary != nil || a.Secondary != nil || a.Tertiary != nil
+}
+
+// identity collapses the observer's keys to one stable account identity.
+func (a AccountWindows) identity() string {
+	if a.AccountID != "" {
+		return a.AccountID
+	}
+	if a.Email != "" {
+		return strings.ToLower(a.Email)
+	}
+	return a.AccountKey
+}
+
+// identified reports whether the observer named the account at all. An
+// unidentified observation can be neither confirmed nor refuted against a
+// wanted account.
+func (a AccountWindows) identified() bool {
+	return a.AccountID != "" || a.Email != ""
+}
+
+// identifies reports whether this observation belongs to account want, which
+// may be an email or an account id.
+func (a AccountWindows) identifies(want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	if want == "" {
+		return false
+	}
+	if strings.EqualFold(a.Email, want) || strings.EqualFold(a.AccountID, want) {
+		return true
+	}
+	// OMP embeds both inside its composed key.
+	return strings.Contains(strings.ToLower(a.AccountKey), want)
+}
+
+// windowSlot is where a provider's window belongs in the display triple.
+type windowSlot int
+
+const (
+	slotNone windowSlot = iota
+	slotPrimary
+	slotSecondary
+	slotTertiary
+)
+
+// slotForLimitID maps an OMP limit_id to a display slot.
+//
+// The window vocabulary differs per provider, so the mapping is explicit
+// rather than pattern-matched: an unrecognized id is skipped, never guessed
+// into the wrong bar. The returned minutes label the window for display.
+func slotForLimitID(providerID, limitID string) (windowSlot, int) {
+	switch providerID {
+	case "claude":
+		switch limitID {
+		case "anthropic:5h":
+			return slotPrimary, 300
+		case "anthropic:7d":
+			return slotSecondary, 10080
+		}
+		// anthropic:extra carries no window semantics the panel can render.
+	case "codex":
+		switch {
+		case strings.HasSuffix(limitID, ":primary"):
+			return slotPrimary, 300
+		case strings.HasSuffix(limitID, ":secondary"):
+			return slotSecondary, 10080
+		}
+	case "grok":
+		switch limitID {
+		// The plan meter, matching the single window CollectGrokLimits shows.
+		case "xai-oauth:credits:1w":
+			return slotPrimary, 10080
+		case "xai-oauth:included:1mo":
+			return slotSecondary, 43200
+		}
+		// xai-oauth:product:* are per-product sub-meters with no display slot.
+	case "opencode":
+		switch limitID {
+		case "rolling-5h":
+			return slotPrimary, 300
+		case "weekly":
+			return slotSecondary, 10080
+		case "monthly":
+			return slotTertiary, 43200
+		}
+	}
+	return slotNone, 0
+}
+
+// windowFromUsageFraction converts an OMP row to a display window. The
+// fraction may exceed 1 for an exhausted window; remaining cannot go
+// negative, so it clamps at fully used. resets_at is epoch ms upstream and
+// epoch seconds in LimitWindow.
+func windowFromUsageFraction(usedFraction float64, resetsAtMs int64, windowMinutes int) *LimitWindow {
+	used := usedFraction * 100
+	if used < 0 {
+		used = 0
+	}
+	if used > 100 {
+		used = 100
+	}
+	w := &LimitWindow{UsedPercentage: used}
+	if windowMinutes > 0 {
+		m := windowMinutes
+		w.WindowMinutes = &m
+	}
+	if resetsAtMs > 0 {
+		sec := resetsAtMs / 1000
+		w.ResetsAt = &sec
+	}
+	return w
+}
+
+// AccountWindowsFromOMP folds OMP's usage_history rows into per-account
+// observations.
+//
+// Rows reach a collector through the one shared route table
+// (SubscriptionRouteForProviderAuth): a usage_history row only exists for a
+// subscription account, which is what "oauth" asserts there. Providers the
+// table does not route are skipped rather than guessed.
+func AccountWindowsFromOMP(rows []omp.UsageWindow) []AccountWindows {
+	// Oldest first, so a newer row for the same slot overwrites an older one.
+	ordered := make([]omp.UsageWindow, len(rows))
+	copy(ordered, rows)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].RecordedAtMs < ordered[j].RecordedAtMs
+	})
+
+	type key struct{ provider, account string }
+	index := make(map[key]*AccountWindows)
+	order := make([]key, 0, len(ordered))
+
+	for _, row := range ordered {
+		route, ok := SubscriptionRouteForProviderAuth(row.Provider, "oauth")
+		if !ok {
+			continue
+		}
+		slot, minutes := slotForLimitID(route.CollectorProviderID, row.LimitID)
+		if slot == slotNone {
+			continue
+		}
+		candidate := AccountWindows{
+			ProviderID: route.CollectorProviderID,
+			AccountKey: row.AccountKey,
+			AccountID:  row.AccountID,
+			Email:      row.Email,
+			Observer:   "OMP",
+		}
+		k := key{route.CollectorProviderID, candidate.identity()}
+		acc, seen := index[k]
+		if !seen {
+			acc = &candidate
+			index[k] = acc
+			order = append(order, k)
+		}
+		if acc.Email == "" {
+			acc.Email = row.Email
+		}
+		if acc.AccountID == "" {
+			acc.AccountID = row.AccountID
+		}
+		window := windowFromUsageFraction(row.UsedFraction, row.ResetsAtMs, minutes)
+		switch slot {
+		case slotPrimary:
+			acc.Primary = window
+		case slotSecondary:
+			acc.Secondary = window
+		case slotTertiary:
+			acc.Tertiary = window
+		}
+		if row.RecordedAtMs > acc.ObservedAtMs {
+			acc.ObservedAtMs = row.RecordedAtMs
+		}
+	}
+
+	out := make([]AccountWindows, 0, len(order))
+	for _, k := range order {
+		out = append(out, *index[k])
+	}
+	return out
+}
+
+// SelectAccountWindows picks the observation a collector may borrow for
+// providerID, or nil when borrowing cannot be shown to concern the right
+// account.
+//
+// wantAccount is the identity the pane bills to, empty when the collector
+// cannot name it. The rules, in order:
+//   - An exact identity match always wins.
+//   - Identities exist for this provider but none match the wanted account →
+//     refuse. Showing account A's numbers on a pane billing account B is
+//     worse than showing nothing.
+//   - Nobody named the account (the observer records some providers by
+//     opaque key only) → borrow only when a single account was observed, and
+//     let BorrowedProviderLimits label it unverified.
+func SelectAccountWindows(observations []AccountWindows, providerID, wantAccount string) *AccountWindows {
+	var candidates []AccountWindows
+	for _, o := range observations {
+		if o.ProviderID == providerID && o.hasWindow() {
+			candidates = append(candidates, o)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	if strings.TrimSpace(wantAccount) != "" {
+		var matched []AccountWindows
+		anyIdentified := false
+		for _, c := range candidates {
+			if c.identified() {
+				anyIdentified = true
+			}
+			if c.identifies(wantAccount) {
+				matched = append(matched, c)
+			}
+		}
+		switch {
+		case len(matched) > 0:
+			candidates = matched
+		case anyIdentified:
+			return nil
+		default:
+			if !singleAccount(candidates) {
+				return nil
+			}
+		}
+	} else if !singleAccount(candidates) {
+		return nil
+	}
+
+	newest := candidates[0]
+	for _, c := range candidates[1:] {
+		if c.ObservedAtMs > newest.ObservedAtMs {
+			newest = c
+		}
+	}
+	return &newest
+}
+
+// singleAccount reports whether every candidate is the same account.
+func singleAccount(candidates []AccountWindows) bool {
+	first := candidates[0].identity()
+	for _, c := range candidates[1:] {
+		if c.identity() != first {
+			return false
+		}
+	}
+	return true
+}
+
+// observationAge renders how long ago an observation was taken.
+func observationAge(observedAtMs, nowMs int64) string {
+	minutes := int((nowMs - observedAtMs) / 60_000)
+	if minutes < 1 {
+		return "just now"
+	}
+	if minutes < 60 {
+		return "~" + itoa(minutes) + "m ago"
+	}
+	return "~" + itoa(minutes/60) + "h ago"
+}
+
+// BorrowedProviderLimits renders another agent's observation as this
+// provider's row. Attribution, account and age are not optional: without them
+// a borrowed number is indistinguishable from a first-hand one.
+func BorrowedProviderLimits(o AccountWindows, providerID, label string, nowMs int64) ProviderLimits {
+	account := "account unverified"
+	if o.Email != "" {
+		account = "account " + o.Email
+	}
+	// An observation with no timestamp is dated "now" so the row is not
+	// treated as stale, and its age is reported as unknown rather than
+	// computed from the epoch — the row must not claim both at once.
+	age := "age unknown"
+	fetched := nowMs
+	if o.ObservedAtMs > 0 {
+		age = observationAge(o.ObservedAtMs, nowMs)
+		fetched = o.ObservedAtMs
+	}
+	note := strings.Join([]string{account, "via " + o.Observer, age}, " · ")
+	return ProviderLimits{
+		ProviderID:  providerID,
+		Label:       label,
+		Primary:     o.Primary,
+		Secondary:   o.Secondary,
+		Tertiary:    o.Tertiary,
+		Source:      strings.ToLower(o.Observer) + " usage_history",
+		FetchedAtMs: fetched,
+		Note:        &note,
+	}
+}

--- a/internal/limits/windowpool_io.go
+++ b/internal/limits/windowpool_io.go
@@ -1,0 +1,29 @@
+/**
+ * Disk side of the window pool: gathers every local observation.
+ */
+package limits
+
+import "github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
+
+// ObserveAccountWindows returns every rate-limit observation available on
+// this machine.
+//
+// OMP's usage_history is currently the only observer that records windows for
+// accounts beyond its own vendor CLI's, so it is the only source here; the
+// vendor CLIs stay each collector's first-hand tier. Adding an observer means
+// appending to this function, not touching the collectors.
+func ObserveAccountWindows() []AccountWindows {
+	return AccountWindowsFromOMP(omp.LatestUsageWindows(omp.ResolveAgentDBPath()))
+}
+
+// borrowWindows builds providerID's row from another agent's observation of
+// account wantAccount, or returns nil when nothing may be borrowed. Pass an
+// empty wantAccount when the collector cannot name its account.
+func borrowWindows(providerID, label, wantAccount string, nowMs int64) *ProviderLimits {
+	selected := SelectAccountWindows(ObserveAccountWindows(), providerID, wantAccount)
+	if selected == nil {
+		return nil
+	}
+	borrowed := BorrowedProviderLimits(*selected, providerID, label, nowMs)
+	return &borrowed
+}

--- a/internal/limits/windowpool_test.go
+++ b/internal/limits/windowpool_test.go
@@ -1,0 +1,783 @@
+/**
+ * Tests for the pure logic of the account-keyed window pool: limit-id → slot
+ * routing, OMP fraction → display window conversion, folding usage_history
+ * rows into per-account observations, borrow eligibility, and the rendering
+ * of a borrowed row.
+ *
+ * Collector integration and the SQLite reader are covered elsewhere; nothing
+ * here touches disk.
+ */
+package limits
+
+import (
+	"math"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/omp"
+)
+
+// Observed on-disk shapes. One real account reaches usage_history under
+// several account_key spellings, which is exactly what the pool must collapse.
+const (
+	wpKeyOAuthFull   = "oauth|account:f3a39003-3c6f-438d-8b25-cf345f085528|email:asrsena3302@gmail.com|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+	wpKeyOAuthSecret = "oauth|secret:c5f777162aca2d15"
+	wpKeyAPIKey      = "api_key|secret:e9554082fe7595c1"
+	wpAccountID      = "f3a39003-3c6f-438d-8b25-cf345f085528"
+	wpEmail          = "asrsena3302@gmail.com"
+	wpResetsAtMs     = int64(1785128400228)
+	wpResetsAtSec    = int64(1785128400)
+)
+
+func wpSlotName(s windowSlot) string {
+	switch s {
+	case slotNone:
+		return "slotNone"
+	case slotPrimary:
+		return "slotPrimary"
+	case slotSecondary:
+		return "slotSecondary"
+	case slotTertiary:
+		return "slotTertiary"
+	}
+	return "windowSlot(?)"
+}
+
+// wpNearly compares display percentages. They come from float arithmetic on a
+// fraction (0.28*100 is 28.000000000000004), so exact equality would assert
+// the FPU rather than the contract.
+func wpNearly(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func wpWindow(pct float64) *LimitWindow { return &LimitWindow{UsedPercentage: pct} }
+
+// wpMinutes renders a *int window length for failure messages.
+func wpMinutes(w *LimitWindow) string {
+	if w == nil {
+		return "<no window>"
+	}
+	if w.WindowMinutes == nil {
+		return "<nil>"
+	}
+	return itoa(*w.WindowMinutes)
+}
+
+func TestSlotForLimitID(t *testing.T) {
+	cases := []struct {
+		name        string
+		providerID  string
+		limitID     string
+		wantSlot    windowSlot
+		wantMinutes int
+	}{
+		{"claude 5h", "claude", "anthropic:5h", slotPrimary, 300},
+		{"claude 7d", "claude", "anthropic:7d", slotSecondary, 10080},
+		{"claude extra has no display slot", "claude", "anthropic:extra", slotNone, 0},
+
+		{"codex primary", "codex", "openai-codex:primary", slotPrimary, 300},
+		{"codex secondary", "codex", "openai-codex:secondary", slotSecondary, 10080},
+
+		{"grok weekly credits", "grok", "xai-oauth:credits:1w", slotPrimary, 10080},
+		{"grok monthly included", "grok", "xai-oauth:included:1mo", slotSecondary, 43200},
+		{"grok per-product sub-meter has no display slot", "grok", "xai-oauth:product:api:1w", slotNone, 0},
+
+		{"opencode rolling 5h", "opencode", "rolling-5h", slotPrimary, 300},
+		{"opencode weekly", "opencode", "weekly", slotSecondary, 10080},
+		{"opencode monthly", "opencode", "monthly", slotTertiary, 43200},
+
+		{"unknown id is never guessed", "claude", "anthropic:3h", slotNone, 0},
+		{"empty id", "claude", "", slotNone, 0},
+		{"unknown provider", "gemini", "anthropic:5h", slotNone, 0},
+		{"empty provider", "", "anthropic:5h", slotNone, 0},
+		{"provider id is matched exactly", "Claude", "anthropic:5h", slotNone, 0},
+
+		// A valid id belonging to a different provider must not leak across.
+		{"opencode id under claude", "claude", "rolling-5h", slotNone, 0},
+		{"claude id under opencode", "opencode", "anthropic:5h", slotNone, 0},
+		{"grok id under codex", "codex", "xai-oauth:credits:1w", slotNone, 0},
+		{"opencode weekly under codex", "codex", "weekly", slotNone, 0},
+		{"codex id under grok", "grok", "openai-codex:primary", slotNone, 0},
+
+		// The codex ids are matched by suffix, so a longer sub-meter id that
+		// merely contains "primary" is an unrecognized window, not the 5h one.
+		{"codex sub-meter below the primary window", "codex", "openai-codex:primary:legacy", slotNone, 0},
+		{"codex bare primary is not the suffix", "codex", "primary", slotNone, 0},
+		{"codex bare secondary is not the suffix", "codex", "secondary", slotNone, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			slot, minutes := slotForLimitID(c.providerID, c.limitID)
+			if slot != c.wantSlot {
+				t.Fatalf("%s: slotForLimitID(%q, %q) slot = %s, want %s",
+					c.name, c.providerID, c.limitID, wpSlotName(slot), wpSlotName(c.wantSlot))
+			}
+			if minutes != c.wantMinutes {
+				t.Fatalf("%s: slotForLimitID(%q, %q) minutes = %d, want %d",
+					c.name, c.providerID, c.limitID, minutes, c.wantMinutes)
+			}
+		})
+	}
+}
+
+func TestWindowFromUsageFraction(t *testing.T) {
+	// wantResetsAtSec / wantWindowMinutes of 0 mean "the pointer must be nil":
+	// the production rule is that only a positive value is displayable.
+	cases := []struct {
+		name              string
+		fraction          float64
+		resetsAtMs        int64
+		windowMinutes     int
+		wantPct           float64
+		wantResetsAtSec   int64
+		wantWindowMinutes int
+	}{
+		{"fraction scales to percent", 0.28, wpResetsAtMs, 300, 28, wpResetsAtSec, 300},
+		{"exhausted window clamps to 100", 1.0172968, wpResetsAtMs, 300, 100, wpResetsAtSec, 300},
+		{"negative fraction clamps to 0", -0.5, wpResetsAtMs, 300, 0, wpResetsAtSec, 300},
+		{"zero fraction", 0, wpResetsAtMs, 10080, 0, wpResetsAtSec, 10080},
+		{"exactly full", 1, wpResetsAtMs, 43200, 100, wpResetsAtSec, 43200},
+		{"sub-second reset truncates to the second", 0.5, 1785128400999, 300, 50, wpResetsAtSec, 300},
+		{"no reset time", 0.5, 0, 300, 50, 0, 300},
+		{"negative reset time is dropped", 0.5, -1, 300, 50, 0, 300},
+		{"no window length", 0.5, wpResetsAtMs, 0, 50, wpResetsAtSec, 0},
+		{"negative window length is dropped", 0.5, wpResetsAtMs, -1, 50, wpResetsAtSec, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := windowFromUsageFraction(c.fraction, c.resetsAtMs, c.windowMinutes)
+			if w == nil {
+				t.Fatalf("%s: windowFromUsageFraction returned nil", c.name)
+			}
+			if !wpNearly(w.UsedPercentage, c.wantPct) {
+				t.Fatalf("%s: UsedPercentage = %v, want %v (fraction %v)",
+					c.name, w.UsedPercentage, c.wantPct, c.fraction)
+			}
+			switch {
+			case c.wantResetsAtSec == 0 && w.ResetsAt != nil:
+				t.Fatalf("%s: ResetsAt = %d, want nil (resetsAtMs %d)", c.name, *w.ResetsAt, c.resetsAtMs)
+			case c.wantResetsAtSec != 0 && w.ResetsAt == nil:
+				t.Fatalf("%s: ResetsAt = nil, want %d epoch seconds (resetsAtMs %d)",
+					c.name, c.wantResetsAtSec, c.resetsAtMs)
+			case c.wantResetsAtSec != 0 && *w.ResetsAt != c.wantResetsAtSec:
+				t.Fatalf("%s: ResetsAt = %d, want %d epoch SECONDS from %d epoch ms",
+					c.name, *w.ResetsAt, c.wantResetsAtSec, c.resetsAtMs)
+			}
+			switch {
+			case c.wantWindowMinutes == 0 && w.WindowMinutes != nil:
+				t.Fatalf("%s: WindowMinutes = %d, want nil (windowMinutes %d)",
+					c.name, *w.WindowMinutes, c.windowMinutes)
+			case c.wantWindowMinutes != 0 && w.WindowMinutes == nil:
+				t.Fatalf("%s: WindowMinutes = nil, want %d", c.name, c.wantWindowMinutes)
+			case c.wantWindowMinutes != 0 && *w.WindowMinutes != c.wantWindowMinutes:
+				t.Fatalf("%s: WindowMinutes = %d, want %d", c.name, *w.WindowMinutes, c.wantWindowMinutes)
+			}
+		})
+	}
+}
+
+func TestAccountWindowsFromOMP(t *testing.T) {
+	t.Run("folds an account's windows into one observation", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:5h", UsedFraction: 0.28, ResetsAtMs: wpResetsAtMs, RecordedAtMs: 1785110000000},
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:7d", UsedFraction: 0.61, ResetsAtMs: 1785600000000, RecordedAtMs: 1785110000000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 1 {
+			t.Fatalf("fold 5h+7d: got %d observations, want 1: %+v", len(got), got)
+		}
+		o := got[0]
+		if o.ProviderID != "claude" {
+			t.Fatalf("fold 5h+7d: ProviderID = %q, want %q (collector id, not OMP's provider)", o.ProviderID, "claude")
+		}
+		if o.Observer != "OMP" {
+			t.Fatalf("fold 5h+7d: Observer = %q, want %q", o.Observer, "OMP")
+		}
+		if o.Primary == nil || o.Secondary == nil {
+			t.Fatalf("fold 5h+7d: want Primary and Secondary set, got Primary=%v Secondary=%v", o.Primary, o.Secondary)
+		}
+		if !wpNearly(o.Primary.UsedPercentage, 28) {
+			t.Fatalf("fold 5h+7d: Primary.UsedPercentage = %v, want 28", o.Primary.UsedPercentage)
+		}
+		if !wpNearly(o.Secondary.UsedPercentage, 61) {
+			t.Fatalf("fold 5h+7d: Secondary.UsedPercentage = %v, want 61", o.Secondary.UsedPercentage)
+		}
+		if wpMinutes(o.Primary) != "300" {
+			t.Fatalf("fold 5h+7d: Primary.WindowMinutes = %s, want 300", wpMinutes(o.Primary))
+		}
+		if wpMinutes(o.Secondary) != "10080" {
+			t.Fatalf("fold 5h+7d: Secondary.WindowMinutes = %s, want 10080", wpMinutes(o.Secondary))
+		}
+		if o.Tertiary != nil {
+			t.Fatalf("fold 5h+7d: Tertiary = %+v, want nil (claude has no monthly window)", *o.Tertiary)
+		}
+		if o.ObservedAtMs != 1785110000000 {
+			t.Fatalf("fold 5h+7d: ObservedAtMs = %d, want 1785110000000", o.ObservedAtMs)
+		}
+	})
+
+	t.Run("one account under two account keys collapses", func(t *testing.T) {
+		// The regression this whole pool exists for: OMP composes account_key
+		// from the credential shape, so the same subscription shows up as both
+		// "oauth|account:…|email:…" and "oauth|secret:…". Grouping by the raw
+		// key would produce two half-populated accounts.
+		identified := omp.UsageWindow{
+			Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+			LimitID: "anthropic:5h", UsedFraction: 0.28, ResetsAtMs: wpResetsAtMs,
+		}
+		opaque := omp.UsageWindow{
+			Provider: "anthropic", AccountKey: wpKeyOAuthSecret, AccountID: wpAccountID,
+			LimitID: "anthropic:7d", UsedFraction: 0.61, ResetsAtMs: 1785600000000,
+		}
+		cases := []struct {
+			name             string
+			identifiedAtMs   int64
+			opaqueAtMs       int64
+			wantObservedAtMs int64
+		}{
+			{"identified row recorded first", 1785110000000, 1785110500000, 1785110500000},
+			{"opaque row recorded first", 1785110500000, 1785110000000, 1785110500000},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				a, b := identified, opaque
+				a.RecordedAtMs = c.identifiedAtMs
+				b.RecordedAtMs = c.opaqueAtMs
+				got := AccountWindowsFromOMP([]omp.UsageWindow{a, b})
+				if len(got) != 1 {
+					t.Fatalf("%s: got %d observations, want 1 — grouping by raw account_key splits one account in two: %+v",
+						c.name, len(got), got)
+				}
+				o := got[0]
+				if o.AccountID != wpAccountID {
+					t.Fatalf("%s: AccountID = %q, want %q", c.name, o.AccountID, wpAccountID)
+				}
+				if o.Email != wpEmail {
+					t.Fatalf("%s: Email = %q, want %q — the collapsed observation must keep the identity the identified row carried",
+						c.name, o.Email, wpEmail)
+				}
+				if o.Primary == nil || o.Secondary == nil {
+					t.Fatalf("%s: want both keys' windows merged, got Primary=%v Secondary=%v", c.name, o.Primary, o.Secondary)
+				}
+				if o.ObservedAtMs != c.wantObservedAtMs {
+					t.Fatalf("%s: ObservedAtMs = %d, want %d (newest of the merged rows)", c.name, o.ObservedAtMs, c.wantObservedAtMs)
+				}
+			})
+		}
+	})
+
+	t.Run("email identity is case-insensitive", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "opencode-go", AccountKey: "a", Email: "User@Example.COM",
+				LimitID: "rolling-5h", UsedFraction: 0.1, RecordedAtMs: 1000},
+			{Provider: "opencode-go", AccountKey: "b", Email: "user@example.com",
+				LimitID: "weekly", UsedFraction: 0.2, RecordedAtMs: 2000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 1 {
+			t.Fatalf("email case: got %d observations, want 1 (identity is the lowercased email): %+v", len(got), got)
+		}
+		if got[0].Primary == nil || got[0].Secondary == nil {
+			t.Fatalf("email case: want both windows merged, got %+v", got[0])
+		}
+	})
+
+	t.Run("routes every OMP provider to its collector", func(t *testing.T) {
+		cases := []struct {
+			name           string
+			provider       string
+			limitID        string
+			wantProviderID string
+			wantMinutes    string
+		}{
+			{"anthropic", "anthropic", "anthropic:5h", "claude", "300"},
+			{"openai-codex", "openai-codex", "openai-codex:primary", "codex", "300"},
+			{"xai-oauth", "xai-oauth", "xai-oauth:credits:1w", "grok", "10080"},
+			{"opencode-go", "opencode-go", "rolling-5h", "opencode", "300"},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				got := AccountWindowsFromOMP([]omp.UsageWindow{{
+					Provider: c.provider, AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+					LimitID: c.limitID, UsedFraction: 0.5, ResetsAtMs: wpResetsAtMs, RecordedAtMs: 1000,
+				}})
+				if len(got) != 1 {
+					t.Fatalf("%s: got %d observations, want 1: %+v", c.name, len(got), got)
+				}
+				if got[0].ProviderID != c.wantProviderID {
+					t.Fatalf("%s: ProviderID = %q, want %q", c.name, got[0].ProviderID, c.wantProviderID)
+				}
+				if wpMinutes(got[0].Primary) != c.wantMinutes {
+					t.Fatalf("%s: Primary.WindowMinutes = %s, want %s", c.name, wpMinutes(got[0].Primary), c.wantMinutes)
+				}
+			})
+		}
+	})
+
+	t.Run("skips providers the route table does not route", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			// A limit id another provider does map: it must not sneak through
+			// on an unrouted provider.
+			{Provider: "deepseek", AccountKey: "dsk", Email: "a@b.com",
+				LimitID: "rolling-5h", UsedFraction: 0.9, RecordedAtMs: 3000},
+			// "opencode" is this plugin's collector id, not one of OMP's
+			// provider ids (OMP records "opencode-go"). Treating the recorded
+			// provider string as a collector id would let this row through.
+			{Provider: "opencode", AccountKey: "oc", Email: "a@b.com",
+				LimitID: "rolling-5h", UsedFraction: 0.8, RecordedAtMs: 3000},
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:5h", UsedFraction: 0.1, RecordedAtMs: 1000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 1 {
+			t.Fatalf("unrouted provider: got %d observations, want only the anthropic one: %+v", len(got), got)
+		}
+		if got[0].ProviderID != "claude" {
+			t.Fatalf("unrouted provider: ProviderID = %q, want %q", got[0].ProviderID, "claude")
+		}
+	})
+
+	t.Run("skips unmapped limit ids without advancing the observation time", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:extra", UsedFraction: 0.99, ResetsAtMs: wpResetsAtMs, RecordedAtMs: 2000},
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:5h", UsedFraction: 0.1, ResetsAtMs: wpResetsAtMs, RecordedAtMs: 1000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 1 {
+			t.Fatalf("unmapped id: got %d observations, want 1: %+v", len(got), got)
+		}
+		o := got[0]
+		if o.Primary == nil || !wpNearly(o.Primary.UsedPercentage, 10) {
+			t.Fatalf("unmapped id: Primary = %+v, want the anthropic:5h window at 10%%", o.Primary)
+		}
+		if o.Secondary != nil || o.Tertiary != nil {
+			t.Fatalf("unmapped id: anthropic:extra must not land in any slot, got Secondary=%v Tertiary=%v", o.Secondary, o.Tertiary)
+		}
+		if o.ObservedAtMs != 1000 {
+			t.Fatalf("unmapped id: ObservedAtMs = %d, want 1000 — a skipped row must not make the observation look fresher", o.ObservedAtMs)
+		}
+	})
+
+	t.Run("all rows unmapped yields no observation", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:extra", UsedFraction: 0.99, RecordedAtMs: 2000},
+			{Provider: "xai-oauth", AccountKey: "x", LimitID: "xai-oauth:product:api:1w", UsedFraction: 0.5, RecordedAtMs: 2000},
+		}
+		if got := AccountWindowsFromOMP(rows); len(got) != 0 {
+			t.Fatalf("all rows unmapped: got %d observations, want 0: %+v", len(got), got)
+		}
+	})
+
+	t.Run("no rows yields no observation", func(t *testing.T) {
+		if got := AccountWindowsFromOMP(nil); len(got) != 0 {
+			t.Fatalf("nil rows: got %d observations, want 0: %+v", len(got), got)
+		}
+	})
+
+	t.Run("newest row wins per slot regardless of input order", func(t *testing.T) {
+		older := omp.UsageWindow{
+			Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+			LimitID: "anthropic:5h", UsedFraction: 0.1, ResetsAtMs: 1785000000000, RecordedAtMs: 1000,
+		}
+		newer := omp.UsageWindow{
+			Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+			LimitID: "anthropic:5h", UsedFraction: 0.9, ResetsAtMs: wpResetsAtMs, RecordedAtMs: 2000,
+		}
+		cases := []struct {
+			name string
+			rows []omp.UsageWindow
+		}{
+			{"older first", []omp.UsageWindow{older, newer}},
+			{"newer first", []omp.UsageWindow{newer, older}},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				got := AccountWindowsFromOMP(c.rows)
+				if len(got) != 1 {
+					t.Fatalf("%s: got %d observations, want 1: %+v", c.name, len(got), got)
+				}
+				o := got[0]
+				if o.Primary == nil || !wpNearly(o.Primary.UsedPercentage, 90) {
+					t.Fatalf("%s: Primary = %+v, want the recorded_at=2000 row at 90%%", c.name, o.Primary)
+				}
+				if o.Primary.ResetsAt == nil || *o.Primary.ResetsAt != wpResetsAtSec {
+					t.Fatalf("%s: Primary.ResetsAt = %v, want %d from the newest row", c.name, o.Primary.ResetsAt, wpResetsAtSec)
+				}
+				if o.ObservedAtMs != 2000 {
+					t.Fatalf("%s: ObservedAtMs = %d, want 2000 (the max recorded_at)", c.name, o.ObservedAtMs)
+				}
+			})
+		}
+	})
+
+	t.Run("distinct accounts stay separate", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, Email: wpEmail, AccountID: wpAccountID,
+				LimitID: "anthropic:5h", UsedFraction: 0.1, RecordedAtMs: 1000},
+			{Provider: "anthropic", AccountKey: "oauth|account:9999|email:other@example.com", Email: "other@example.com",
+				AccountID: "9999", LimitID: "anthropic:5h", UsedFraction: 0.2, RecordedAtMs: 1000},
+			// No email and no account id: the raw key is the only identity left.
+			{Provider: "anthropic", AccountKey: wpKeyAPIKey,
+				LimitID: "anthropic:5h", UsedFraction: 0.3, RecordedAtMs: 1000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 3 {
+			t.Fatalf("distinct accounts: got %d observations, want 3: %+v", len(got), got)
+		}
+		seen := map[string]bool{}
+		for _, o := range got {
+			seen[o.AccountKey] = true
+		}
+		for _, key := range []string{wpKeyOAuthFull, "oauth|account:9999|email:other@example.com", wpKeyAPIKey} {
+			if !seen[key] {
+				t.Fatalf("distinct accounts: missing an observation for account key %q, got %+v", key, got)
+			}
+		}
+	})
+
+	t.Run("same account key under two providers stays separate", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: "shared", Email: "a@b.com",
+				LimitID: "anthropic:5h", UsedFraction: 0.1, RecordedAtMs: 1000},
+			{Provider: "opencode-go", AccountKey: "shared", Email: "a@b.com",
+				LimitID: "rolling-5h", UsedFraction: 0.2, RecordedAtMs: 1000},
+		}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 2 {
+			t.Fatalf("shared key across providers: got %d observations, want 2: %+v", len(got), got)
+		}
+	})
+
+	t.Run("does not mutate the caller's rows", func(t *testing.T) {
+		rows := []omp.UsageWindow{
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, LimitID: "anthropic:5h", RecordedAtMs: 2000},
+			{Provider: "anthropic", AccountKey: wpKeyOAuthFull, LimitID: "anthropic:7d", RecordedAtMs: 1000},
+		}
+		AccountWindowsFromOMP(rows)
+		if rows[0].LimitID != "anthropic:5h" || rows[1].LimitID != "anthropic:7d" {
+			t.Fatalf("caller's rows were reordered in place: %+v", rows)
+		}
+	})
+}
+
+func TestSelectAccountWindows(t *testing.T) {
+	// wantKey is the AccountKey of the expected observation; "" means nil.
+	cases := []struct {
+		name         string
+		observations []AccountWindows
+		providerID   string
+		wantAccount  string
+		wantKey      string
+	}{
+		{
+			name: "exact email match beats a newer sibling",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "k-a",
+		},
+		{
+			name: "exact account id match",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", AccountID: "id-a", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", AccountID: "id-b", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "id-a", wantKey: "k-a",
+		},
+		{
+			name: "email match ignores case",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 100, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "A@B.CoM", wantKey: "k-a",
+		},
+		{
+			name: "identity embedded only in the composed account key",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: wpKeyOAuthFull, ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "oauth|secret:deadbeef", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: wpEmail, wantKey: wpKeyOAuthFull,
+		},
+		{
+			name: "identities exist but none match refuses",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "e@f.com", wantKey: "",
+		},
+		{
+			name: "the only identified account does not match refuses",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+			},
+			providerID: "claude", wantAccount: "e@f.com", wantKey: "",
+		},
+		{
+			name: "one identified sibling poisons an unidentified pool",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "opaque-1", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "e@f.com", wantKey: "",
+		},
+		{
+			name: "nobody named the account and only one was observed",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "opaque-1", ObservedAtMs: 100, Primary: wpWindow(10)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "opaque-1",
+		},
+		{
+			name: "nobody named the account and two were observed refuses",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "opaque-1", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "opaque-2", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "",
+		},
+		{
+			name: "unnamed want with one account borrows",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "opaque-1", ObservedAtMs: 100, Primary: wpWindow(10)},
+			},
+			providerID: "claude", wantAccount: "", wantKey: "opaque-1",
+		},
+		{
+			name: "unnamed want with two accounts refuses",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "", wantKey: "",
+		},
+		{
+			name: "blank want is treated as unnamed",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-b", Email: "c@d.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "   ", wantKey: "",
+		},
+		{
+			name: "unnamed want with one account under two keys borrows the newest",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-1", AccountID: "id-a", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-2", AccountID: "id-a", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "", wantKey: "k-2",
+		},
+		{
+			name: "newest observation wins among matches",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-old", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-new", Email: "a@b.com", ObservedAtMs: 300, Primary: wpWindow(20)},
+				{ProviderID: "claude", AccountKey: "k-mid", Email: "a@b.com", ObservedAtMs: 200, Primary: wpWindow(30)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "k-new",
+		},
+		{
+			name: "windowless observations are not candidates",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+				{ProviderID: "claude", AccountKey: "k-empty", Email: "c@d.com", ObservedAtMs: 900},
+			},
+			providerID: "claude", wantAccount: "", wantKey: "k-a",
+		},
+		{
+			name: "a windowless observation is never returned",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-empty", Email: "a@b.com", ObservedAtMs: 900},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "",
+		},
+		{
+			name: "a secondary-only observation is a candidate",
+			observations: []AccountWindows{
+				{ProviderID: "claude", AccountKey: "k-sec", Email: "a@b.com", ObservedAtMs: 100, Secondary: wpWindow(10)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "k-sec",
+		},
+		{
+			name: "a tertiary-only observation is a candidate",
+			observations: []AccountWindows{
+				{ProviderID: "opencode", AccountKey: "k-ter", Email: "a@b.com", ObservedAtMs: 100, Tertiary: wpWindow(10)},
+			},
+			providerID: "opencode", wantAccount: "a@b.com", wantKey: "k-ter",
+		},
+		{
+			name: "other providers are filtered out before the single-account check",
+			observations: []AccountWindows{
+				{ProviderID: "codex", AccountKey: "k-codex", Email: "z@z.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+				{ProviderID: "claude", AccountKey: "k-claude", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+			},
+			providerID: "claude", wantAccount: "", wantKey: "k-claude",
+		},
+		{
+			name: "a matching account under the wrong provider is refused",
+			observations: []AccountWindows{
+				{ProviderID: "codex", AccountKey: "k-codex", Email: "a@b.com", ObservedAtMs: 900, Primary: wpWindow(20)},
+			},
+			providerID: "claude", wantAccount: "a@b.com", wantKey: "",
+		},
+		{
+			name:         "empty pool",
+			observations: nil,
+			providerID:   "claude", wantAccount: "a@b.com", wantKey: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SelectAccountWindows(c.observations, c.providerID, c.wantAccount)
+			if c.wantKey == "" {
+				if got != nil {
+					t.Fatalf("%s: got observation %q, want nil (borrowing must be refused)", c.name, got.AccountKey)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("%s: got nil, want the observation keyed %q", c.name, c.wantKey)
+			}
+			if got.AccountKey != c.wantKey {
+				t.Fatalf("%s: got observation %q, want %q", c.name, got.AccountKey, c.wantKey)
+			}
+		})
+	}
+
+	t.Run("returns a copy the caller cannot use to mutate the pool", func(t *testing.T) {
+		pool := []AccountWindows{
+			{ProviderID: "claude", AccountKey: "k-a", Email: "a@b.com", ObservedAtMs: 100, Primary: wpWindow(10)},
+		}
+		got := SelectAccountWindows(pool, "claude", "a@b.com")
+		if got == nil {
+			t.Fatalf("copy: got nil, want the only observation")
+		}
+		got.Email = "mutated@example.com"
+		if pool[0].Email != "a@b.com" {
+			t.Fatalf("copy: mutating the result changed the pool entry to %q", pool[0].Email)
+		}
+	})
+}
+
+func TestBorrowedProviderLimits(t *testing.T) {
+	const nowMs = int64(1785128400228)
+
+	t.Run("note, source and timestamps", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			email           string
+			observedAtMs    int64
+			wantNote        string
+			wantFetchedAtMs int64
+		}{
+			{
+				name: "identified account", email: "a@b", observedAtMs: nowMs - 5*60_000,
+				wantNote: "account a@b · via OMP · ~5m ago", wantFetchedAtMs: nowMs - 5*60_000,
+			},
+			{
+				name: "unnamed account is labelled unverified", email: "", observedAtMs: nowMs - 90*60_000,
+				wantNote: "account unverified · via OMP · ~1h ago", wantFetchedAtMs: nowMs - 90*60_000,
+			},
+			{
+				name: "fresh observation", email: wpEmail, observedAtMs: nowMs - 30_000,
+				wantNote: "account " + wpEmail + " · via OMP · just now", wantFetchedAtMs: nowMs - 30_000,
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				o := AccountWindows{
+					ProviderID: "claude", AccountKey: wpKeyOAuthFull, Email: c.email,
+					Primary: wpWindow(28), ObservedAtMs: c.observedAtMs, Observer: "OMP",
+				}
+				got := BorrowedProviderLimits(o, "claude", "Claude", nowMs)
+				if got.Note == nil {
+					t.Fatalf("%s: Note is nil — a borrowed number without attribution is indistinguishable from a first-hand one", c.name)
+				}
+				if *got.Note != c.wantNote {
+					t.Fatalf("%s: Note = %q, want %q", c.name, *got.Note, c.wantNote)
+				}
+				if got.Source != "omp usage_history" {
+					t.Fatalf("%s: Source = %q, want %q", c.name, got.Source, "omp usage_history")
+				}
+				if got.FetchedAtMs != c.wantFetchedAtMs {
+					t.Fatalf("%s: FetchedAtMs = %d, want %d (the observation time, not now)", c.name, got.FetchedAtMs, c.wantFetchedAtMs)
+				}
+			})
+		}
+	})
+
+	t.Run("windows and labels pass through unchanged", func(t *testing.T) {
+		primary := wpWindow(28)
+		secondary := wpWindow(61)
+		tertiary := wpWindow(3)
+		o := AccountWindows{
+			ProviderID: "opencode", AccountKey: wpKeyOAuthFull, Email: wpEmail,
+			Primary: primary, Secondary: secondary, Tertiary: tertiary,
+			ObservedAtMs: nowMs - 60_000, Observer: "OMP",
+		}
+		got := BorrowedProviderLimits(o, "opencode", "OpenCode Go", nowMs)
+		if got.ProviderID != "opencode" {
+			t.Fatalf("pass-through: ProviderID = %q, want %q", got.ProviderID, "opencode")
+		}
+		if got.Label != "OpenCode Go" {
+			t.Fatalf("pass-through: Label = %q, want %q", got.Label, "OpenCode Go")
+		}
+		if got.Primary != primary || got.Secondary != secondary || got.Tertiary != tertiary {
+			t.Fatalf("pass-through: windows were rebuilt, got Primary=%v Secondary=%v Tertiary=%v",
+				got.Primary, got.Secondary, got.Tertiary)
+		}
+	})
+
+	t.Run("a missing window stays missing", func(t *testing.T) {
+		o := AccountWindows{
+			ProviderID: "claude", AccountKey: "k", Email: wpEmail,
+			Primary: wpWindow(28), ObservedAtMs: nowMs - 60_000, Observer: "OMP",
+		}
+		got := BorrowedProviderLimits(o, "claude", "Claude", nowMs)
+		if got.Secondary != nil || got.Tertiary != nil {
+			t.Fatalf("missing window: got Secondary=%v Tertiary=%v, want both nil", got.Secondary, got.Tertiary)
+		}
+	})
+
+	t.Run("an unset observation time falls back to now", func(t *testing.T) {
+		o := AccountWindows{
+			ProviderID: "claude", AccountKey: "k", Email: wpEmail,
+			Primary: wpWindow(28), ObservedAtMs: 0, Observer: "OMP",
+		}
+		got := BorrowedProviderLimits(o, "claude", "Claude", nowMs)
+		if got.FetchedAtMs != nowMs {
+			t.Fatalf("unset observation time: FetchedAtMs = %d, want %d (staleness must not read as 1970)", got.FetchedAtMs, nowMs)
+		}
+	})
+}
+
+func TestObservationAge(t *testing.T) {
+	const nowMs = int64(1785128400228)
+	cases := []struct {
+		name         string
+		observedAtMs int64
+		want         string
+	}{
+		{"same instant", nowMs, "just now"},
+		{"just under a minute", nowMs - 59_999, "just now"},
+		{"exactly a minute", nowMs - 60_000, "~1m ago"},
+		{"five minutes", nowMs - 5*60_000, "~5m ago"},
+		{"just under an hour", nowMs - 59*60_000, "~59m ago"},
+		{"exactly an hour", nowMs - 60*60_000, "~1h ago"},
+		{"two and a half hours", nowMs - 150*60_000, "~2h ago"},
+		{"a day", nowMs - 24*60*60_000, "~24h ago"},
+		{"clock skew into the future", nowMs + 5*60_000, "just now"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := observationAge(c.observedAtMs, nowMs); got != c.want {
+				t.Fatalf("%s: observationAge(%d, %d) = %q, want %q", c.name, c.observedAtMs, nowMs, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/providers/codex/auth.go
+++ b/internal/providers/codex/auth.go
@@ -1,0 +1,35 @@
+/**
+ * Reads only the account identity from Codex's auth.json.
+ *
+ * The tokens themselves are never touched. The account id exists here for one
+ * purpose: a rate-limit window borrowed from another agent must be checkable
+ * against the account this machine's Codex CLI is actually signed into, so a
+ * second account's numbers can never be shown on a Codex pane.
+ */
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AccountID returns the ChatGPT account id recorded in $CODEX_HOME/auth.json,
+// or "" when Codex has never signed in on this machine — in which case there
+// is no local identity to check a borrowed observation against.
+func AccountID() string {
+	raw, err := os.ReadFile(filepath.Join(codexHome(), "auth.json"))
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		Tokens *struct {
+			AccountID *string `json:"account_id"`
+		} `json:"tokens"`
+	}
+	if json.Unmarshal(raw, &parsed) != nil || parsed.Tokens == nil || parsed.Tokens.AccountID == nil {
+		return ""
+	}
+	return strings.TrimSpace(*parsed.Tokens.AccountID)
+}

--- a/internal/providers/codex/auth_test.go
+++ b/internal/providers/codex/auth_test.go
@@ -1,0 +1,88 @@
+/**
+ * Tests for reading the Codex account identity out of auth.json.
+ */
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCodexAuth(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "auth.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestAccountID(t *testing.T) {
+	// The real shape: the id sits under tokens, beside secrets this must not
+	// touch.
+	const real = `{
+		"last_refresh": "2026-07-25T12:30:49Z",
+		"OPENAI_API_KEY": null,
+		"tokens": {
+			"access_token": "secret-access",
+			"account_id": "a1afefbc-024d-46be-beb3-add8311de670",
+			"id_token": "secret-id",
+			"refresh_token": "secret-refresh"
+		}
+	}`
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"real auth.json", real, "a1afefbc-024d-46be-beb3-add8311de670"},
+		{"surrounding whitespace trimmed", `{"tokens":{"account_id":"  abc-123  "}}`, "abc-123"},
+		{"api-key login has no account id", `{"OPENAI_API_KEY":"sk-x","tokens":null}`, ""},
+		{"tokens without account_id", `{"tokens":{"access_token":"x"}}`, ""},
+		{"account_id is null", `{"tokens":{"account_id":null}}`, ""},
+		{"empty object", `{}`, ""},
+		{"unparseable json", `{"tokens":`, ""},
+		{"empty file", ``, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CODEX_HOME", writeCodexAuth(t, tc.body))
+			if got := AccountID(); got != tc.want {
+				t.Fatalf("AccountID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccountIDWithoutAuthFile(t *testing.T) {
+	// Never signed in here: the caller must get "" so a borrowed rate-limit
+	// window falls back to the pool's own single-account rule instead of
+	// being matched against a fabricated identity.
+	t.Setenv("CODEX_HOME", t.TempDir())
+	if got := AccountID(); got != "" {
+		t.Fatalf("AccountID() = %q, want empty", got)
+	}
+}
+
+func TestAccountIDNeverReturnsSecrets(t *testing.T) {
+	t.Setenv("CODEX_HOME", writeCodexAuth(t, `{
+		"tokens": {
+			"access_token": "sk-super-secret",
+			"id_token": "jwt-secret",
+			"refresh_token": "rt-secret",
+			"account_id": "acct-1"
+		}
+	}`))
+	got := AccountID()
+	if got != "acct-1" {
+		t.Fatalf("AccountID() = %q, want %q", got, "acct-1")
+	}
+	for _, secret := range []string{"sk-super-secret", "jwt-secret", "rt-secret"} {
+		if got == secret {
+			t.Fatalf("AccountID() leaked %q", secret)
+		}
+	}
+}

--- a/internal/providers/omp/auth.go
+++ b/internal/providers/omp/auth.go
@@ -14,11 +14,11 @@ import (
 // without reading its secret material. OMP records OAuth and API-key
 // credentials separately in agent.db.
 func CredentialType(provider string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
+	dbPath := ResolveAgentDBPath()
+	if dbPath == "" {
 		return ""
 	}
-	db, err := sql.Open("sqlite", "file:"+filepath.Join(home, ".omp", "agent", "agent.db")+"?mode=ro")
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
 	if err != nil {
 		return ""
 	}

--- a/internal/providers/omp/usagehistory.go
+++ b/internal/providers/omp/usagehistory.go
@@ -1,0 +1,105 @@
+/**
+ * Read-only reader for OMP's own rate-limit window cache.
+ *
+ * OMP records the server-reported windows of every subscription account it
+ * drives in agent.db `usage_history`, one row per (account, limit_id) per
+ * refresh. Unlike a vendor CLI's session artifacts these rows exist for any
+ * account OMP touches, so for a subscription whose vendor CLI never runs
+ * this is the only local observation of the real windows.
+ *
+ * Secret material is never read: this file touches `usage_history` only,
+ * never `auth_credentials.data`.
+ */
+package omp
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// UsageWindow is one recorded rate-limit window for one account.
+type UsageWindow struct {
+	// Provider is OMP's own provider id (anthropic, xai-oauth, opencode-go, …).
+	Provider string
+	// AccountKey identifies the account within that provider. Its shape is
+	// OMP's, e.g. "email:a@b|org:<uuid>"; treat it as opaque.
+	AccountKey string
+	Email      string
+	AccountID  string
+	// LimitID is OMP's window id, e.g. "anthropic:5h" or "rolling-5h".
+	LimitID     string
+	Label       string
+	WindowLabel string
+	// UsedFraction is 0..1, and may exceed 1 for an exhausted window.
+	UsedFraction float64
+	Status       string
+	// ResetsAtMs is epoch milliseconds; 0 when the window has no reset.
+	ResetsAtMs int64
+	// RecordedAtMs is when OMP observed this window.
+	RecordedAtMs int64
+}
+
+// ResolveAgentDBPath returns USAGEBAR_OMP_AGENT_DB or ~/.omp/agent/agent.db.
+func ResolveAgentDBPath() string {
+	if override := strings.TrimSpace(os.Getenv("USAGEBAR_OMP_AGENT_DB")); override != "" {
+		return override
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".omp", "agent", "agent.db")
+}
+
+// LatestUsageWindows returns the newest row per (provider, account, limit_id).
+// It returns nil for any failure — a missing DB, an OMP old enough to predate
+// the table, or an unreadable file are all "no observation", never an error
+// the panel has to render.
+func LatestUsageWindows(dbPath string) []UsageWindow {
+	if dbPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+
+	// SQLite resolves the bare columns from the row holding MAX(recorded_at)
+	// within each group, so this is the newest observation per window.
+	rows, err := db.Query(`
+		SELECT provider, account_key, COALESCE(email, ''), COALESCE(account_id, ''),
+		       limit_id, label, COALESCE(window_label, ''),
+		       COALESCE(used_fraction, 0), COALESCE(status, ''),
+		       COALESCE(resets_at, 0), MAX(recorded_at)
+		FROM usage_history
+		GROUP BY lower(trim(provider)), account_key, lower(trim(limit_id))`)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []UsageWindow
+	for rows.Next() {
+		var w UsageWindow
+		if err := rows.Scan(&w.Provider, &w.AccountKey, &w.Email, &w.AccountID,
+			&w.LimitID, &w.Label, &w.WindowLabel,
+			&w.UsedFraction, &w.Status, &w.ResetsAtMs, &w.RecordedAtMs); err != nil {
+			return nil
+		}
+		w.Provider = strings.ToLower(strings.TrimSpace(w.Provider))
+		w.LimitID = strings.ToLower(strings.TrimSpace(w.LimitID))
+		out = append(out, w)
+	}
+	if rows.Err() != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/providers/omp/usagehistory_test.go
+++ b/internal/providers/omp/usagehistory_test.go
@@ -1,0 +1,316 @@
+/**
+ * Tests for the read-only OMP agent.db usage-window reader.
+ *
+ * The contract these defend: the reader yields exactly one window per
+ * (provider, account_key, limit_id) — the newest observation — with provider
+ * and limit ids normalised, NULL columns degraded to zero values, and every
+ * failure mode reported as "no observation" (nil) rather than an error or a
+ * panic the panel would have to render.
+ */
+package omp
+
+import (
+	"database/sql"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// usageRow is one usage_history row for a fixture DB. The nullable columns
+// are typed `any` so a test can insert a real SQL NULL by leaving them nil.
+type usageRow struct {
+	RecordedAtMs int64
+	Provider     string
+	AccountKey   string
+	Email        any
+	AccountID    any
+	LimitID      string
+	Label        string
+	WindowLabel  any
+	UsedFraction any
+	Status       any
+	ResetsAtMs   any
+}
+
+// writeUsageDB builds an agent.db with OMP's real usage_history schema.
+func writeUsageDB(t *testing.T, rows ...usageRow) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open fixture db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE usage_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		recorded_at INTEGER NOT NULL,
+		provider TEXT NOT NULL,
+		account_key TEXT NOT NULL,
+		email TEXT,
+		account_id TEXT,
+		limit_id TEXT NOT NULL,
+		label TEXT NOT NULL,
+		window_label TEXT,
+		used_fraction REAL,
+		status TEXT,
+		resets_at INTEGER)`); err != nil {
+		t.Fatalf("create fixture table: %v", err)
+	}
+	for _, r := range rows {
+		if _, err := db.Exec(`INSERT INTO usage_history
+			(recorded_at, provider, account_key, email, account_id, limit_id,
+			 label, window_label, used_fraction, status, resets_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+			r.RecordedAtMs, r.Provider, r.AccountKey, r.Email, r.AccountID,
+			r.LimitID, r.Label, r.WindowLabel, r.UsedFraction, r.Status,
+			r.ResetsAtMs); err != nil {
+			t.Fatalf("insert fixture row: %v", err)
+		}
+	}
+	return path
+}
+
+func TestResolveAgentDBPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("user home dir: %v", err)
+	}
+	fallback := filepath.Join(home, ".omp", "agent", "agent.db")
+
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"override wins", "/tmp/usagebar-test/agent.db", "/tmp/usagebar-test/agent.db"},
+		{"override is trimmed", "  /tmp/usagebar-test/agent.db  ", "/tmp/usagebar-test/agent.db"},
+		{"unset falls back to ~/.omp", "", fallback},
+		{"blank override falls back", "   ", fallback},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("USAGEBAR_OMP_AGENT_DB", tc.env)
+			if got := ResolveAgentDBPath(); got != tc.want {
+				t.Fatalf("ResolveAgentDBPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLatestUsageWindowsNewestPerWindow(t *testing.T) {
+	const (
+		provider = "anthropic"
+		account  = "oauth|account:f3a39003-3c6f-438d-8b25-cf345f085528|email:asrsena3302@gmail.com|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+		limitID  = "anthropic:5h"
+	)
+	// Inserted out of chronological order so a reader that simply takes the
+	// first or last inserted row cannot pass by accident.
+	path := writeUsageDB(t,
+		usageRow{RecordedAtMs: 1_700_000_100_000, Provider: provider, AccountKey: account,
+			Email: "asrsena3302@gmail.com", LimitID: limitID, Label: "oldest",
+			UsedFraction: 0.10, Status: "stale", ResetsAtMs: int64(1_700_000_400_000)},
+		usageRow{RecordedAtMs: 1_700_000_300_000, Provider: provider, AccountKey: account,
+			Email: "asrsena3302@gmail.com", LimitID: limitID, Label: "newest",
+			UsedFraction: 0.75, Status: "allowed", ResetsAtMs: int64(1_700_001_200_000)},
+		usageRow{RecordedAtMs: 1_700_000_200_000, Provider: provider, AccountKey: account,
+			Email: "asrsena3302@gmail.com", LimitID: limitID, Label: "middle",
+			UsedFraction: 0.20, Status: "stale", ResetsAtMs: int64(1_700_000_800_000)},
+	)
+
+	got := LatestUsageWindows(path)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 collapsed window; got %+v", len(got), got)
+	}
+	w := got[0]
+	if w.RecordedAtMs != 1_700_000_300_000 {
+		t.Errorf("RecordedAtMs = %d, want the newest 1700000300000", w.RecordedAtMs)
+	}
+	// Every non-aggregated column must come from the newest row too, not from
+	// an arbitrary member of the group.
+	if !closeEnough(w.UsedFraction, 0.75) {
+		t.Errorf("UsedFraction = %v, want the newest row's 0.75", w.UsedFraction)
+	}
+	if w.Label != "newest" {
+		t.Errorf("Label = %q, want %q", w.Label, "newest")
+	}
+	if w.Status != "allowed" {
+		t.Errorf("Status = %q, want %q", w.Status, "allowed")
+	}
+	if w.ResetsAtMs != 1_700_001_200_000 {
+		t.Errorf("ResetsAtMs = %d, want the newest row's 1700001200000", w.ResetsAtMs)
+	}
+	if w.Provider != provider || w.AccountKey != account || w.LimitID != limitID {
+		t.Errorf("identity = (%q, %q, %q), want (%q, %q, %q)",
+			w.Provider, w.AccountKey, w.LimitID, provider, account, limitID)
+	}
+	if w.Email != "asrsena3302@gmail.com" {
+		t.Errorf("Email = %q, want %q", w.Email, "asrsena3302@gmail.com")
+	}
+}
+
+func TestLatestUsageWindowsGroupsAreIndependent(t *testing.T) {
+	const (
+		oauthKey  = "oauth|account:f3a39003-3c6f-438d-8b25-cf345f085528|email:asrsena3302@gmail.com|org:1ee9778e-5379-4a19-a14a-2625ea6002d5"
+		secretKey = "oauth|secret:c5f777162aca2d15"
+		apiKey    = "api_key|secret:e9554082fe7595c1"
+	)
+	path := writeUsageDB(t,
+		// Same account, same provider, two different limit ids.
+		usageRow{RecordedAtMs: 10, Provider: "anthropic", AccountKey: oauthKey, LimitID: "anthropic:5h", Label: "5h", UsedFraction: 0.11},
+		usageRow{RecordedAtMs: 20, Provider: "anthropic", AccountKey: oauthKey, LimitID: "anthropic:7d", Label: "7d", UsedFraction: 0.22},
+		// Same provider and limit id, a different account_key.
+		usageRow{RecordedAtMs: 30, Provider: "anthropic", AccountKey: secretKey, LimitID: "anthropic:5h", Label: "5h", UsedFraction: 0.33},
+		// A different provider entirely, and one with no email at all.
+		usageRow{RecordedAtMs: 40, Provider: "xai-oauth", AccountKey: apiKey, LimitID: "xai-oauth:credits:1w", Label: "credits", UsedFraction: 0.44},
+		usageRow{RecordedAtMs: 50, Provider: "openai-codex", AccountKey: oauthKey, LimitID: "openai-codex:primary", Label: "5h", UsedFraction: 0.55},
+		// A superseded row inside one of the groups above.
+		usageRow{RecordedAtMs: 5, Provider: "openai-codex", AccountKey: oauthKey, LimitID: "openai-codex:primary", Label: "5h", UsedFraction: 0.99},
+	)
+
+	type key struct{ provider, account, limitID string }
+	want := map[key]float64{
+		{"anthropic", oauthKey, "anthropic:5h"}:            0.11,
+		{"anthropic", oauthKey, "anthropic:7d"}:            0.22,
+		{"anthropic", secretKey, "anthropic:5h"}:           0.33,
+		{"xai-oauth", apiKey, "xai-oauth:credits:1w"}:      0.44,
+		{"openai-codex", oauthKey, "openai-codex:primary"}: 0.55,
+	}
+
+	got := LatestUsageWindows(path)
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d; got %+v", len(got), len(want), got)
+	}
+	seen := make(map[key]bool, len(got))
+	for _, w := range got {
+		k := key{w.Provider, w.AccountKey, w.LimitID}
+		fraction, ok := want[k]
+		if !ok {
+			t.Errorf("unexpected window %+v", k)
+			continue
+		}
+		if seen[k] {
+			t.Errorf("duplicate window for %+v", k)
+		}
+		seen[k] = true
+		if !closeEnough(w.UsedFraction, fraction) {
+			t.Errorf("%+v UsedFraction = %v, want %v", k, w.UsedFraction, fraction)
+		}
+	}
+	for k := range want {
+		if !seen[k] {
+			t.Errorf("missing window %+v", k)
+		}
+	}
+}
+
+func TestLatestUsageWindowsNormalisesIDs(t *testing.T) {
+	path := writeUsageDB(t, usageRow{
+		RecordedAtMs: 1, Provider: "  ANTHROPIC  ", AccountKey: "  oauth|secret:c5f777162aca2d15  ",
+		LimitID: "ANTHROPIC:5H", Label: "Current session", UsedFraction: 0.5,
+	})
+
+	got := LatestUsageWindows(path)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	w := got[0]
+	if w.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want %q", w.Provider, "anthropic")
+	}
+	if w.LimitID != "anthropic:5h" {
+		t.Errorf("LimitID = %q, want %q", w.LimitID, "anthropic:5h")
+	}
+	// AccountKey is documented as opaque: it must survive verbatim, since
+	// mangling it would break the join back to OMP's own records.
+	if w.AccountKey != "  oauth|secret:c5f777162aca2d15  " {
+		t.Errorf("AccountKey = %q, want it preserved verbatim", w.AccountKey)
+	}
+	if w.Label != "Current session" {
+		t.Errorf("Label = %q, want it preserved verbatim", w.Label)
+	}
+}
+
+func TestLatestUsageWindowsNullColumns(t *testing.T) {
+	path := writeUsageDB(t, usageRow{
+		RecordedAtMs: 1_700_000_000_000,
+		Provider:     "opencode-go",
+		AccountKey:   "api_key|secret:e9554082fe7595c1",
+		LimitID:      "rolling-5h",
+		Label:        "5h",
+		// email, account_id, window_label, used_fraction, status and
+		// resets_at are all left nil, i.e. inserted as SQL NULL.
+	})
+
+	got := LatestUsageWindows(path)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want the NULL-bearing row to survive; got %+v", len(got), got)
+	}
+	w := got[0]
+	if w.Email != "" || w.AccountID != "" || w.WindowLabel != "" || w.Status != "" {
+		t.Errorf("NULL text columns = (%q, %q, %q, %q), want empty strings",
+			w.Email, w.AccountID, w.WindowLabel, w.Status)
+	}
+	if w.UsedFraction != 0 {
+		t.Errorf("UsedFraction = %v, want 0", w.UsedFraction)
+	}
+	if w.ResetsAtMs != 0 {
+		t.Errorf("ResetsAtMs = %d, want 0", w.ResetsAtMs)
+	}
+	if w.Provider != "opencode-go" || w.LimitID != "rolling-5h" {
+		t.Errorf("identity = (%q, %q), want (opencode-go, rolling-5h)", w.Provider, w.LimitID)
+	}
+}
+
+func TestLatestUsageWindowsFailuresReturnNil(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent", "agent.db")
+
+	notSQLite := filepath.Join(t.TempDir(), "agent.db")
+	if err := os.WriteFile(notSQLite, []byte("this is not a database\n"), 0o644); err != nil {
+		t.Fatalf("write junk file: %v", err)
+	}
+
+	dir := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"empty path", ""},
+		{"missing file", missing},
+		{"not a sqlite file", notSQLite},
+		{"directory instead of file", dir},
+		{"sqlite without usage_history", sqliteWithoutUsageHistory(t)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LatestUsageWindows(tc.path)
+			if got != nil {
+				t.Fatalf("LatestUsageWindows(%q) = %+v, want nil", tc.path, got)
+			}
+		})
+	}
+}
+
+// sqliteWithoutUsageHistory builds a real SQLite file from an OMP old enough
+// to predate the usage_history table.
+func sqliteWithoutUsageHistory(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE auth_credentials (
+		provider TEXT NOT NULL, credential_type TEXT, disabled_cause TEXT, updated_at INTEGER)`); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	return path
+}
+
+func closeEnough(got, want float64) bool {
+	return math.Abs(got-want) < 1e-9
+}

--- a/internal/providers/opencode/auth.go
+++ b/internal/providers/opencode/auth.go
@@ -22,7 +22,17 @@ func CredentialType(providerID string) string {
 	if json.Unmarshal(raw, &entries) != nil {
 		return ""
 	}
-	for _, id := range []string{providerID, "openai-codex", "openai"} {
+	// OpenCode files the Codex OAuth entry under either openai key, so a Codex
+	// backend id may have to look at its sibling. Probing those keys for an
+	// unrelated provider (anthropic, …) would answer with a credential that
+	// has nothing to do with the queried account — and a route keyed on that
+	// answer binds the wrong subscription. The fallback stays in the family.
+	candidates := []string{providerID}
+	switch strings.ToLower(strings.TrimSpace(providerID)) {
+	case "openai", "openai-codex", "openai-codex-oauth":
+		candidates = append(candidates, "openai-codex", "openai")
+	}
+	for _, id := range candidates {
 		entry, ok := entries[id]
 		if !ok {
 			continue

--- a/internal/providers/opencode/auth_test.go
+++ b/internal/providers/opencode/auth_test.go
@@ -1,0 +1,93 @@
+/**
+ * CredentialType must answer for the provider that was asked about.
+ *
+ * OpenCode files the Codex OAuth entry under either openai key, so a Codex
+ * backend id legitimately reads its sibling. That fallback used to run for
+ * every provider id, so asking about anthropic returned the Codex entry's
+ * kind — and a subscription route keyed on that answer bound the wrong
+ * account. These tests pin the fallback to the openai family.
+ */
+package opencode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// codexOnlyAuth is an auth.json holding nothing but the Codex OAuth entry —
+// the shape that made an unrelated provider look signed in.
+const codexOnlyAuth = `{"openai-codex":{"type":"oauth","refresh":"rt-fixture"}}`
+
+// useOpenCodeAuth points HOME at a fixture tree. An empty authJSON leaves
+// auth.json absent.
+func useOpenCodeAuth(t *testing.T, authJSON string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if authJSON == "" {
+		return
+	}
+	dir := filepath.Join(home, ".local", "share", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create fixture auth dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(authJSON), 0o600); err != nil {
+		t.Fatalf("write fixture auth.json: %v", err)
+	}
+}
+
+func TestCredentialType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		authJSON string
+		provider string
+		want     string
+	}{
+		// The regression: the Codex entry answered for a provider that has
+		// nothing to do with it.
+		{"unrelated provider never reads the codex entry", codexOnlyAuth, "anthropic", ""},
+		{"unknown provider never reads the codex entry", codexOnlyAuth, "deepseek", ""},
+		{"empty provider id matches nothing", codexOnlyAuth, "", ""},
+
+		// The intended in-family fallback has to survive the fix.
+		{"openai falls back to the codex entry", codexOnlyAuth, "openai", "oauth"},
+		{"openai-codex reads its own entry", codexOnlyAuth, "openai-codex", "oauth"},
+		{"openai-codex-oauth stays in the family", codexOnlyAuth, "openai-codex-oauth", "oauth"},
+		{"family fallback tolerates case", codexOnlyAuth, "OpenAI-Codex", "oauth"},
+
+		// An exact entry is always the answer, fallback or not.
+		{
+			"exact entry beats the family fallback",
+			`{"openai":{"type":"api"},"openai-codex":{"type":"oauth"}}`,
+			"openai", "api",
+		},
+		{
+			"exact entry answers outside the family",
+			`{"anthropic":{"type":"api"},"openai-codex":{"type":"oauth"}}`,
+			"anthropic", "api",
+		},
+		{"kind is normalized", `{"anthropic":{"type":"  OAuth "}}`, "anthropic", "oauth"},
+
+		// Nothing to read is never an error the caller has to handle.
+		{"entry carries no type", `{"anthropic":{"refresh":"rt"}}`, "anthropic", ""},
+		{"auth.json is unparseable", `{not json`, "openai-codex", ""},
+		{"auth.json is absent", "", "openai-codex", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			useOpenCodeAuth(t, tc.authJSON)
+			if got := CredentialType(tc.provider); got != tc.want {
+				t.Fatalf("CredentialType(%q) = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// The credential value itself must never leave this function: a caller that
+// gets a token back would leak it into whatever it renders.
+func TestCredentialTypeReturnsKindNotSecret(t *testing.T) {
+	useOpenCodeAuth(t, `{"openai-codex":{"type":"oauth","access":"secret-token","refresh":"secret-refresh"}}`)
+	if got := CredentialType("openai-codex"); got != "oauth" {
+		t.Fatalf("CredentialType = %q, want the kind only", got)
+	}
+}

--- a/scripts/contractdrift/contracts.json
+++ b/scripts/contractdrift/contracts.json
@@ -53,7 +53,8 @@
       "assistant JSONL provider model contextSnapshot usage cost and timestamp fields",
       "session directory and agent_session path conventions",
       "models.db model_cache schema",
-      "agent.db auth_credentials credential_type schema"
+      "agent.db auth_credentials credential_type schema",
+      "agent.db usage_history schema (provider account_key email account_id limit_id used_fraction resets_at) and its limit_id vocabulary"
     ]
   },
   {


### PR DESCRIPTION
## Summary

- add a read-only, account-keyed OMP `usage_history` observation pool for subscription rate-limit windows
- fall back safely across harnesses when native collector artifacts are absent, refusing contradictory identified accounts
- prefer newer observations over stale Claude/Codex cache artifacts and preserve source/account/age attribution
- document the account-window contract, supported OpenCode OAuth routes, and observed local artifacts

Fixes #29.

## Verification

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./... -count=1`
- live Herdr integration probes: `openPaneSnapshots -> ActiveProviderFilter -> collectPanel`, with live OMP/Claude/OpenCode panes resolving to Claude, Codex, Grok, and OpenCode
