### PR TITLE
fix: preserve observed usage windows and track Opus 5

### DIFF
--- a/internal/claude/modelwindows.go
+++ b/internal/claude/modelwindows.go
@@ -21,6 +21,7 @@ import (
 var contextWindowTokens = map[string]int{
 	// --- 1M (Claude Code paid default / OpenCode anthropic catalog) ---
 	"claude-sonnet-5":   1_000_000,
+	"claude-opus-5":     1_000_000,
 	"claude-fable-5":    1_000_000,
 	"claude-opus-4-8":   1_000_000,
 	"claude-opus-4-7":   1_000_000,

--- a/internal/claude/modelwindows_test.go
+++ b/internal/claude/modelwindows_test.go
@@ -17,6 +17,7 @@ func TestNormalizeClaudeModelId_Strips1m(t *testing.T) {
 func TestContextWindowFor_1MDefaults(t *testing.T) {
 	models := []string{
 		"claude-sonnet-5",
+		"claude-opus-5",
 		"claude-fable-5",
 		"claude-opus-4-8",
 		"claude-opus-4-7",

--- a/internal/limits/windowpool.go
+++ b/internal/limits/windowpool.go
@@ -98,11 +98,12 @@ const (
 	slotTertiary
 )
 
-// slotForLimitID maps an OMP limit_id to a display slot.
+// slotForLimitID maps an OMP limit_id to a display slot and fallback duration.
 //
 // The window vocabulary differs per provider, so the mapping is explicit
 // rather than pattern-matched: an unrecognized id is skipped, never guessed
-// into the wrong bar. The returned minutes label the window for display.
+// into the wrong bar. A recognized persisted window label overrides the
+// fallback duration when observations are folded below.
 func slotForLimitID(providerID, limitID string) (windowSlot, int) {
 	switch providerID {
 	case "claude":
@@ -140,6 +141,22 @@ func slotForLimitID(providerID, limitID string) (windowSlot, int) {
 		}
 	}
 	return slotNone, 0
+}
+
+// windowMinutesFromLabel returns the duration explicitly recorded by OMP.
+// Provider limit ids such as openai-codex:primary are ordinals, not durations:
+// the same primary id may represent the only 7-day window for an account.
+func windowMinutesFromLabel(label string) int {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "5h", "5 hour", "5 hours":
+		return 300
+	case "7d", "7 day", "7 days", "weekly":
+		return 10080
+	case "30d", "30 day", "30 days", "monthly":
+		return 43200
+	default:
+		return 0
+	}
 }
 
 // windowFromUsageFraction converts an OMP row to a display window. The
@@ -191,6 +208,9 @@ func AccountWindowsFromOMP(rows []omp.UsageWindow) []AccountWindows {
 			continue
 		}
 		slot, minutes := slotForLimitID(route.CollectorProviderID, row.LimitID)
+		if observedMinutes := windowMinutesFromLabel(row.WindowLabel); observedMinutes > 0 {
+			minutes = observedMinutes
+		}
 		if slot == slotNone {
 			continue
 		}

--- a/internal/limits/windowpool_test.go
+++ b/internal/limits/windowpool_test.go
@@ -215,6 +215,33 @@ func TestAccountWindowsFromOMP(t *testing.T) {
 		}
 	})
 
+	t.Run("uses the observed Codex duration instead of the primary ordinal", func(t *testing.T) {
+		rows := []omp.UsageWindow{{
+			Provider:     "openai-codex",
+			AccountKey:   wpKeyOAuthFull,
+			AccountID:    wpAccountID,
+			LimitID:      "openai-codex:primary",
+			WindowLabel:  "7 days",
+			UsedFraction: 0.09,
+			ResetsAtMs:   1785839498000,
+			RecordedAtMs: 1785235600947,
+		}}
+		got := AccountWindowsFromOMP(rows)
+		if len(got) != 1 {
+			t.Fatalf("got %d observations, want 1: %+v", len(got), got)
+		}
+		if got[0].Primary == nil {
+			t.Fatalf("Primary = nil, want the observed Codex window: %+v", got[0])
+		}
+		if wpMinutes(got[0].Primary) != "10080" {
+			t.Fatalf("Primary.WindowMinutes = %s, want 10080 for %q",
+				wpMinutes(got[0].Primary), rows[0].WindowLabel)
+		}
+		if got[0].Secondary != nil {
+			t.Fatalf("Secondary = %+v, want nil for a single observed window", *got[0].Secondary)
+		}
+	})
+
 	t.Run("one account under two account keys collapses", func(t *testing.T) {
 		// The regression this whole pool exists for: OMP composes account_key
 		// from the credential shape, so the same subscription shows up as both


### PR DESCRIPTION
## Summary

- derive OMP window durations from the persisted `window_label` instead of assuming Codex `primary` always means five hours
- preserve explicit provider slot routing while allowing observed durations such as Codex `7 days` to drive the rendered label and reset math
- track `claude-opus-5` as a 1M-context model
- add regressions for the real `openai-codex:primary` + `7 days` observation and the Opus 5 context window

Fixes #30

## Verification

- `go test ./...` — 20 packages passed, 2 packages have no tests
- `go vet ./...`
- `go build ./...`
- `gofmt -l ...` — no output
- workspace LSP diagnostics — no issues
- `go run ./scripts/modeldrift` — no model-window drift
- rebuilt `bin/usagebar limits --once` renders Codex as `7d`