### PR TITLE
chore: correct commit lint docs and pin the hook toolchain

### DIFF
--- a/.commitlint.yaml
+++ b/.commitlint.yaml
@@ -5,7 +5,9 @@
 #     (https://github.com/conventionalcommit/commitlint, a Go implementation
 #     of conventional commit linting, no Node.js required)
 #   - the lint-pr-title GitHub Action, which validates the PR title against
-#     the same `type-enum` rule with an equivalent header pattern.
+#     the same `type-enum` list but enforces neither this file's length
+#     rules nor the same scope charset — see the asymmetry note in
+#     .github/workflows/lint-pr-title.yml.
 #
 # Rule reference: https://github.com/conventionalcommit/commitlint#available-rules
 #
@@ -26,6 +28,9 @@ severity:
   default: error
   rules: {}
 settings:
+  # header-min-length / header-max-length count BYTES, not runes (see
+  # conventionalcommit/commitlint rule/rule.go). For Japanese subjects, 72
+  # bytes is roughly 22-24 characters, not 72.
   header-min-length:
     argument: 10
     flags: {}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,14 +13,20 @@
 #   - `synchronize` is included so the check re-runs on every push; omit it
 #     only if you do not mark this as a required status check.
 #
-# The action uses its default header pattern. That pattern is slightly
-# more permissive on scope characters than commitlint-go's default scope
-# charset, but in practice the unused extra characters (uppercase, `$`, `*`,
-# spaces in the scope) never appear in this repo, so a PR title that passes
-# here also passes `commitlint lint` locally against the same message. The
-# reverse is not guaranteed: `feat(API): ...` is accepted locally but
-# rejected here. Contributors wanting uppercase scopes should rewrite the
-# scope in lowercase.
+# Known asymmetries between this action and .commitlint.yaml (both verified
+# against commitlint-go v0.12.0 source, not just its README):
+#   - Length: this action enforces no title-length rule at all, while
+#     .commitlint.yaml sets header-min-length 10 / header-max-length 72
+#     (measured in BYTES). `fix: typo` (9 bytes) passes here and is
+#     rejected by the local hook; a 90-byte title does the opposite.
+#   - Scope charset: commitlint-go enables no scope rule, so any rune except
+#     newline/parens passes locally (e.g. `feat(データ層): ...`). This
+#     action's default headerPattern restricts the scope to `[\w$.\-*/ ]`,
+#     which is ASCII-only, so a non-ASCII scope fails here but passes
+#     locally. An uppercase ASCII scope such as `feat(API): ...` passes
+#     BOTH tools (`\w` includes A-Z; commitlint-go has no charset rule).
+# Net effect: passing here does not guarantee passing locally, and vice
+# versa. Treat the local hook as the stricter, authoritative check.
 name: Lint PR title
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,13 @@ Build and test the project from the repository root:
 make build
 make test
 ```
-Before opening a pull request, run the same core checks used by CI
-(`gofmt -l .` should produce no output):
+
+Add or update tests for the behavior you change. Prefer focused tests beside
+the affected package, and include regression coverage for bug fixes when
+practical.
+
+Format changed Go files with `gofmt`. Before opening a pull request, run the
+same core checks used by CI (`gofmt -l .` should produce no output):
 
 ```sh
 gofmt -l .
@@ -81,13 +86,19 @@ Allowed `<type>` values:
 
 Use a lowercase scope in parentheses to identify the affected package when
 it is obvious (for example `chore(deps): bump actions/checkout to v7`).
-Keep the summary line under 72 characters and use the imperative mood
-("add", not "added" or "adds").
+Keep the summary line between 10 and 72 bytes (measured in bytes, not
+characters — roughly 3-24 characters for Japanese text) and use the
+imperative mood ("add", not "added" or "adds"). If squash-merge defaults to
+the PR title (see "Maintainer notes" below), GitHub appends " (#123)" to
+the merged commit header, so leave a few bytes of headroom below 72 for the
+PR title itself.
 
 PR titles must follow the same format. They are validated by the
 `Lint PR title` GitHub Actions workflow
 (`.github/workflows/lint-pr-title.yml`), which uses the same type list as
-the local hook.
+the local hook. The two tools are not fully equivalent — see the asymmetry
+note at the top of that workflow file — so treat the local hook as the
+stricter, authoritative check before pushing.
 
 To lint commits locally before pushing, install the commit-msg hook:
 
@@ -100,7 +111,11 @@ This installs
 (a Go implementation, no Node.js required) and configures it against
 `.commitlint.yaml`. After installation, a non-conforming message such as
 `git commit -m "fix typo"` will be rejected; rewrite it as
-`fix: correct typo in setup output` and try again.
+`fix: correct typo in setup output` and try again. The hook exits non-zero
+whenever `commitlint` is missing from `PATH` (for example after
+`go clean -modcache`), which blocks every local commit until it is
+reinstalled; run `git config --unset core.hooksPath` to disable the hook if
+you need to commit before reinstalling.
 
 ### Maintainer notes (enforcing the rule)
 
@@ -110,7 +125,8 @@ must apply both of the following GitHub repository settings once this
 commit lands on `main`:
 
 1. **Required status check.** Under *Settings → Branches → Branch
-   protection rules*, mark `Lint PR title / Validate PR title` as a
+   protection rules*, mark **Validate PR title** (the job name; shown in
+   the check list as `Lint PR title / Validate PR title`) as a
    required check for `main`. `synchronize` is included in the workflow
    trigger so the check re-runs on every push and stays current as
    required checks require it.
@@ -122,7 +138,7 @@ commit lands on `main`:
 
 These settings live in GitHub, not in the repository, so they are not
 versioned here. Re-apply them after creating a new repository or
-re import.
+reimporting this one.
 
 ## Pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ install-plugin: build
 # pre-push, ...) stop running until you copy them under
 # `.commitlint/hooks/` or unset `core.hooksPath`.
 install-hooks:
-	@command -v commitlint >/dev/null 2>&1 || \
-	  (echo "installing commitlint v0.12.0..." && \
-	   go install github.com/conventionalcommit/commitlint@v0.12.0)
-	commitlint init
-	@echo "commit-msg hook installed. Try: git commit -m 'foo: bad'"
+	@CL=commitlint; \
+	if ! command -v commitlint >/dev/null 2>&1 || ! commitlint --version 2>/dev/null | grep -q '0\.12\.0'; then \
+	  echo "installing commitlint v0.12.0..."; \
+	  go install github.com/conventionalcommit/commitlint@v0.12.0; \
+	  CL="$$(go env GOPATH)/bin/commitlint"; \
+	fi; \
+	"$$CL" init; \
+	echo "commit-msg hook installed. Try: git commit -m 'foo: bad'"


### PR DESCRIPTION
## Summary

The review follow-ups described in #37's "Update (post-review)" section were edited in the
working tree at 20:47–20:48 JST but never committed. #37 squash-merged at 20:58 from
`ca2282c`, which predates those edits, so `main` never received them. `git log --all -S` finds
no commit carrying them and the stash was empty — the write-up shipped, the commits did not.

This PR lands exactly those 5 files, based on current `main`.

- **`.github/dependabot.yml`** — add `commit-message: {prefix: chore, include: scope}` to both
  ecosystems. This is the only functional gap: dependabot's default titles are
  `Bump x from 1 to 2` (see #1, #2, #3), which fails `type-enum`. Once `Validate PR title`
  becomes a required check, those PRs would be permanently unmergeable.
- **`Makefile`** — `install-hooks` previously accepted any `commitlint` on `PATH`, silently
  skipping the pinned v0.12.0 install. It now verifies the resolved binary reports `0.12.0`
  and falls back to `$(go env GOPATH)/bin/commitlint` when `go install`'s output dir is not
  on `PATH`.
- **`.github/workflows/lint-pr-title.yml`** — the comment claimed "a PR title that passes here
  also passes `commitlint lint` locally". That is false in both directions and was verified
  against commitlint-go v0.12.0: the action enforces no length rule, while `.commitlint.yaml`
  sets `header-min-length: 10` / `header-max-length: 72` in **bytes**; and commitlint-go
  enables no scope rule, while the action's default `headerPattern` scope charset is
  ASCII-only. Replaced with the verified asymmetries.
- **`.commitlint.yaml`** — document that the length rules count bytes, not runes (72 bytes is
  roughly 22–24 characters of Japanese).
- **`CONTRIBUTING.md`** — restore the test-addition and `gofmt` guidance that #37 dropped as a
  side effect, and document the byte-based limits, the ` (#123)` squash suffix eating into the
  72-byte budget, the exact job name to mark required, and the `core.hooksPath` escape hatch.

No Go code changes; no runtime or user-visible behavior change.

## Verification

- `commitlint lint` on this commit's own message → `✔ commit message`
- `make install-hooks` smoke-tested in an isolated repo with the new target: hook installed,
  `bad msg` rejected (`Total 1 errors`), `chore: add a file here` accepted
- `commitlint --version` → `commitlint version v0.12.0`, so the new `grep '0\.12\.0'` check matches
- `.github/dependabot.yml` re-parsed with `yaml.safe_load`: valid, one `commit-message` block
  per ecosystem
- Asymmetry claims reproduced live: `fix: typo` (9 bytes) is rejected locally by
  `header-min-length` while the action enforces no length rule
- `go test ./...` clean on this branch; `make build` produces a working binary

## Remaining maintainer action (not fixable in-repo)

The `Protect main` ruleset requires `test (ubuntu-latest)`, `test (macos-latest)`, `lint`,
`vulncheck`, `review-policy` — **`Validate PR title` is not among them**, so the check reports
but does not block. Squash title is also still `COMMIT_OR_PR_TITLE`, not `PR_TITLE`. Live
evidence of that second gap: #33's title was `fix: statusLine notification deduplication`, yet
it landed on `main` as `Fix notification deduplication and configuration (#33)`.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
- [x] The PR title follows Conventional Commits
