### PR TITLE
fix: statusLine notification deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ enabled = true
 remaining_thresholds = [50, 20, 10, 5]
 ```
 
+`enabled = false` suppresses all Agent Usage toasts, including remaining-limit
+warnings and update-available notices; statusLine summaries and cached limits
+continue to refresh. `remaining_thresholds` accepts remaining percentages from
+1 through 100 (for example `[30, 10]`); each threshold can notify once per
+window, from least to most severe.
+
 ### Herdr toast delivery
 
 Required for notifications to appear on screen:

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -105,7 +105,7 @@ func runUpdateCheck(args []string) {
 		CurrentVersion: currentVersion,
 		StateDir:       setup.ResolvePluginConfigDir(environment()),
 		Force:          hasFlag(args, "--force"),
-		Notify:         herdrcli.ShowNotification,
+		Notify:         updateNotification(environment()),
 	})
 	if quiet {
 		return
@@ -152,6 +152,37 @@ func environment() map[string]string {
 		}
 	}
 	return env
+}
+
+// notificationsEnabled returns the plugin-level switch for usage-limit toasts.
+// Statusline rendering and provider notifications remain available when off.
+func notificationsEnabled(env map[string]string) bool {
+	config := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(env))
+	return config.NotifyEnabled
+}
+
+// updateNotification returns the update-toast callback only when plugin
+// notifications are enabled.
+func updateNotification(env map[string]string) updatecheck.NotifyFunc {
+	if !notificationsEnabled(env) {
+		return nil
+	}
+	return herdrcli.ShowNotification
+}
+
+// runStatusLineNotifications applies configured notification policy to one
+// statusline render while the caller continues rendering its summary.
+func runStatusLineNotifications(
+	profile claude.ClaudeProfile,
+	stdinJSON string,
+	nowMs int64,
+	config setup.PluginConfig,
+	notify ratelimit.ShowNotificationFn,
+) {
+	if !config.NotifyEnabled {
+		return
+	}
+	ratelimit.RunRateLimitCheckWithThresholdsIn(profile.StateDir, stdinJSON, nowMs, config.RemainingThresholds, notify)
 }
 
 func resolveCwd() *string {
@@ -425,13 +456,18 @@ func runLimitsPane(args []string) error {
 }
 
 func runNotify() {
+	env := environment()
+	if !notificationsEnabled(env) {
+		return
+	}
+	config := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(env))
 	nowMs := time.Now().UnixMilli()
 	opts := limits.DefaultCollectOptions()
 	// Never toast about subscription windows for pay-as-you-go setups.
 	snaps, panesOK := openPaneSnapshots()
 	opts.Only = limits.BillingProviderFilter(snaps, panesOK, limits.DefaultBillingDeps())
 	providers := limits.CollectAllProviderLimits(resolveCwd(), nowMs, opts)
-	limits.NotifyProviderPrimaryLimits(providers, nowMs)
+	limits.NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, config.RemainingThresholds)
 }
 
 func runStatusLine() {
@@ -488,13 +524,14 @@ func runStatusLine() {
 		notify = func(title, body string) bool { return inner(label+": "+title, body) }
 	}
 
+	config := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(env))
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Fprintf(os.Stderr, "[usagebar-rate] check failed: %v\n", r)
 			}
 		}()
-		ratelimit.RunRateLimitCheckIn(profile.StateDir, stdinJSON, nowMs, notify)
+		runStatusLineNotifications(profile, stdinJSON, nowMs, config, notify)
 	}()
 	printStatusLineSummary(stdinJSON)
 }

--- a/cmd/usagebar/main_test.go
+++ b/cmd/usagebar/main_test.go
@@ -1,0 +1,96 @@
+// Command-level tests for usagebar notification configuration.
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
+	"github.com/senna-lang/herdr-agent-usage/internal/setup"
+)
+
+// TestNotificationsEnabledHonorsPluginConfig ensures both notification entrypoints
+// use the documented [notify].enabled switch.
+func TestNotificationsEnabledHonorsPluginConfig(t *testing.T) {
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[notify]\nenabled = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if notificationsEnabled(map[string]string{"HERDR_PLUGIN_CONFIG_DIR": configDir}) {
+		t.Fatal("notifications must be disabled by config")
+	}
+}
+
+func TestUpdateNotificationHonorsPluginConfig(t *testing.T) {
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[notify]\nenabled = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if updateNotification(map[string]string{"HERDR_PLUGIN_CONFIG_DIR": configDir}) != nil {
+		t.Fatal("update toast must be disabled by config")
+	}
+}
+
+// TestStatusLineNotificationsDeduplicatesEveryTick reproduces issue #32's
+// once-per-second statusLine calls after entering the 50% remaining bucket.
+func TestStatusLineNotificationsDeduplicatesEveryTick(t *testing.T) {
+	profile := claude.ClaudeProfile{StateDir: t.TempDir()}
+	config := setup.PluginConfig{NotifyEnabled: true, RemainingThresholds: []int{50, 20, 10, 5}}
+	payload := `{"rate_limits":{"five_hour":{"used_percentage":55,"resets_at":1800000000}}}`
+	notifications := 0
+	notify := ratelimit.ShowNotificationFn(func(_, _ string) bool {
+		notifications++
+		return true
+	})
+
+	for nowMs := int64(1_700_000_000_000); nowMs < 1_700_000_003_000; nowMs += 1_000 {
+		runStatusLineNotifications(profile, payload, nowMs, config, notify)
+	}
+
+	if notifications != 1 {
+		t.Fatalf("statusline sent %d notifications, want exactly one", notifications)
+	}
+	raw, err := os.ReadFile(filepath.Join(profile.StateDir, "rate-limit-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		FiveHour *struct {
+			NotifiedBucket *string `json:"notifiedBucket"`
+		} `json:"fiveHour"`
+	}
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatal(err)
+	}
+	if state.FiveHour == nil || state.FiveHour.NotifiedBucket == nil || *state.FiveHour.NotifiedBucket != "50" {
+		t.Fatalf("notified bucket was not persisted: %s", raw)
+	}
+}
+
+// TestStatusLineNotificationsDisabled reproduces issue #32's documented
+// notify.enabled=false switch for the same threshold-crossing statusline input.
+func TestStatusLineNotificationsDisabled(t *testing.T) {
+	profile := claude.ClaudeProfile{StateDir: t.TempDir()}
+	config := setup.PluginConfig{NotifyEnabled: false, RemainingThresholds: []int{50, 20, 10, 5}}
+	notifications := 0
+
+	runStatusLineNotifications(
+		profile,
+		`{"rate_limits":{"five_hour":{"used_percentage":55,"resets_at":1800000000}}}`,
+		1_700_000_000_000,
+		config,
+		func(_, _ string) bool {
+			notifications++
+			return true
+		},
+	)
+
+	if notifications != 0 {
+		t.Fatalf("disabled notifications sent %d toasts", notifications)
+	}
+}

--- a/internal/limits/notifystate.go
+++ b/internal/limits/notifystate.go
@@ -7,17 +7,22 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
 
-// NotifyProviderPrimaryLimits checks non-Claude primary windows under the
-// shared lock, excluding every configured Claude profile id.
+// NotifyProviderPrimaryLimits checks non-Claude primary windows with default
+// thresholds under the shared notification-state lock.
 func NotifyProviderPrimaryLimits(providers []ProviderLimits, nowMs int64) {
+	NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, nil)
+}
+
+// NotifyProviderPrimaryLimitsWithThresholds applies plugin-configured
+// remaining-percent thresholds under the shared notification-state lock.
+func NotifyProviderPrimaryLimitsWithThresholds(providers []ProviderLimits, nowMs int64, thresholds []int) {
 	claudeProfiles := ResolvedClaudeProfiles()
 	ratelimit.WithLockedProviderState(func(current ratelimit.ProviderNotifyStateMap) ratelimit.ProviderNotifyStateMap {
-		// convert to limits.ProviderNotifyState
 		cur := ProviderNotifyState{}
 		for k, v := range current {
 			cur[k] = v
 		}
-		next := CheckProviderPrimaryLimits(providers, cur, nowMs, herdrcliShowNotification, claudeProfiles)
+		next := CheckProviderPrimaryLimitsWithThresholds(providers, cur, nowMs, thresholds, herdrcliShowNotification, claudeProfiles)
 		out := ratelimit.ProviderNotifyStateMap{}
 		for k, v := range next {
 			out[k] = v

--- a/internal/limits/primarynotify.go
+++ b/internal/limits/primarynotify.go
@@ -21,6 +21,7 @@ func processProvider(
 	provider ProviderLimits,
 	previous *ratelimit.WindowState,
 	nowMs int64,
+	thresholds []int,
 	notify NotifyFunc,
 ) *ratelimit.WindowState {
 	primary := provider.Primary
@@ -28,9 +29,10 @@ func processProvider(
 		return previous
 	}
 
-	decision := ratelimit.DecideBucket(
+	decision := ratelimit.DecideBucketWithThresholds(
 		ratelimit.WindowInput{UsedPercentage: primary.UsedPercentage, ResetsAt: *primary.ResetsAt},
 		previous,
+		thresholds,
 	)
 	if decision.BucketToNotify == nil {
 		next := decision.NewState
@@ -46,15 +48,14 @@ func processProvider(
 	return ratelimit.ApplyNotifyResult(previous, decision.NewState, notify(text.Title, text.Body))
 }
 
-// CheckProviderPrimaryLimits is the pure state transition for non-Claude
-// primary windows. Every configured Claude profile id is excluded (not just
-// the literal "claude") because Claude's statusLine already owns its own
-// per-profile alerts — without this, a non-default profile like
-// "claude-secondary" would double-notify through this generic loop too.
-func CheckProviderPrimaryLimits(
+// CheckProviderPrimaryLimitsWithThresholds is the pure state transition for
+// non-Claude primary windows. Every configured Claude profile id is excluded
+// because Claude's statusLine owns its own per-profile alerts.
+func CheckProviderPrimaryLimitsWithThresholds(
 	providers []ProviderLimits,
 	current ProviderNotifyState,
 	nowMs int64,
+	thresholds []int,
 	notify NotifyFunc,
 	claudeProfiles []claude.ClaudeProfile,
 ) ProviderNotifyState {
@@ -67,7 +68,18 @@ func CheckProviderPrimaryLimits(
 			continue
 		}
 		prev := current[provider.ProviderID]
-		next[provider.ProviderID] = processProvider(provider, prev, nowMs, notify)
+		next[provider.ProviderID] = processProvider(provider, prev, nowMs, thresholds, notify)
 	}
 	return next
+}
+
+// CheckProviderPrimaryLimits uses the default 50/20/10/5% thresholds.
+func CheckProviderPrimaryLimits(
+	providers []ProviderLimits,
+	current ProviderNotifyState,
+	nowMs int64,
+	notify NotifyFunc,
+	claudeProfiles []claude.ClaudeProfile,
+) ProviderNotifyState {
+	return CheckProviderPrimaryLimitsWithThresholds(providers, current, nowMs, nil, notify, claudeProfiles)
 }

--- a/internal/limits/primarynotify_test.go
+++ b/internal/limits/primarynotify_test.go
@@ -130,3 +130,45 @@ func TestCheckProviderPrimaryLimits_IgnoresConfiguredSecondaryProfile(t *testing
 		t.Fatalf("claude-secondary must not double-notify through the generic loop: %v", notifications)
 	}
 }
+
+func TestCheckProviderPrimaryLimitsWithThresholds_UsesConfiguredBuckets(t *testing.T) {
+	var notifications []string
+	next := CheckProviderPrimaryLimitsWithThresholds(
+		[]ProviderLimits{notifyTestProvider(nil)},
+		ProviderNotifyState{},
+		notifyNowMs,
+		[]int{30},
+		func(title, body string) bool {
+			notifications = append(notifications, title+": "+body)
+			return true
+		},
+		defaultClaudeProfiles,
+	)
+	if len(notifications) != 0 {
+		t.Fatalf("45%% remaining must not cross a 30%% threshold: %v", notifications)
+	}
+	if next["codex"] == nil || next["codex"].NotifiedBucket != nil {
+		t.Fatalf("next=%+v", next["codex"])
+	}
+
+	crossed := notifyTestProvider(func(p *ProviderLimits) {
+		p.Primary.UsedPercentage = 75
+	})
+	next = CheckProviderPrimaryLimitsWithThresholds(
+		[]ProviderLimits{crossed},
+		next,
+		notifyNowMs,
+		[]int{30},
+		func(title, body string) bool {
+			notifications = append(notifications, title+": "+body)
+			return true
+		},
+		defaultClaudeProfiles,
+	)
+	if len(notifications) != 1 || notifications[0] != "Codex limit: 30% remaining · resets in 2h 0m" {
+		t.Fatalf("notifications=%v", notifications)
+	}
+	if next["codex"] == nil || next["codex"].NotifiedBucket == nil || *next["codex"].NotifiedBucket != ratelimit.Bucket("30") {
+		t.Fatalf("next=%+v", next["codex"])
+	}
+}

--- a/internal/ratelimit/bucket.go
+++ b/internal/ratelimit/bucket.go
@@ -1,50 +1,73 @@
 /**
- * Pure function that decides the bucket (50/20/10/5%) from the remaining
- * rate-limit percentage.
+ * Decides rate-limit notification buckets from configured remaining-percent
+ * thresholds while retaining default 50/20/10/5% behavior when absent.
  */
 package ratelimit
 
-var bucketRemainingThreshold = map[Bucket]float64{
-	Bucket50: 50,
-	Bucket20: 20,
-	Bucket10: 10,
-	Bucket5:  5,
-}
+import (
+	"sort"
+	"strconv"
+)
 
 func remainingPercentageOf(usedPercentage float64) float64 {
 	return 100 - usedPercentage
 }
 
-// worstBucketFor returns the most severe bucket that remaining has entered, or nil.
-func worstBucketFor(remainingPercentage float64) *Bucket {
+func bucketsForThresholds(thresholds []int) []Bucket {
+	if len(thresholds) == 0 {
+		return BucketOrder
+	}
+
+	unique := make(map[int]struct{}, len(thresholds))
+	values := make([]int, 0, len(thresholds))
+	for _, threshold := range thresholds {
+		if threshold < 1 || threshold > 100 {
+			continue
+		}
+		if _, exists := unique[threshold]; exists {
+			continue
+		}
+		unique[threshold] = struct{}{}
+		values = append(values, threshold)
+	}
+	if len(values) == 0 {
+		return BucketOrder
+	}
+
+	sort.Slice(values, func(i, j int) bool { return values[i] > values[j] })
+	buckets := make([]Bucket, len(values))
+	for i, threshold := range values {
+		buckets[i] = Bucket(strconv.Itoa(threshold))
+	}
+	return buckets
+}
+
+// worstBucketFor returns the most severe configured bucket that remaining has entered.
+func worstBucketFor(remainingPercentage float64, buckets []Bucket) *Bucket {
 	var worst *Bucket
-	for i := range BucketOrder {
-		b := BucketOrder[i]
-		if remainingPercentage <= bucketRemainingThreshold[b] {
-			worst = &b
+	for i := range buckets {
+		bucket := buckets[i]
+		threshold, err := strconv.Atoi(string(bucket))
+		if err == nil && remainingPercentage <= float64(threshold) {
+			worst = &bucket
 		}
 	}
 	return worst
 }
 
-func severityRankOf(bucket *Bucket) int {
+func severityRankOf(bucket *Bucket, buckets []Bucket) int {
 	if bucket == nil {
 		return -1
 	}
-	for i, b := range BucketOrder {
-		if b == *bucket {
+	for i, candidate := range buckets {
+		if candidate == *bucket {
 			return i
 		}
 	}
 	return -1
 }
 
-// DecideBucket decides the next state and which bucket (if any) should trigger a notification.
-//
-// - When resetsAt differs from the previous reading, treat it as a new window and reset notified state.
-// - When multiple buckets are crossed in a single step, notify only for the most severe one.
-// - When the remaining percentage has improved (not worsened), do not notify.
-func DecideBucket(input WindowInput, previous *WindowState) BucketDecision {
+func decideBucket(input WindowInput, previous *WindowState, buckets []Bucket) BucketDecision {
 	isNewWindow := previous == nil || previous.ResetsAt != input.ResetsAt
 	var notifiedBucket *Bucket
 	if !isNewWindow && previous != nil {
@@ -52,9 +75,8 @@ func DecideBucket(input WindowInput, previous *WindowState) BucketDecision {
 	}
 
 	remaining := remainingPercentageOf(input.UsedPercentage)
-	currentWorst := worstBucketFor(remaining)
-
-	shouldNotify := currentWorst != nil && severityRankOf(currentWorst) > severityRankOf(notifiedBucket)
+	currentWorst := worstBucketFor(remaining, buckets)
+	shouldNotify := currentWorst != nil && severityRankOf(currentWorst, buckets) > severityRankOf(notifiedBucket, buckets)
 
 	var newNotified *Bucket
 	if shouldNotify {
@@ -76,4 +98,14 @@ func DecideBucket(input WindowInput, previous *WindowState) BucketDecision {
 		},
 		BucketToNotify: bucketToNotify,
 	}
+}
+
+// DecideBucket uses the default 50/20/10/5% remaining thresholds.
+func DecideBucket(input WindowInput, previous *WindowState) BucketDecision {
+	return decideBucket(input, previous, BucketOrder)
+}
+
+// DecideBucketWithThresholds uses remaining-percent thresholds from plugin config.
+func DecideBucketWithThresholds(input WindowInput, previous *WindowState, thresholds []int) BucketDecision {
+	return decideBucket(input, previous, bucketsForThresholds(thresholds))
 }

--- a/internal/ratelimit/bucket_test.go
+++ b/internal/ratelimit/bucket_test.go
@@ -89,3 +89,23 @@ func TestDecideBucket_NoThreshold(t *testing.T) {
 		t.Fatalf("notifiedBucket = %#v, want nil", result.NewState.NotifiedBucket)
 	}
 }
+
+func TestDecideBucketWithThresholds_UsesConfiguredBuckets(t *testing.T) {
+	first := DecideBucketWithThresholds(
+		WindowInput{UsedPercentage: 78, ResetsAt: resetsAt},
+		nil,
+		[]int{30, 10},
+	)
+	if first.BucketToNotify == nil || *first.BucketToNotify != Bucket("30") {
+		t.Fatalf("bucketToNotify = %#v, want 30", first.BucketToNotify)
+	}
+
+	second := DecideBucketWithThresholds(
+		WindowInput{UsedPercentage: 90, ResetsAt: resetsAt},
+		&first.NewState,
+		[]int{30, 10},
+	)
+	if second.BucketToNotify == nil || *second.BucketToNotify != Bucket10 {
+		t.Fatalf("bucketToNotify = %#v, want 10", second.BucketToNotify)
+	}
+}

--- a/internal/ratelimit/format.go
+++ b/internal/ratelimit/format.go
@@ -45,7 +45,7 @@ func formatDuration(remainingMs int64) string {
 }
 
 // FormatNotificationBody builds Claude window notification text.
-// remainingBucket is the bucket name (50/20/10/5).
+// remainingBucket is the configured remaining-percent threshold.
 func FormatNotificationBody(
 	windowKey WindowKey,
 	remainingBucket Bucket,

--- a/internal/ratelimit/run.go
+++ b/internal/ratelimit/run.go
@@ -7,21 +7,22 @@ package ratelimit
 // ShowNotificationFn displays a toast; returns whether it was shown.
 type ShowNotificationFn func(title, body string) bool
 
-// ProcessWindow applies decideBucket + notify for one Claude window.
+// ProcessWindow applies the configured bucket decision and notification for one Claude window.
 func ProcessWindow(
 	key WindowKey,
 	input *RateWindowInput,
 	previous *WindowState,
 	nowMs int64,
+	thresholds []int,
 	notify ShowNotificationFn,
 ) *WindowState {
 	if input == nil {
 		return previous
 	}
-	decision := DecideBucket(WindowInput{
+	decision := DecideBucketWithThresholds(WindowInput{
 		UsedPercentage: input.UsedPercentage,
 		ResetsAt:       input.ResetsAt,
-	}, previous)
+	}, previous, thresholds)
 	if decision.BucketToNotify == nil {
 		next := decision.NewState
 		return &next
@@ -43,6 +44,18 @@ func RunRateLimitCheck(stdinJSON string, nowMs int64, notify ShowNotificationFn)
 // RunRateLimitCheckIn is RunRateLimitCheck scoped to an explicit per-profile
 // state dir, so two Claude accounts keep independent notify state.
 func RunRateLimitCheckIn(stateDir string, stdinJSON string, nowMs int64, notify ShowNotificationFn) {
+	RunRateLimitCheckWithThresholdsIn(stateDir, stdinJSON, nowMs, nil, notify)
+}
+
+// RunRateLimitCheckWithThresholdsIn applies the configured remaining-percent
+// thresholds to one profile's statusline rate-limit update.
+func RunRateLimitCheckWithThresholdsIn(
+	stateDir string,
+	stdinJSON string,
+	nowMs int64,
+	thresholds []int,
+	notify ShowNotificationFn,
+) {
 	rateLimits := ParseRateLimits(stdinJSON)
 	if rateLimits == nil {
 		return
@@ -52,8 +65,8 @@ func RunRateLimitCheckIn(stateDir string, stdinJSON string, nowMs int64, notify 
 	}
 	WithLockedStateIn(stateDir, func(current ClaudeNotifyState) ClaudeNotifyState {
 		return ClaudeNotifyState{
-			FiveHour: ProcessWindow(WindowFiveHour, rateLimits.FiveHour, current.FiveHour, nowMs, notify),
-			SevenDay: ProcessWindow(WindowSevenDay, rateLimits.SevenDay, current.SevenDay, nowMs, notify),
+			FiveHour: ProcessWindow(WindowFiveHour, rateLimits.FiveHour, current.FiveHour, nowMs, thresholds, notify),
+			SevenDay: ProcessWindow(WindowSevenDay, rateLimits.SevenDay, current.SevenDay, nowMs, thresholds, notify),
 		}
 	})
 }

--- a/internal/ratelimit/run_test.go
+++ b/internal/ratelimit/run_test.go
@@ -1,0 +1,32 @@
+// Tests configured-threshold notification execution from statusline input.
+package ratelimit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRunRateLimitCheckWithThresholdsInUsesConfiguredBuckets ensures the
+// statusline execution path does not fall back to the fixed 20% bucket.
+func TestRunRateLimitCheckWithThresholdsInUsesConfiguredBuckets(t *testing.T) {
+	dir := t.TempDir()
+	var notifications []string
+	RunRateLimitCheckWithThresholdsIn(
+		dir,
+		`{"rate_limits":{"five_hour":{"used_percentage":78,"resets_at":1800000000}}}`,
+		1_700_000_000_000,
+		[]int{30},
+		func(title, body string) bool {
+			notifications = append(notifications, title+": "+body)
+			return true
+		},
+	)
+
+	if len(notifications) != 1 || notifications[0] != "Session limit: 30% remaining · resets in 1157d 9h" {
+		t.Fatalf("notifications=%v", notifications)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rate-limit-state.json")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/ratelimit/statestore.go
+++ b/internal/ratelimit/statestore.go
@@ -14,7 +14,7 @@ import (
 const (
 	lockRetryInterval = 20 * time.Millisecond
 	lockTimeout       = 2 * time.Second
-	lockStale         = 10 * time.Second
+	lockStale         = time.Minute
 )
 
 // baseDir is the single-default notify-state dir. Per-profile isolation is
@@ -180,19 +180,17 @@ func WithLockedState(update func(current ClaudeNotifyState) ClaudeNotifyState) C
 	return WithLockedStateIn("", update)
 }
 
-// WithLockedStateIn is WithLockedState scoped to an explicit state dir.
+// WithLockedStateIn is WithLockedState scoped to an explicit state dir. It
+// never runs update without the lock, since that decision could not persist.
 func WithLockedStateIn(dir string, update func(current ClaudeNotifyState) ClaudeNotifyState) ClaudeNotifyState {
-	locked := AcquireLockIn(dir)
-	defer func() {
-		if locked {
-			ReleaseLockIn(dir)
-		}
-	}()
+	if !AcquireLockIn(dir) {
+		return readClaudeStateIn(dir)
+	}
+	defer ReleaseLockIn(dir)
+
 	current := readClaudeStateIn(dir)
 	next := update(current)
-	if locked {
-		writeClaudeStateIn(dir, next)
-	}
+	writeClaudeStateIn(dir, next)
 	return next
 }
 
@@ -233,17 +231,16 @@ func writeProviderState(state ProviderNotifyStateMap) {
 }
 
 // WithLockedProviderState runs provider-primary notify under the same lock.
+// It does not run update without the lock because its deduplication result
+// would not be persisted.
 func WithLockedProviderState(update func(current ProviderNotifyStateMap) ProviderNotifyStateMap) ProviderNotifyStateMap {
-	locked := AcquireLock()
-	defer func() {
-		if locked {
-			ReleaseLock()
-		}
-	}()
+	if !AcquireLock() {
+		return readProviderState()
+	}
+	defer ReleaseLock()
+
 	current := readProviderState()
 	next := update(current)
-	if locked {
-		writeProviderState(next)
-	}
+	writeProviderState(next)
 	return next
 }

--- a/internal/ratelimit/statestore_test.go
+++ b/internal/ratelimit/statestore_test.go
@@ -45,6 +45,25 @@ func TestAcquireLock_DoesNotDestroyFresh(t *testing.T) {
 	}
 }
 
+func TestAcquireLock_DoesNotReclaimLockYoungerThanOneMinute(t *testing.T) {
+	dir := withTempStateDir(t)
+	lockPath := filepath.Join(dir, "rate-limit-state.lock")
+	if err := os.WriteFile(lockPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Now().Add(-20 * time.Second)
+	if err := os.Chtimes(lockPath, createdAt, createdAt); err != nil {
+		t.Fatal(err)
+	}
+
+	if AcquireLock() {
+		t.Fatal("must not reclaim a lock that can still belong to notification delivery")
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatal("lock must remain")
+	}
+}
+
 func TestWithLockedState_Writes(t *testing.T) {
 	dir := withTempStateDir(t)
 	b50 := Bucket50
@@ -72,7 +91,10 @@ func TestWithLockedState_Writes(t *testing.T) {
 	}
 }
 
-func TestWithLockedState_NoWriteWhenLocked(t *testing.T) {
+// TestWithLockedState_SkipsUpdateWhenLocked prevents a concurrent statusline
+// render from showing a duplicate toast without being able to persist its
+// deduplication state.
+func TestWithLockedState_SkipsUpdateWhenLocked(t *testing.T) {
 	dir := withTempStateDir(t)
 	statePath := filepath.Join(dir, "rate-limit-state.json")
 	existing := []byte(`{"fiveHour":{"resetsAt":1,"notifiedBucket":"20","failedNotifyAttempts":0},"sevenDay":null}`)
@@ -86,23 +108,52 @@ func TestWithLockedState_NoWriteWhenLocked(t *testing.T) {
 	now := time.Now()
 	_ = os.Chtimes(lockPath, now, now)
 
-	b5 := Bucket5
+	called := false
 	next := WithLockedState(func(current ClaudeNotifyState) ClaudeNotifyState {
-		return ClaudeNotifyState{
-			FiveHour: &WindowState{ResetsAt: 999, NotifiedBucket: &b5},
-		}
+		called = true
+		return ClaudeNotifyState{}
 	})
-	if next.FiveHour == nil || *next.FiveHour.NotifiedBucket != Bucket5 {
-		t.Fatalf("update still runs: %+v", next)
+	if called {
+		t.Fatal("update must not run without the persistence lock")
 	}
-	onDisk, _ := os.ReadFile(statePath)
-	var parsed map[string]any
-	_ = json.Unmarshal(onDisk, &parsed)
-	five := parsed["fiveHour"].(map[string]any)
-	if five["notifiedBucket"] != "20" {
-		t.Fatalf("disk should keep 20, got %v", five)
+	if next.FiveHour == nil || next.FiveHour.NotifiedBucket == nil || *next.FiveHour.NotifiedBucket != Bucket20 {
+		t.Fatalf("got %+v, want persisted state", next)
+	}
+	onDisk, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != string(existing) {
+		t.Fatalf("disk changed: %s", onDisk)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatal("other lock must remain")
+	}
+}
+
+func TestWithLockedProviderState_SkipsUpdateWhenLocked(t *testing.T) {
+	dir := withTempStateDir(t)
+	statePath := filepath.Join(dir, "provider-limit-notify-state.json")
+	existing := []byte(`{"codex":{"resetsAt":1,"notifiedBucket":"20","failedNotifyAttempts":0}}`)
+	if err := os.WriteFile(statePath, existing, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(dir, "rate-limit-state.lock")
+	if err := os.WriteFile(lockPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	_ = os.Chtimes(lockPath, now, now)
+
+	called := false
+	next := WithLockedProviderState(func(current ProviderNotifyStateMap) ProviderNotifyStateMap {
+		called = true
+		return ProviderNotifyStateMap{}
+	})
+	if called {
+		t.Fatal("update must not run without the persistence lock")
+	}
+	if next["codex"] == nil || next["codex"].NotifiedBucket == nil || *next["codex"].NotifiedBucket != Bucket20 {
+		t.Fatalf("got %+v, want persisted state", next)
 	}
 }


### PR DESCRIPTION
## Summary
- persist and honor statusLine notification deduplication across every render
- honor `notify.enabled = false` for statusLine, provider, and update toasts
- apply configured `remaining_thresholds` to Claude and non-Claude notifications
- prevent non-Claude notification callbacks when the shared state lock is unavailable

## Verification
- `go test ./cmd/usagebar -run 'TestStatusLineNotifications(DeduplicatesEveryTick|Disabled)' -count=1 -v`
  - simulates three one-second statusLine ticks after crossing the 50% boundary: exactly one notification and persisted `notifiedBucket: "50"`
  - verifies `notify.enabled = false` sends zero notifications
- `go test ./... -count=1`
- LSP diagnostics: OK

Closes #32.