### PR TITLE
chore: Release v0.5.5

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.4"
+version = "0.5.5"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
## Release v0.5.5

Bumps `herdr-plugin.toml` to `0.5.5`. Patch release: two user-facing bug fixes, no new
features and no breaking changes.

### Fixes

- **#38 — Codex windows were mislabelled `5h`, and Opus 5 had no context percentage.**
  OMP persists a `window_label` alongside each `limit_id`; `openai-codex:primary` is an
  ordinal, not a duration, so an account whose only window is 7 days rendered as `5h` with a
  reset 6+ days out, and the burn-rate projection was computed off the wrong window length.
  The observed label now drives both the rendered label and the reset math.
  `claude-opus-5` is also tracked as a 1M-context model — previously it resolved to no window
  at all, so the sidebar showed a bare token count with no percentage.
- **#36 — Claude profile `config_dir` matching was exact string equality.**
  Two common multi-account setups matched nothing and silently skipped the limits cache write:
  the default account (bare `claude` sets no `CLAUDE_CONFIG_DIR`), and any `config_dir`
  spelled with a leading `~`. A single `~` profile was worse than broken — it short-circuited
  and attributed every account to it, writing the cache under a directory literally named `~`
  in the process cwd. Paths are now normalized before comparison, an unset `CLAUDE_CONFIG_DIR`
  resolves to `~/.claude`, and a non-match refuses to write instead of misattributing.
  `usagebar setup` gained a claude-profiles report, and the unmatched-profile case now logs
  to stderr.

### Internal

- **#37 / #39** — Conventional Commits enforcement: a pinned local `commit-msg` hook via
  `make install-hooks` and a `Validate PR title` check on every PR. No runtime impact.

### Verification

Both fixes were reproduced against the pre-fix binary and confirmed on this code with real
on-disk data, not just unit tests:

- Codex label: a real `openai-codex:primary` + `7 days` row in `~/.omp/agent/agent.db`
  rendered `5h  82% left  6d 22h  (empty in ~3h 39m)` before and
  `7d  82% left  6d 22h  (empty in ~2d 6h)` after; confirmed live in a Herdr plugin pane.
- Opus 5: a real `claude-opus-5` transcript record (61,625 tokens) rendered `⛁ 62k` before and
  `⛁ 6% (62k)` after.
- Profile matching: all four scenarios from #35 reproduced against a v0.5.4 build in an
  isolated `HOME` (including the stray `~`-named directory) and confirmed fixed, with the
  zero-config default path verified unchanged.
- `go test ./...`, `go vet ./...`, `gofmt -l .`, `go run ./scripts/modeldrift` all clean.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
- [x] The PR title follows Conventional Commits
