### PR TITLE
fix: normalize config_dir matching and cover the default account

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,36 @@ continue to refresh. `remaining_thresholds` accepts remaining percentages from
 1 through 100 (for example `[30, 10]`); each threshold can notify once per
 window, from least to most severe.
 
+### Multiple Claude accounts
+
+Add one `[[claude.profiles]]` block per account to the plugin config. Each
+profile owns its own limits cache, notify state, and transcript root under its
+`config_dir`, so accounts never share readings. With no profile configured the
+plugin tracks a single account at `~/.claude` (unchanged behavior).
+
+```toml
+[[claude.profiles]]
+id = "base"                    # provider id; must be unique
+label = "personal"             # optional, shown in the pane and toasts
+config_dir = "~/.claude"       # the default account
+
+[[claude.profiles]]
+id = "work"
+config_dir = "~/.claude-work"  # started via CLAUDE_CONFIG_DIR=~/.claude-work claude
+```
+
+- **Declare the default account too.** Bare `claude` sets no
+  `CLAUDE_CONFIG_DIR` — the convention is to set it only for *additional*
+  accounts — so once any profile exists, the account at `~/.claude` needs an
+  entry of its own to be recorded.
+- `config_dir` may use `~`; it is expanded and each account is matched to its
+  profile by the resolved path. `claude_json_path` is optional and only needed
+  for a non-default `.claude.json` location.
+- A statusLine invocation whose config dir matches no profile writes nothing
+  and names the mismatch on stderr rather than attributing usage to the wrong
+  account. `usagebar setup` lists the resolved profiles and warns when an entry
+  was ignored or the default account is uncovered.
+
 ### Herdr toast delivery
 
 Required for notifications to appear on screen:

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -481,14 +481,18 @@ func runStatusLine() {
 
 	// Route this statusLine invocation to the profile matching its own
 	// CLAUDE_CONFIG_DIR. The statusLine runs inside the Claude process, so the
-	// env var is present and identifies the account unambiguously.
+	// env var identifies the account; when it is unset Claude is running the
+	// default account and the profile for ~/.claude is the match.
 	env := environment()
-	profiles := setup.ResolveClaudeProfiles(env)
-	profile, known := claude.ResolveActiveProfile(profiles, env["CLAUDE_CONFIG_DIR"])
+	profile, profiles, known := setup.ResolveActiveClaudeProfile(env)
 	if !known {
 		// Profiles are configured but none match this CLAUDE_CONFIG_DIR: skip all
-		// writes and notifications rather than misattribute the account. Still
-		// print the summary so the Claude status line renders.
+		// writes and notifications rather than misattribute the account. Name the
+		// mismatch on stderr — silently rendering correct numbers while never
+		// caching them is otherwise invisible. Still print the summary so the
+		// Claude status line renders.
+		fmt.Fprintf(os.Stderr, "[usagebar-rate] no claude profile matches CLAUDE_CONFIG_DIR=%s; configured config_dirs: %s (skipping cache write and notifications)\n",
+			describeConfigDir(env["CLAUDE_CONFIG_DIR"]), describeProfileDirs(profiles))
 		printStatusLineSummary(stdinJSON)
 		return
 	}
@@ -541,6 +545,24 @@ func printStatusLineSummary(stdinJSON string) {
 	if summary != "" {
 		fmt.Println(summary)
 	}
+}
+
+// describeConfigDir renders CLAUDE_CONFIG_DIR for the profile-miss diagnostic,
+// distinguishing "unset" (the default account) from an explicit value.
+func describeConfigDir(configDir string) string {
+	if configDir == "" {
+		return "(unset, i.e. the default account)"
+	}
+	return configDir
+}
+
+// describeProfileDirs lists the configured profiles as id=config_dir pairs.
+func describeProfileDirs(profiles []claude.ClaudeProfile) string {
+	parts := make([]string, len(profiles))
+	for i, p := range profiles {
+		parts[i] = p.ID + "=" + p.ConfigDir
+	}
+	return strings.Join(parts, ", ")
 }
 
 // runOpenCodeCheck reports each stage of the OpenCode Go usage path so a

--- a/internal/claude/profile.go
+++ b/internal/claude/profile.go
@@ -3,13 +3,18 @@
  *
  * A profile is one CLAUDE_CONFIG_DIR-scoped account. All plugin-derived files
  * (limits cache, notify state, transcript root) live under the profile's config
- * dir, so two accounts never collide. Absence of any configured profile
- * synthesizes today's single implicit "claude" profile, whose derived paths are
- * byte-identical to the historical ~/.claude defaults (env overrides still win).
+ * dir, so two accounts never collide. Configured paths are normalized (leading
+ * "~" expanded, cleaned) so config.toml and the env var can spell the same dir
+ * differently. Absence of any configured profile synthesizes today's single
+ * implicit "claude" profile, whose derived paths are byte-identical to the
+ * historical ~/.claude defaults (env overrides still win).
  */
 package claude
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // DefaultProfileID is the provider id used for the single implicit profile.
 const DefaultProfileID = "claude"
@@ -34,6 +39,11 @@ type ClaudeProfile struct {
 	LimitsCache  string // statusLine limits cache
 	StateDir     string // notify state + lock dir
 	ProjectsRoot string // transcript projects root
+	// Implicit is true only for the synthesized default profile (no
+	// [[claude.profiles]] configured at all). It marks the profile that must
+	// absorb every statusLine invocation regardless of CLAUDE_CONFIG_DIR, since
+	// zero-config installs have no other place to attribute usage to.
+	Implicit bool
 }
 
 // derivedLimitsCache is the per-config-dir limits cache path.
@@ -61,6 +71,27 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+// normalizePath makes a configured or env-provided path comparable: it expands a
+// leading "~" (nothing expands it when the value comes from TOML) and cleans the
+// result, so "~/.claude", "/home/u/.claude/" and "/home/u/./.claude" all reduce
+// to the same string.
+//
+// Relative paths are deliberately NOT resolved against the cwd. The write side
+// (statusLine) runs inside the Claude process with cwd = the user's project,
+// while the read side (panel/sidebar/notify) runs as a Herdr plugin action with
+// an unrelated cwd; expanding against cwd would make the two sides disagree
+// about the same profile. A relative config_dir therefore stays relative and
+// simply fails to match, which the caller reports.
+func normalizePath(path, home string) string {
+	if path == "" {
+		return ""
+	}
+	if home != "" && (path == "~" || strings.HasPrefix(path, "~/")) {
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	return filepath.Clean(path)
+}
+
 // synthesizeDefaultProfile builds the single implicit "claude" profile.
 //
 // Its derived paths are anchored to the historical ~/.claude location, NOT
@@ -84,6 +115,7 @@ func synthesizeDefaultProfile(env map[string]string, home string) ClaudeProfile 
 		LimitsCache:  firstNonEmpty(env["USAGEBAR_CLAUDE_LIMITS_PATH"], derivedLimitsCache(configDir)),
 		StateDir:     firstNonEmpty(env["USAGEBAR_STATE_DIR"], derivedStateDir(configDir)),
 		ProjectsRoot: firstNonEmpty(env["CLAUDE_PROJECTS_ROOT"], derivedProjectsRoot(configDir)),
+		Implicit:     true,
 	}
 }
 
@@ -107,17 +139,22 @@ func defaultJSONPathFor(configDir, home string) string {
 // resolveSpec builds a concrete profile from one config entry. Env path
 // overrides are deliberately ignored in multi-profile mode: a single global
 // override cannot be attributed to one of several profiles.
+//
+// Paths are normalized (leading "~" expanded, cleaned) before anything is
+// derived from them: a literal "~/.claude-dev" would otherwise become a
+// derived cache under a directory actually named "~".
 func resolveSpec(spec ProfileSpec, home string) ClaudeProfile {
 	label := firstNonEmpty(spec.Label, spec.ID)
-	jsonPath := firstNonEmpty(spec.JSONPath, defaultJSONPathFor(spec.ConfigDir, home))
+	configDir := normalizePath(spec.ConfigDir, home)
+	jsonPath := firstNonEmpty(normalizePath(spec.JSONPath, home), defaultJSONPathFor(configDir, home))
 	return ClaudeProfile{
 		ID:           spec.ID,
 		Label:        label,
-		ConfigDir:    spec.ConfigDir,
+		ConfigDir:    configDir,
 		JSONPath:     jsonPath,
-		LimitsCache:  derivedLimitsCache(spec.ConfigDir),
-		StateDir:     derivedStateDir(spec.ConfigDir),
-		ProjectsRoot: derivedProjectsRoot(spec.ConfigDir),
+		LimitsCache:  derivedLimitsCache(configDir),
+		StateDir:     derivedStateDir(configDir),
+		ProjectsRoot: derivedProjectsRoot(configDir),
 	}
 }
 
@@ -127,6 +164,8 @@ func resolveSpec(spec ProfileSpec, home string) ClaudeProfile {
 //   - Otherwise each valid spec becomes a profile. Entries missing id or
 //     config_dir are skipped, as are duplicate ids and duplicate config dirs
 //     (first wins), so malformed config degrades safely rather than colliding.
+//     Duplicate detection compares normalized dirs, so "~/.claude" and
+//     "/home/you/.claude" count as the same account.
 func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []ClaudeProfile {
 	if len(specs) == 0 {
 		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}
@@ -135,14 +174,15 @@ func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []
 	seenID := map[string]bool{}
 	seenDir := map[string]bool{}
 	for _, spec := range specs {
-		if spec.ID == "" || spec.ConfigDir == "" {
+		configDir := normalizePath(spec.ConfigDir, home)
+		if spec.ID == "" || configDir == "" {
 			continue
 		}
-		if seenID[spec.ID] || seenDir[spec.ConfigDir] {
+		if seenID[spec.ID] || seenDir[configDir] {
 			continue
 		}
 		seenID[spec.ID] = true
-		seenDir[spec.ConfigDir] = true
+		seenDir[configDir] = true
 		out = append(out, resolveSpec(spec, home))
 	}
 	if len(out) == 0 {
@@ -152,17 +192,28 @@ func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []
 }
 
 // ResolveActiveProfile picks the profile whose ConfigDir matches the given
-// configDir (typically the in-process CLAUDE_CONFIG_DIR on the write side).
+// configDir (the in-process CLAUDE_CONFIG_DIR on the write side).
 //
-//   - Single profile: always returns it (ok=true) — the single-profile fallback.
-//   - Multiple profiles: returns the config-dir match, or ok=false when none
-//     match, so the caller can skip writes rather than misattribute the account.
-func ResolveActiveProfile(profiles []ClaudeProfile, configDir string) (ClaudeProfile, bool) {
-	if len(profiles) == 1 {
+//   - Lone synthesized default (no [[claude.profiles]] at all): always returns
+//     it, so a zero-config install with a relocated CLAUDE_CONFIG_DIR keeps
+//     caching to the historical ~/.claude location both sides agree on.
+//   - Configured profiles: returns the normalized config-dir match, or ok=false
+//     when none match, so the caller can skip writes rather than misattribute
+//     the account. This holds for a single configured profile too: matching one
+//     account's usage onto another profile is worse than not recording it.
+//   - An empty configDir means Claude Code was started without the env var,
+//     i.e. it is running the default account, so it resolves to ~/.claude —
+//     the convention is to set CLAUDE_CONFIG_DIR only for additional accounts.
+func ResolveActiveProfile(profiles []ClaudeProfile, configDir, home string) (ClaudeProfile, bool) {
+	if len(profiles) == 1 && profiles[0].Implicit {
 		return profiles[0], true
 	}
+	if configDir == "" {
+		configDir = filepath.Join(home, ".claude")
+	}
+	want := normalizePath(configDir, home)
 	for _, p := range profiles {
-		if p.ConfigDir == configDir {
+		if normalizePath(p.ConfigDir, home) == want {
 			return p, true
 		}
 	}

--- a/internal/claude/profile.go
+++ b/internal/claude/profile.go
@@ -39,10 +39,12 @@ type ClaudeProfile struct {
 	LimitsCache  string // statusLine limits cache
 	StateDir     string // notify state + lock dir
 	ProjectsRoot string // transcript projects root
-	// Implicit is true only for the synthesized default profile (no
-	// [[claude.profiles]] configured at all). It marks the profile that must
-	// absorb every statusLine invocation regardless of CLAUDE_CONFIG_DIR, since
-	// zero-config installs have no other place to attribute usage to.
+	// Implicit is true only when zero [[claude.profiles]] were configured at
+	// all (len(specs) == 0). It marks the profile that must absorb every
+	// statusLine invocation regardless of CLAUDE_CONFIG_DIR, since zero-config
+	// installs have no other place to attribute usage to. A profile synthesized
+	// because every configured entry was invalid stays non-implicit: malformed
+	// config must not silently absorb an unrelated account's usage.
 	Implicit bool
 }
 
@@ -80,8 +82,8 @@ func firstNonEmpty(values ...string) string {
 // (statusLine) runs inside the Claude process with cwd = the user's project,
 // while the read side (panel/sidebar/notify) runs as a Herdr plugin action with
 // an unrelated cwd; expanding against cwd would make the two sides disagree
-// about the same profile. A relative config_dir therefore stays relative and
-// simply fails to match, which the caller reports.
+// about the same profile. A relative config_dir is therefore rejected by
+// ResolveProfiles rather than kept and compared relatively (see validateSpec).
 func normalizePath(path, home string) string {
 	if path == "" {
 		return ""
@@ -105,7 +107,13 @@ func normalizePath(path, home string) string {
 // The explicit USAGEBAR_*/CLAUDE_PROJECTS_ROOT/CLAUDE_CONFIG_JSON overrides
 // still apply here since they are pre-existing, side-agnostic escape hatches
 // the caller sets deliberately (not an implicit CLAUDE_CONFIG_DIR read).
-func synthesizeDefaultProfile(env map[string]string, home string) ClaudeProfile {
+//
+// implicit is true only for the true zero-config case (no [[claude.profiles]]
+// at all). When ResolveProfiles falls back here because every configured entry
+// was invalid, implicit must be false: the caller tried to scope accounts and
+// got it wrong, so ResolveActiveProfile must still require a config-dir match
+// rather than absorb any CLAUDE_CONFIG_DIR into this profile's cache.
+func synthesizeDefaultProfile(env map[string]string, home string, implicit bool) ClaudeProfile {
 	configDir := filepath.Join(home, ".claude")
 	return ClaudeProfile{
 		ID:           DefaultProfileID,
@@ -115,7 +123,7 @@ func synthesizeDefaultProfile(env map[string]string, home string) ClaudeProfile 
 		LimitsCache:  firstNonEmpty(env["USAGEBAR_CLAUDE_LIMITS_PATH"], derivedLimitsCache(configDir)),
 		StateDir:     firstNonEmpty(env["USAGEBAR_STATE_DIR"], derivedStateDir(configDir)),
 		ProjectsRoot: firstNonEmpty(env["CLAUDE_PROJECTS_ROOT"], derivedProjectsRoot(configDir)),
-		Implicit:     true,
+		Implicit:     implicit,
 	}
 }
 
@@ -158,27 +166,65 @@ func resolveSpec(spec ProfileSpec, home string) ClaudeProfile {
 	}
 }
 
+// validateSpec reports whether spec is admissible: non-empty id, and a
+// config_dir that normalizes to a non-empty absolute path not already claimed
+// by an earlier id or dir in this batch (seenID/seenDir are mutated by the
+// caller after a true result). Shared by ResolveProfiles and
+// ValidProfileSpecCount so the two can never disagree on what counts as valid.
+func validateSpec(spec ProfileSpec, home string, seenID, seenDir map[string]bool) (configDir string, ok bool) {
+	configDir = normalizePath(spec.ConfigDir, home)
+	if spec.ID == "" || configDir == "" || !filepath.IsAbs(configDir) {
+		return "", false
+	}
+	if seenID[spec.ID] || seenDir[configDir] {
+		return "", false
+	}
+	return configDir, true
+}
+
+// ValidProfileSpecCount reports how many specs would survive ResolveProfiles'
+// validation. Used by `usagebar setup` to detect the "every entry was invalid"
+// fallback: that resolves to the same single default ClaudeProfile as a
+// genuinely valid single profile re-declaring ~/.claude, so the two are
+// otherwise indistinguishable by inspecting the resolved profile alone.
+func ValidProfileSpecCount(specs []ProfileSpec, home string) int {
+	seenID := map[string]bool{}
+	seenDir := map[string]bool{}
+	n := 0
+	for _, spec := range specs {
+		configDir, ok := validateSpec(spec, home, seenID, seenDir)
+		if !ok {
+			continue
+		}
+		seenID[spec.ID] = true
+		seenDir[configDir] = true
+		n++
+	}
+	return n
+}
+
 // ResolveProfiles turns config entries into concrete profiles.
 //
-//   - No specs -> one synthesized default "claude" profile (backward compat).
-//   - Otherwise each valid spec becomes a profile. Entries missing id or
-//     config_dir are skipped, as are duplicate ids and duplicate config dirs
-//     (first wins), so malformed config degrades safely rather than colliding.
-//     Duplicate detection compares normalized dirs, so "~/.claude" and
-//     "/home/you/.claude" count as the same account.
+//   - No specs -> one synthesized default "claude" profile (backward compat),
+//     Implicit = true.
+//   - Otherwise each spec passing validateSpec becomes a profile (first wins on
+//     a duplicate id or dir), so malformed config degrades safely rather than
+//     colliding or matching the wrong cwd. Duplicate detection compares
+//     normalized dirs, so "~/.claude" and "/home/you/.claude" count as the
+//     same account.
+//   - If every entry was invalid, falls back to the synthesized default like
+//     "no specs" -- but with Implicit = false, so a malformed config can never
+//     silently absorb an unrelated account's usage (see synthesizeDefaultProfile).
 func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []ClaudeProfile {
 	if len(specs) == 0 {
-		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}
+		return []ClaudeProfile{synthesizeDefaultProfile(env, home, true)}
 	}
 	out := make([]ClaudeProfile, 0, len(specs))
 	seenID := map[string]bool{}
 	seenDir := map[string]bool{}
 	for _, spec := range specs {
-		configDir := normalizePath(spec.ConfigDir, home)
-		if spec.ID == "" || configDir == "" {
-			continue
-		}
-		if seenID[spec.ID] || seenDir[configDir] {
+		configDir, ok := validateSpec(spec, home, seenID, seenDir)
+		if !ok {
 			continue
 		}
 		seenID[spec.ID] = true
@@ -186,7 +232,7 @@ func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []
 		out = append(out, resolveSpec(spec, home))
 	}
 	if len(out) == 0 {
-		return []ClaudeProfile{synthesizeDefaultProfile(env, home)}
+		return []ClaudeProfile{synthesizeDefaultProfile(env, home, false)}
 	}
 	return out
 }
@@ -194,16 +240,21 @@ func ResolveProfiles(specs []ProfileSpec, env map[string]string, home string) []
 // ResolveActiveProfile picks the profile whose ConfigDir matches the given
 // configDir (the in-process CLAUDE_CONFIG_DIR on the write side).
 //
-//   - Lone synthesized default (no [[claude.profiles]] at all): always returns
-//     it, so a zero-config install with a relocated CLAUDE_CONFIG_DIR keeps
-//     caching to the historical ~/.claude location both sides agree on.
-//   - Configured profiles: returns the normalized config-dir match, or ok=false
-//     when none match, so the caller can skip writes rather than misattribute
-//     the account. This holds for a single configured profile too: matching one
-//     account's usage onto another profile is worse than not recording it.
+//   - Lone synthesized default from true zero-config (Implicit, no
+//     [[claude.profiles]] at all): always returns it, so a relocated
+//     CLAUDE_CONFIG_DIR still caches to the historical ~/.claude location both
+//     sides agree on.
+//   - Configured profiles, or a non-implicit synthesized default (every
+//     configured entry was invalid): returns the normalized config-dir match,
+//     or ok=false when none match, so the caller can skip writes rather than
+//     misattribute the account. This holds for a single profile too: matching
+//     one account's usage onto another is worse than not recording it.
 //   - An empty configDir means Claude Code was started without the env var,
 //     i.e. it is running the default account, so it resolves to ~/.claude —
 //     the convention is to set CLAUDE_CONFIG_DIR only for additional accounts.
+//   - A non-absolute configDir (or, in a corrupt environment, a non-absolute
+//     home) never matches: relative paths compare meaninglessly against a
+//     write-side cwd the read side does not share.
 func ResolveActiveProfile(profiles []ClaudeProfile, configDir, home string) (ClaudeProfile, bool) {
 	if len(profiles) == 1 && profiles[0].Implicit {
 		return profiles[0], true
@@ -212,6 +263,9 @@ func ResolveActiveProfile(profiles []ClaudeProfile, configDir, home string) (Cla
 		configDir = filepath.Join(home, ".claude")
 	}
 	want := normalizePath(configDir, home)
+	if !filepath.IsAbs(want) {
+		return ClaudeProfile{}, false
+	}
 	for _, p := range profiles {
 		if normalizePath(p.ConfigDir, home) == want {
 			return p, true

--- a/internal/claude/profile_test.go
+++ b/internal/claude/profile_test.go
@@ -151,9 +151,12 @@ func TestIsClaudeProviderID(t *testing.T) {
 	}
 }
 
-func TestResolveActiveProfile_SingleAlwaysMatches(t *testing.T) {
+func TestResolveActiveProfile_LoneSynthesizedDefaultAlwaysMatches(t *testing.T) {
+	// Zero-config install: a relocated CLAUDE_CONFIG_DIR still attributes to the
+	// synthesized ~/.claude profile, which is the only place both the write and
+	// read sides agree on.
 	profiles := ResolveProfiles(nil, map[string]string{"CLAUDE_CONFIG_DIR": "/x"}, "/home/u")
-	p, ok := ResolveActiveProfile(profiles, "/totally/different")
+	p, ok := ResolveActiveProfile(profiles, "/totally/different", "/home/u")
 	if !ok || p.ID != "claude" {
 		t.Fatalf("single-profile fallback failed: ok=%v id=%q", ok, p.ID)
 	}
@@ -165,7 +168,7 @@ func TestResolveActiveProfile_MultiMatchesConfigDir(t *testing.T) {
 		{ID: "claude-m", ConfigDir: "/b"},
 	}
 	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
-	p, ok := ResolveActiveProfile(profiles, "/b")
+	p, ok := ResolveActiveProfile(profiles, "/b", "/home/u")
 	if !ok || p.ID != "claude-m" {
 		t.Fatalf("want claude-m, ok=%v id=%q", ok, p.ID)
 	}
@@ -177,8 +180,77 @@ func TestResolveActiveProfile_MultiUnknownSkips(t *testing.T) {
 		{ID: "claude-m", ConfigDir: "/b"},
 	}
 	profiles := ResolveProfiles(specs, map[string]string{}, "/home/u")
-	if _, ok := ResolveActiveProfile(profiles, "/unknown"); ok {
+	if _, ok := ResolveActiveProfile(profiles, "/unknown", "/home/u"); ok {
 		t.Fatal("unknown CLAUDE_CONFIG_DIR must not match under multi-profile")
+	}
+}
+
+func TestResolveActiveProfile_UnsetConfigDirMatchesDefaultDirProfile(t *testing.T) {
+	// Bare `claude` sets no CLAUDE_CONFIG_DIR: the convention is to set it only
+	// for additional accounts, so an empty value means the default ~/.claude
+	// account and must match the profile declaring that dir.
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: filepath.Join(home, ".claude")},
+		{ID: "dev", ConfigDir: filepath.Join(home, ".claude-dev")},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	p, ok := ResolveActiveProfile(profiles, "", home)
+	if !ok || p.ID != "base" {
+		t.Fatalf("unset CLAUDE_CONFIG_DIR: ok=%v id=%q, want base", ok, p.ID)
+	}
+}
+
+func TestResolveActiveProfile_UnsetConfigDirWithoutDefaultDirProfileSkips(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "dev", ConfigDir: filepath.Join(home, ".claude-dev")},
+		{ID: "work", ConfigDir: filepath.Join(home, ".claude-work")},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if _, ok := ResolveActiveProfile(profiles, "", home); ok {
+		t.Fatal("default account must not be attributed to an unrelated profile")
+	}
+}
+
+func TestResolveActiveProfile_TildeProfileMatchesAbsoluteConfigDir(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "dev", ConfigDir: "~/.claude-dev"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	p, ok := ResolveActiveProfile(profiles, filepath.Join(home, ".claude-dev"), home)
+	if !ok || p.ID != "dev" {
+		t.Fatalf("tilde config_dir must match absolute env: ok=%v id=%q", ok, p.ID)
+	}
+}
+
+func TestResolveActiveProfile_TrailingSlashAndDotSegmentsMatch(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: "/home/u/.claude/"},
+		{ID: "dev", ConfigDir: "/home/u/./.claude-dev"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if p, ok := ResolveActiveProfile(profiles, "/home/u/.claude", home); !ok || p.ID != "base" {
+		t.Fatalf("trailing slash: ok=%v id=%q", ok, p.ID)
+	}
+	if p, ok := ResolveActiveProfile(profiles, "/home/u/.claude-dev/", home); !ok || p.ID != "dev" {
+		t.Fatalf("dot segment: ok=%v id=%q", ok, p.ID)
+	}
+}
+
+func TestResolveActiveProfile_SingleConfiguredProfileStillRequiresMatch(t *testing.T) {
+	// One configured profile must not absorb every account: silently reporting
+	// one account's usage as another's is worse than recording nothing.
+	home := "/home/u"
+	profiles := ResolveProfiles([]ProfileSpec{{ID: "dev", ConfigDir: "~/.claude-dev"}}, map[string]string{}, home)
+	if _, ok := ResolveActiveProfile(profiles, filepath.Join(home, ".claude-other"), home); ok {
+		t.Fatal("single configured profile must not match a foreign config dir")
+	}
+	if p, ok := ResolveActiveProfile(profiles, filepath.Join(home, ".claude-dev"), home); !ok || p.ID != "dev" {
+		t.Fatalf("its own config dir must match: ok=%v id=%q", ok, p.ID)
 	}
 }
 
@@ -221,5 +293,67 @@ func TestResolveProfiles_ExplicitJSONPathOverridesDefaultDirHeuristic(t *testing
 	p := ResolveProfiles(specs, map[string]string{}, home)[0]
 	if p.JSONPath != "/custom/path.json" {
 		t.Fatalf("explicit claude_json_path must win, got %q", p.JSONPath)
+	}
+}
+
+func TestResolveProfiles_ExpandsTildeInPaths(t *testing.T) {
+	// A "~" in config.toml is never expanded by a shell, so derived paths would
+	// otherwise land under a directory literally named "~".
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "dev", ConfigDir: "~/.claude-dev", JSONPath: "~/custom/dev.json"},
+	}
+	p := ResolveProfiles(specs, map[string]string{}, home)[0]
+	if p.ConfigDir != filepath.Join(home, ".claude-dev") {
+		t.Fatalf("configDir = %q", p.ConfigDir)
+	}
+	if p.JSONPath != filepath.Join(home, "custom", "dev.json") {
+		t.Fatalf("jsonPath = %q", p.JSONPath)
+	}
+	if p.LimitsCache != filepath.Join(home, ".claude-dev", "herdr-usagebar", "claude-limits-latest.json") {
+		t.Fatalf("limitsCache = %q", p.LimitsCache)
+	}
+	if p.StateDir != filepath.Join(home, ".claude-dev", "herdr-usagebar") {
+		t.Fatalf("stateDir = %q", p.StateDir)
+	}
+	if p.ProjectsRoot != filepath.Join(home, ".claude-dev", "projects") {
+		t.Fatalf("projectsRoot = %q", p.ProjectsRoot)
+	}
+}
+
+func TestResolveProfiles_TildeDefaultDirUsesSiblingJSONPath(t *testing.T) {
+	// The sibling-.claude.json rule must survive tilde notation too.
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "dev", ConfigDir: "~/.claude-dev"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if profiles[0].JSONPath != filepath.Join(home, ".claude.json") {
+		t.Fatalf("tilde default-dir jsonPath = %q, want sibling ~/.claude.json", profiles[0].JSONPath)
+	}
+	if profiles[1].JSONPath != filepath.Join(home, ".claude-dev", ".claude.json") {
+		t.Fatalf("tilde separate-dir jsonPath = %q", profiles[1].JSONPath)
+	}
+}
+
+func TestResolveProfiles_DedupesTildeAndAbsoluteSameDir(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "base-again", ConfigDir: "/home/u/.claude/"},
+	}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if len(profiles) != 1 || profiles[0].ID != "base" {
+		t.Fatalf("want only the first spec for one dir, got %+v", profiles)
+	}
+}
+
+func TestResolveProfiles_RelativeConfigDirIsNotCwdExpanded(t *testing.T) {
+	// Resolving against the cwd would make the write side (cwd = project) and
+	// the read side (cwd = Herdr) disagree, so a relative dir stays relative.
+	p := ResolveProfiles([]ProfileSpec{{ID: "rel", ConfigDir: "./.claude"}}, map[string]string{}, "/home/u")[0]
+	if p.ConfigDir != ".claude" {
+		t.Fatalf("configDir = %q, want cleaned-but-relative", p.ConfigDir)
 	}
 }

--- a/internal/claude/profile_test.go
+++ b/internal/claude/profile_test.go
@@ -349,11 +349,58 @@ func TestResolveProfiles_DedupesTildeAndAbsoluteSameDir(t *testing.T) {
 	}
 }
 
-func TestResolveProfiles_RelativeConfigDirIsNotCwdExpanded(t *testing.T) {
+func TestResolveProfiles_RejectsRelativeConfigDir(t *testing.T) {
 	// Resolving against the cwd would make the write side (cwd = project) and
-	// the read side (cwd = Herdr) disagree, so a relative dir stays relative.
-	p := ResolveProfiles([]ProfileSpec{{ID: "rel", ConfigDir: "./.claude"}}, map[string]string{}, "/home/u")[0]
-	if p.ConfigDir != ".claude" {
-		t.Fatalf("configDir = %q, want cleaned-but-relative", p.ConfigDir)
+	// the read side (cwd = Herdr) disagree, so a relative config_dir is
+	// rejected outright (not kept and compared relatively). The only spec is
+	// invalid, so this falls back to the non-implicit synthesized default.
+	home := "/home/u"
+	profiles := ResolveProfiles([]ProfileSpec{{ID: "rel", ConfigDir: "./.claude-rel"}}, map[string]string{}, home)
+	if len(profiles) != 1 || profiles[0].ID != DefaultProfileID || profiles[0].Implicit {
+		t.Fatalf("want non-implicit fallback default, got %+v", profiles[0])
+	}
+}
+
+func TestResolveActiveProfile_RelativeConfigDirNeverMatches(t *testing.T) {
+	// Even though the spec's (rejected) config_dir and the running
+	// CLAUDE_CONFIG_DIR are textually identical relative strings, the spec
+	// never became a profile and the fallback default must not match a
+	// relative env value either.
+	home := "/home/u"
+	profiles := ResolveProfiles([]ProfileSpec{{ID: "rel", ConfigDir: "./.claude-rel"}}, map[string]string{}, home)
+	if _, ok := ResolveActiveProfile(profiles, "./.claude-rel", home); ok {
+		t.Fatal("relative CLAUDE_CONFIG_DIR must never match")
+	}
+}
+
+func TestResolveActiveProfile_AllSpecsInvalidFallbackRequiresMatch(t *testing.T) {
+	// Every configured entry is malformed (empty id here). ResolveProfiles
+	// falls back to the default profile, but -- unlike true zero-config --
+	// that fallback must not silently absorb an unrelated account's usage.
+	home := "/home/u"
+	specs := []ProfileSpec{{ID: "", ConfigDir: "~/.claude-dev"}}
+	profiles := ResolveProfiles(specs, map[string]string{}, home)
+	if len(profiles) != 1 || profiles[0].Implicit {
+		t.Fatalf("want non-implicit fallback default, got %+v", profiles[0])
+	}
+	if _, ok := ResolveActiveProfile(profiles, filepath.Join(home, ".claude-dev"), home); ok {
+		t.Fatal("malformed-config fallback must not absorb an unrelated account's CLAUDE_CONFIG_DIR")
+	}
+	// The default account itself must still work.
+	if p, ok := ResolveActiveProfile(profiles, "", home); !ok || p.ID != DefaultProfileID {
+		t.Fatalf("default account must still match: ok=%v id=%q", ok, p.ID)
+	}
+}
+
+func TestValidProfileSpecCount(t *testing.T) {
+	home := "/home/u"
+	specs := []ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "base-again", ConfigDir: "/home/u/.claude/"}, // duplicate dir
+		{ID: "rel", ConfigDir: "./.claude-rel"},           // relative
+		{ID: "", ConfigDir: "/home/u/.claude-noid"},       // missing id
+	}
+	if n := ValidProfileSpecCount(specs, home); n != 1 {
+		t.Fatalf("ValidProfileSpecCount = %d, want 1", n)
 	}
 }

--- a/internal/setup/pluginconfig.go
+++ b/internal/setup/pluginconfig.go
@@ -96,20 +96,24 @@ func DefaultPluginConfigTOML(config PluginConfig) string {
 		"# remaining % thresholds that may fire a toast (once per window/bucket)",
 		"remaining_thresholds = [" + thresholds + "]",
 		"",
-		"# Multi-account Claude: uncomment and add one block per CLAUDE_CONFIG_DIR.",
+		"# Multi-account Claude: uncomment and add one block per account.",
 		"# Absence of any profile keeps the single default account (fully backward",
-		"# compatible). config_dir must be unique per profile.",
+		"# compatible). config_dir must be unique per profile and may use ~.",
+		"#",
+		"# Once any profile exists, declare the default account too: bare `claude`",
+		"# sets no CLAUDE_CONFIG_DIR, so the ~/.claude account is only recorded if",
+		"# a profile claims that dir. `usagebar setup` warns when it is uncovered.",
 		"#",
 		"# [[claude.profiles]]",
 		"# id = \"claude\"",
 		"# label = \"Claude\"",
-		"# config_dir = \"/home/you/.claude\"",
-		"# claude_json_path = \"/home/you/.claude.json\"",
+		"# config_dir = \"~/.claude\"",
+		"# claude_json_path = \"~/.claude.json\"   # optional; defaults per config_dir",
 		"#",
 		"# [[claude.profiles]]",
 		"# id = \"claude-secondary\"",
 		"# label = \"Claude (secondary)\"",
-		"# config_dir = \"/home/you/.claude-secondary\"",
+		"# config_dir = \"~/.claude-secondary\"",
 		"",
 	}, "\n")
 }
@@ -177,6 +181,17 @@ func ResolveClaudeProfiles(env map[string]string) []claude.ClaudeProfile {
 	cfg := LoadPluginConfig(ResolvePluginConfigDir(env))
 	home, _ := os.UserHomeDir()
 	return claude.ResolveProfiles(cfg.ClaudeProfiles, env, home)
+}
+
+// ResolveActiveClaudeProfile resolves the configured profiles and picks the one
+// this process is running as, using its own CLAUDE_CONFIG_DIR. Write side only
+// (statusLine): the read side cannot see that env var. The full profile list is
+// returned alongside so a caller can report an unmatched config dir.
+func ResolveActiveClaudeProfile(env map[string]string) (claude.ClaudeProfile, []claude.ClaudeProfile, bool) {
+	profiles := ResolveClaudeProfiles(env)
+	home, _ := os.UserHomeDir()
+	profile, ok := claude.ResolveActiveProfile(profiles, env["CLAUDE_CONFIG_DIR"], home)
+	return profile, profiles, ok
 }
 
 // LoadPluginConfig loads config.toml or returns defaults.

--- a/internal/setup/profilereport.go
+++ b/internal/setup/profilereport.go
@@ -18,14 +18,27 @@ import (
 // claudeProfileReportLines renders the configured profiles and the warnings for
 // config that silently loses usage data. specs are the raw config entries,
 // profiles the result of resolving them, home the user's home dir.
+//
+// The "every entry was invalid" fallback and a genuinely valid single profile
+// re-declaring ~/.claude resolve to the same ClaudeProfile, so the branch below
+// checks claude.ValidProfileSpecCount rather than inspecting profiles: it is
+// the only signal that distinguishes "no real config" from "config, but wrong".
 func claudeProfileReportLines(specs []claude.ProfileSpec, profiles []claude.ClaudeProfile, home string) []string {
-	if len(profiles) == 1 && profiles[0].Implicit {
-		lines := []string{"· claude profiles: none configured; single default account: " + profiles[0].ConfigDir}
-		if len(specs) > 0 {
-			lines = append(lines, "  ! all "+itoa(len(specs))+" [[claude.profiles]] entries were ignored:"+
-				" each needs an id and a unique config_dir")
+	validCount := claude.ValidProfileSpecCount(specs, home)
+
+	if len(specs) == 0 {
+		return []string{
+			"· claude profiles: none configured; single default account: " + profiles[0].ConfigDir,
+			"",
 		}
-		return append(lines, "")
+	}
+	if validCount == 0 {
+		return []string{
+			"· claude profiles: none configured; single default account: " + profiles[0].ConfigDir,
+			"  ! all " + itoa(len(specs)) + " [[claude.profiles]] entries were ignored:" +
+				" each needs an id and a unique, absolute config_dir",
+			"",
+		}
 	}
 
 	defaultDir := filepath.Join(home, ".claude")
@@ -39,15 +52,9 @@ func claudeProfileReportLines(specs []claude.ProfileSpec, profiles []claude.Clau
 		}
 		lines = append(lines, row)
 	}
-	if dropped := len(specs) - len(profiles); dropped > 0 {
+	if dropped := len(specs) - validCount; dropped > 0 {
 		lines = append(lines, "  ! "+itoa(dropped)+" entr"+plural(dropped, "y", "ies")+
-			" ignored: each needs an id and a unique config_dir")
-	}
-	for _, p := range profiles {
-		if !filepath.IsAbs(p.ConfigDir) {
-			lines = append(lines, "  ! "+p.ID+": config_dir is not absolute ("+p.ConfigDir+
-				"); use an absolute path or ~/...")
-		}
+			" ignored: each needs an id and a unique, absolute config_dir")
 	}
 	if !coversDefault {
 		lines = append(lines, "  ! no profile has config_dir = "+defaultDir+

--- a/internal/setup/profilereport.go
+++ b/internal/setup/profilereport.go
@@ -1,0 +1,65 @@
+/**
+ * Renders the [[claude.profiles]] block of `usagebar setup`.
+ *
+ * Profile misconfiguration is silent at runtime: the status line still shows
+ * correct numbers while nothing is cached for the account, so setup is the only
+ * place a user can see that an entry was dropped, that a config_dir cannot be
+ * resolved, or that the default account (bare `claude`, no CLAUDE_CONFIG_DIR)
+ * is not covered by any profile.
+ */
+package setup
+
+import (
+	"path/filepath"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+)
+
+// claudeProfileReportLines renders the configured profiles and the warnings for
+// config that silently loses usage data. specs are the raw config entries,
+// profiles the result of resolving them, home the user's home dir.
+func claudeProfileReportLines(specs []claude.ProfileSpec, profiles []claude.ClaudeProfile, home string) []string {
+	if len(profiles) == 1 && profiles[0].Implicit {
+		lines := []string{"· claude profiles: none configured; single default account: " + profiles[0].ConfigDir}
+		if len(specs) > 0 {
+			lines = append(lines, "  ! all "+itoa(len(specs))+" [[claude.profiles]] entries were ignored:"+
+				" each needs an id and a unique config_dir")
+		}
+		return append(lines, "")
+	}
+
+	defaultDir := filepath.Join(home, ".claude")
+	lines := []string{"· claude profiles: " + itoa(len(profiles)) + " configured"}
+	coversDefault := false
+	for _, p := range profiles {
+		row := "    " + p.ID + "  " + p.ConfigDir
+		if p.ConfigDir == defaultDir {
+			coversDefault = true
+			row += "  (default account)"
+		}
+		lines = append(lines, row)
+	}
+	if dropped := len(specs) - len(profiles); dropped > 0 {
+		lines = append(lines, "  ! "+itoa(dropped)+" entr"+plural(dropped, "y", "ies")+
+			" ignored: each needs an id and a unique config_dir")
+	}
+	for _, p := range profiles {
+		if !filepath.IsAbs(p.ConfigDir) {
+			lines = append(lines, "  ! "+p.ID+": config_dir is not absolute ("+p.ConfigDir+
+				"); use an absolute path or ~/...")
+		}
+	}
+	if !coversDefault {
+		lines = append(lines, "  ! no profile has config_dir = "+defaultDir+
+			"; usage of the account started by bare `claude` (no CLAUDE_CONFIG_DIR) is not recorded")
+	}
+	return append(lines, "")
+}
+
+// plural picks the singular or plural suffix for n.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/internal/setup/profilereport_test.go
+++ b/internal/setup/profilereport_test.go
@@ -1,0 +1,85 @@
+/**
+ * Tests for the `usagebar setup` [[claude.profiles]] diagnostics.
+ */
+package setup
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/claude"
+)
+
+func reportText(specs []claude.ProfileSpec, home string) string {
+	profiles := claude.ResolveProfiles(specs, map[string]string{}, home)
+	return strings.Join(claudeProfileReportLines(specs, profiles, home), "\n")
+}
+
+func TestClaudeProfileReport_NoSpecsReportsSingleDefault(t *testing.T) {
+	got := reportText(nil, "/home/u")
+	if !strings.Contains(got, "none configured") ||
+		!strings.Contains(got, filepath.Join("/home/u", ".claude")) {
+		t.Fatalf("report = %q", got)
+	}
+	if strings.Contains(got, "!") {
+		t.Fatalf("zero-config must not warn: %q", got)
+	}
+}
+
+func TestClaudeProfileReport_AllEntriesIgnoredWarns(t *testing.T) {
+	specs := []claude.ProfileSpec{{ID: "", ConfigDir: "/a"}}
+	got := reportText(specs, "/home/u")
+	if !strings.Contains(got, "all 1 [[claude.profiles]] entries were ignored") {
+		t.Fatalf("report = %q", got)
+	}
+}
+
+func TestClaudeProfileReport_MarksDefaultAccountAndListsProfiles(t *testing.T) {
+	home := "/home/u"
+	specs := []claude.ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "dev", ConfigDir: "~/.claude-dev"},
+	}
+	got := reportText(specs, home)
+	if !strings.Contains(got, "2 configured") {
+		t.Fatalf("count missing: %q", got)
+	}
+	if !strings.Contains(got, "base  "+filepath.Join(home, ".claude")+"  (default account)") {
+		t.Fatalf("default marker missing: %q", got)
+	}
+	if !strings.Contains(got, "dev  "+filepath.Join(home, ".claude-dev")) {
+		t.Fatalf("secondary row missing: %q", got)
+	}
+	if strings.Contains(got, "!") {
+		t.Fatalf("valid config must not warn: %q", got)
+	}
+}
+
+func TestClaudeProfileReport_WarnsWhenDefaultAccountUncovered(t *testing.T) {
+	home := "/home/u"
+	specs := []claude.ProfileSpec{
+		{ID: "dev", ConfigDir: "~/.claude-dev"},
+		{ID: "work", ConfigDir: "~/.claude-work"},
+	}
+	got := reportText(specs, home)
+	if !strings.Contains(got, "no profile has config_dir = "+filepath.Join(home, ".claude")) {
+		t.Fatalf("uncovered-default warning missing: %q", got)
+	}
+}
+
+func TestClaudeProfileReport_WarnsOnDroppedDuplicateAndRelativeDir(t *testing.T) {
+	home := "/home/u"
+	specs := []claude.ProfileSpec{
+		{ID: "base", ConfigDir: "~/.claude"},
+		{ID: "base-again", ConfigDir: "/home/u/.claude/"}, // duplicate dir -> dropped
+		{ID: "rel", ConfigDir: "./.claude-rel"},
+	}
+	got := reportText(specs, home)
+	if !strings.Contains(got, "1 entry ignored") {
+		t.Fatalf("dropped-entry warning missing: %q", got)
+	}
+	if !strings.Contains(got, "rel: config_dir is not absolute") {
+		t.Fatalf("relative-dir warning missing: %q", got)
+	}
+}

--- a/internal/setup/profilereport_test.go
+++ b/internal/setup/profilereport_test.go
@@ -69,17 +69,20 @@ func TestClaudeProfileReport_WarnsWhenDefaultAccountUncovered(t *testing.T) {
 }
 
 func TestClaudeProfileReport_WarnsOnDroppedDuplicateAndRelativeDir(t *testing.T) {
+	// duplicate dir and a relative config_dir are both rejected before a
+	// ClaudeProfile is ever built for them, so they surface only via the
+	// dropped-entry count, not a per-profile row or a separate warning line.
 	home := "/home/u"
 	specs := []claude.ProfileSpec{
 		{ID: "base", ConfigDir: "~/.claude"},
 		{ID: "base-again", ConfigDir: "/home/u/.claude/"}, // duplicate dir -> dropped
-		{ID: "rel", ConfigDir: "./.claude-rel"},
+		{ID: "rel", ConfigDir: "./.claude-rel"},           // relative -> dropped
 	}
 	got := reportText(specs, home)
-	if !strings.Contains(got, "1 entry ignored") {
+	if !strings.Contains(got, "2 entries ignored") {
 		t.Fatalf("dropped-entry warning missing: %q", got)
 	}
-	if !strings.Contains(got, "rel: config_dir is not absolute") {
-		t.Fatalf("relative-dir warning missing: %q", got)
+	if strings.Contains(got, "rel") {
+		t.Fatalf("rejected relative entry must not appear as a profile row: %q", got)
 	}
 }

--- a/internal/setup/runsetup.go
+++ b/internal/setup/runsetup.go
@@ -52,8 +52,13 @@ func RunSetup(options SetupOptions) SetupReport {
 	}
 	lines = append(lines,
 		"  notify.enabled="+boolStr(pluginCfg.NotifyEnabled)+"  thresholds=["+strings.Join(thr, ", ")+"]",
-		"",
 	)
+	home, _ := os.UserHomeDir()
+	lines = append(lines, claudeProfileReportLines(
+		pluginCfg.ClaudeProfiles,
+		ResolveClaudeProfiles(env),
+		home,
+	)...)
 
 	toastWrote := false
 	if options.WriteToast {


### PR DESCRIPTION
Fixes #35

## Problem

`ResolveActiveProfile` matched a statusLine invocation to a configured profile by exact string equality on `config_dir`. Two common setups matched nothing:

1. **Default profile never caches** — bare `claude` sets no `CLAUDE_CONFIG_DIR` (the convention is to set it only for *additional* accounts), so `env["CLAUDE_CONFIG_DIR"] == ""` never matched any profile's `ConfigDir`, and the statusLine skipped its cache write while still rendering correct numbers on screen — invisible unless you knew to look.
2. **`~` in `config_dir` silently collapsed accounts** — `"~/.claude-dev" != "/Users/me/.claude-dev"` under raw string comparison. Worse than reported: reproduced against real files, a literal `~` config_dir caused the plugin to write its cache under a directory *literally named* `~` inside the process cwd, not under any account's home directory at all.

## Fix

`internal/claude/profile.go`:
- `normalizePath(path, home)` expands a leading `~` and `filepath.Clean`s the result *before* anything is derived from or compared against a `config_dir`. Applied in `resolveSpec` (so `LimitsCache`/`StateDir`/`ProjectsRoot`/`JSONPath` never land under a literal `~`) and in `ResolveActiveProfile`. Deliberately does **not** resolve relative paths against `cwd` — the write side (statusLine, cwd = user's project) and read side (panel/notify, cwd = Herdr) would otherwise disagree about the same profile.
- `ResolveActiveProfile(profiles, configDir, home)` now falls back to `~/.claude` when `configDir` is empty (the default-account convention), and requires a strict match even with exactly one *configured* profile. The unconditional single-profile fallback survives only for the synthesized implicit default (new `ClaudeProfile.Implicit` field) — misattributing one account's usage to another is worse than recording nothing.
- `ResolveProfiles` dedupes on the normalized dir, so `~/.claude` and its absolute equivalent count as one entry.

Diagnostics (both requested in the issue):
- The `!known` branch in `runStatusLine` now logs the unmatched `CLAUDE_CONFIG_DIR` and the configured profiles to stderr instead of failing silently.
- `usagebar setup` gained a claude-profiles report (`internal/setup/profilereport.go`): lists resolved profiles, flags ignored/duplicate entries, non-absolute `config_dir`, and — the actual root-cause class here — an uncovered default account.

README: documented `[[claude.profiles]]`, the "declare the default account too" requirement, and that `config_dir` accepts `~`.

## Testing

- `internal/claude/profile_test.go` (+12 tests) and new `internal/setup/profilereport_test.go` cover tilde expansion, dedup, env-unset fallback, strict single-profile matching, and every setup warning path.
- `go test ./...`, `go vet ./...`, `gofmt -l .` all clean.
- Reproduced both symptoms against a built binary on `main` (including the stray `~`-named directory the current code creates), then confirmed fixed on this branch with the same scenarios.
