### PR TITLE
chore: ignore the local Serena agent-tool directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 # .commitlint.yaml). The directory is created and managed by commitlint
 # itself; do not commit it.
 .commitlint/
+# Local state for the Serena coding-agent MCP server (project config plus
+# generated memories). It is per-developer tooling, not part of the plugin, and
+# an untracked copy makes `git status --porcelain` non-empty, which blocks
+# scripts/release.sh's clean-worktree check.
+.serena/


### PR DESCRIPTION
## Summary

Adds `.serena/` to `.gitignore`. The Serena coding-agent MCP server writes its project config
and generated memories there; it is per-developer tooling, not part of the plugin.

Two reasons this is worth a line in `.gitignore` rather than being left untracked:

1. **It blocks releases.** `scripts/release.sh` requires `git status --porcelain` to be empty.
   An untracked `.serena/` fails that check, so cutting a release requires moving the directory
   aside first (this happened while tagging v0.5.5).
2. **Consistency.** `.commitlint/` is already ignored on the same grounds — a tool-managed local
   directory that should not be committed.

Serena ships its own `.serena/.gitignore` covering `/cache` and `/project.local.yml`, which
implies it expects `project.yml` and `memories/` to be tracked. That is a reasonable convention
for a team sharing agent context, but this repository has never tracked them, and committing
agent-generated notes into the plugin's history is a separate decision. Ignoring the whole
directory keeps the current behavior and removes the friction; if you would rather share the
memories, revert this and commit `.serena/project.yml` plus `.serena/memories/` instead.

The directory itself is untouched on disk — this only stops git from reporting it.

## Verification

- `git status --porcelain` now reports only this `.gitignore` change; with it committed the
  worktree is empty, so `scripts/release.sh`'s clean-worktree check passes
- `git check-ignore -v .serena/memories/core.md` → `.gitignore:15:.serena/`
- `.serena/memories/` still present on disk (6 memory files, nothing deleted)

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
- [x] The PR title follows Conventional Commits
