### PR TITLE
fix(limits): prefer the fresher of claude.json and the statusLine cache

### DIFF
--- a/internal/limits/claudecache.go
+++ b/internal/limits/claudecache.go
@@ -143,8 +143,10 @@ func CollectClaudeLimits(nowMs int64, options CollectClaudeLimitsOptions) Provid
 	}
 
 	native := CollectClaudeLimitsFromJSON(nowMs, jsonPath)
-	if native == nil {
-		native = collectFromStatusLineCache(nowMs, statusPath)
+	if fromStatusLine := collectFromStatusLineCache(nowMs, statusPath); fromStatusLine != nil {
+		if native == nil || fromStatusLine.FetchedAtMs > native.FetchedAtMs {
+			native = fromStatusLine
+		}
 	}
 	// The windows belong to the account, so any agent's reading of them
 	// counts — including when Claude Code wrote nothing at all.

--- a/internal/limits/claudecache_test.go
+++ b/internal/limits/claudecache_test.go
@@ -52,7 +52,7 @@ func TestClaudeLimitsCache_WriteAndRead(t *testing.T) {
 	}
 }
 
-func TestClaudeLimitsCache_PrefersJSON(t *testing.T) {
+func TestClaudeLimitsCache_PrefersFresherStatusLine(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")
 	jsonPath := filepath.Join(dir, "claude.json")
@@ -75,6 +75,42 @@ func TestClaudeLimitsCache_PrefersJSON(t *testing.T) {
 			ResetsAt       int64
 		}{99, 2},
 	}, 5_000, cachePath)
+
+	limits := CollectClaudeLimits(6_000, CollectClaudeLimitsOptions{
+		StatusLineCachePath: cachePath,
+		ClaudeJSONPath:      jsonPath,
+	})
+	if limits.Primary == nil || limits.Primary.UsedPercentage != 99 {
+		t.Fatalf("%+v", limits.Primary)
+	}
+	if limits.Source != "claude statusLine cache" {
+		t.Fatalf("source=%q", limits.Source)
+	}
+}
+
+func TestClaudeLimitsCache_PrefersFresherJSON(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	jsonPath := filepath.Join(dir, "claude.json")
+	_ = os.WriteFile(jsonPath, []byte(`{
+		"cachedUsageUtilization": {
+			"fetchedAtMs": 5000,
+			"utilization": {
+				"five_hour": { "utilization": 1, "resets_at": "2026-07-15T00:00:00.000Z" },
+				"seven_day": { "utilization": 2, "resets_at": "2026-07-20T00:00:00.000Z" }
+			}
+		}
+	}`), 0o644)
+	_ = WriteClaudeLimitsCache(RateLimitsInput{
+		FiveHour: &struct {
+			UsedPercentage float64
+			ResetsAt       int64
+		}{99, 1},
+		SevenDay: &struct {
+			UsedPercentage float64
+			ResetsAt       int64
+		}{99, 2},
+	}, 1_000, cachePath)
 
 	limits := CollectClaudeLimits(6_000, CollectClaudeLimitsOptions{
 		StatusLineCachePath: cachePath,


### PR DESCRIPTION
Fixes #43.

`CollectClaudeLimits` consulted the statusLine cache only when `~/.claude.json` yielded nothing, so a present-but-stale `cachedUsageUtilization` permanently shadowed a fresh statusLine cache. Since Claude Code stopped refreshing that field (~2026-08-01), every install that ever populated it is frozen on its last snapshot.

This compares `fetchedAtMs` and lets the fresher source win — the behavior the function's doc comment already describes ("Provenance does not make a snapshot current — only its timestamp does"), and the same rule the `borrowWindows` path applies.

Tests: `TestClaudeLimitsCache_PrefersJSON` had the statusLine cache fresher in its fixture yet asserted json wins, codifying the bug; replaced it with a `PrefersFresherStatusLine` / `PrefersFresherJSON` pair. `go test ./...` passes.