### PR TITLE
fix(core): dedupe sidebar tokens against live pane state

### DIFF
--- a/internal/core/throttle.go
+++ b/internal/core/throttle.go
@@ -1,99 +1,15 @@
 /**
- * Persists the most recently reported sidebar metadata token values per pane
- * so unchanged settle/focus events do not spawn redundant Herdr CLI writes.
- *
- * Each value is stamped with the server generation it was reported to. Herdr
- * keeps metadata tokens in server memory, so a value accepted by an earlier
- * server no longer exists after a restart and must not suppress a re-report.
+ * Decides whether a sidebar metadata token needs a Herdr CLI write by
+ * comparing it against the pane's current server-side tokens, so unchanged
+ * settle/focus events do not spawn redundant writes.
  */
 package core
 
-import (
-	"os"
-	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
-)
-
-var unsafeTokenStateChars = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
-
-// serverEpochPrefix heads every state file; the rest of the first line is the
-// server generation the recorded value was reported to.
-const serverEpochPrefix = "#server:"
-
-// serverEpoch identifies the running server generation. The server recreates
-// its socket on startup, so the socket's mtime distinguishes restarts without
-// spawning a CLI call per token check. Unknown identity ("") still dedupes by
-// value alone, which is the pre-epoch behavior.
-func serverEpoch() string {
-	sock := os.Getenv("HERDR_SOCKET_PATH")
-	if sock == "" {
-		return ""
-	}
-	info, err := os.Stat(sock)
-	if err != nil {
-		return ""
-	}
-	return strconv.FormatInt(info.ModTime().UnixNano(), 10)
-}
-
-func tokenStateFilePath(paneID, tokenName string) (string, error) {
-	dir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
-	if dir == "" {
-		return "", os.ErrInvalid
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
-	}
-	safePane := unsafeTokenStateChars.ReplaceAllString(paneID, "_")
-	safeToken := unsafeTokenStateChars.ReplaceAllString(tokenName, "_")
-	return filepath.Join(dir, "last-token-"+safePane+"-"+safeToken+".txt"), nil
-}
-
-func readLastToken(paneID, tokenName string) (string, bool) {
-	path, err := tokenStateFilePath(paneID, tokenName)
-	if err != nil {
-		return "", false
-	}
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return "", false
-	}
-	// A value recorded against another server generation (or by a pre-epoch
-	// version of this file format) refers to tokens that no longer exist.
-	header, value, found := strings.Cut(string(b), "\n")
-	if !found || !strings.HasPrefix(header, serverEpochPrefix) {
-		return "", false
-	}
-	if strings.TrimPrefix(header, serverEpochPrefix) != serverEpoch() {
-		return "", false
-	}
-	return value, true
-}
-
-// ShouldWriteToken reports whether value differs from the last successful
-// write. Force always requests a write.
-func ShouldWriteToken(paneID, tokenName, value string, force bool) bool {
+// ShouldWriteToken reports whether value differs from the pane's current
+// server-side token (absent reads as ""). Force always requests a write.
+func ShouldWriteToken(current map[string]string, name, value string, force bool) bool {
 	if force {
 		return true
 	}
-	last, ok := readLastToken(paneID, tokenName)
-	return !ok || last != value
-}
-
-// MarkTokenWritten records a token value after Herdr accepts the metadata
-// report. An empty value records a successful clear.
-func MarkTokenWritten(paneID, tokenName, value string) {
-	path, err := tokenStateFilePath(paneID, tokenName)
-	if err != nil {
-		return
-	}
-	_ = os.WriteFile(path, []byte(serverEpochPrefix+serverEpoch()+"\n"+value), 0o644)
-	// v0.1.x stored a single custom-status value per pane. Metadata tokens use
-	// independent files, so remove the obsolete predecessor when this pane next
-	// reports successfully.
-	dir := filepath.Dir(path)
-	safePane := unsafeTokenStateChars.ReplaceAllString(paneID, "_")
-	_ = os.Remove(filepath.Join(dir, "last-status-"+safePane+".txt"))
+	return current[name] != value
 }

--- a/internal/core/throttle.go
+++ b/internal/core/throttle.go
@@ -1,6 +1,10 @@
 /**
  * Persists the most recently reported sidebar metadata token values per pane
  * so unchanged settle/focus events do not spawn redundant Herdr CLI writes.
+ *
+ * Each value is stamped with the server generation it was reported to. Herdr
+ * keeps metadata tokens in server memory, so a value accepted by an earlier
+ * server no longer exists after a restart and must not suppress a re-report.
  */
 package core
 
@@ -8,9 +12,31 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 )
 
 var unsafeTokenStateChars = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+// serverEpochPrefix heads every state file; the rest of the first line is the
+// server generation the recorded value was reported to.
+const serverEpochPrefix = "#server:"
+
+// serverEpoch identifies the running server generation. The server recreates
+// its socket on startup, so the socket's mtime distinguishes restarts without
+// spawning a CLI call per token check. Unknown identity ("") still dedupes by
+// value alone, which is the pre-epoch behavior.
+func serverEpoch() string {
+	sock := os.Getenv("HERDR_SOCKET_PATH")
+	if sock == "" {
+		return ""
+	}
+	info, err := os.Stat(sock)
+	if err != nil {
+		return ""
+	}
+	return strconv.FormatInt(info.ModTime().UnixNano(), 10)
+}
 
 func tokenStateFilePath(paneID, tokenName string) (string, error) {
 	dir := os.Getenv("HERDR_PLUGIN_STATE_DIR")
@@ -34,7 +60,16 @@ func readLastToken(paneID, tokenName string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	return string(b), true
+	// A value recorded against another server generation (or by a pre-epoch
+	// version of this file format) refers to tokens that no longer exist.
+	header, value, found := strings.Cut(string(b), "\n")
+	if !found || !strings.HasPrefix(header, serverEpochPrefix) {
+		return "", false
+	}
+	if strings.TrimPrefix(header, serverEpochPrefix) != serverEpoch() {
+		return "", false
+	}
+	return value, true
 }
 
 // ShouldWriteToken reports whether value differs from the last successful
@@ -54,7 +89,7 @@ func MarkTokenWritten(paneID, tokenName, value string) {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(path, []byte(value), 0o644)
+	_ = os.WriteFile(path, []byte(serverEpochPrefix+serverEpoch()+"\n"+value), 0o644)
 	// v0.1.x stored a single custom-status value per pane. Metadata tokens use
 	// independent files, so remove the obsolete predecessor when this pane next
 	// reports successfully.

--- a/internal/core/throttle_test.go
+++ b/internal/core/throttle_test.go
@@ -1,105 +1,44 @@
 /**
- * Tests for per-token content-based write deduplication.
+ * Tests for server-state-based write deduplication.
  */
 package core
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
-)
+import "testing"
 
 func TestShouldWriteToken(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
-
-	if !ShouldWriteToken("w1:p1", "context", "⛁ 10% (10k)", false) {
-		t.Fatal("first context write should be allowed")
+	current := map[string]string{"context": "⛁ 10% (10k)"}
+	if ShouldWriteToken(current, "context", "⛁ 10% (10k)", false) {
+		t.Fatal("matching server value should skip")
 	}
-	MarkTokenWritten("w1:p1", "context", "⛁ 10% (10k)")
-	if ShouldWriteToken("w1:p1", "context", "⛁ 10% (10k)", false) {
-		t.Fatal("identical context should skip")
+	if !ShouldWriteToken(current, "context", "⛁ 21% (21k)", false) {
+		t.Fatal("changed value should be allowed")
 	}
-	if !ShouldWriteToken("w1:p1", "context", "⛁ 21% (21k)", false) {
-		t.Fatal("changed context should be allowed")
-	}
-	if !ShouldWriteToken("w1:p1", "context", "⛁ 10% (10k)", true) {
+	if !ShouldWriteToken(current, "context", "⛁ 10% (10k)", true) {
 		t.Fatal("force should allow an identical value")
 	}
-}
-
-func TestShouldWriteToken_TracksNamesAndClearsIndependently(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
-
-	MarkTokenWritten("w1:p1", "context", "same")
-	if !ShouldWriteToken("w1:p1", "limit", "same", false) {
-		t.Fatal("different token names must not share state")
-	}
-
-	if !ShouldWriteToken("w1:p1", "limit", "", false) {
-		t.Fatal("first clear should be reported")
-	}
-	MarkTokenWritten("w1:p1", "limit", "")
-	if ShouldWriteToken("w1:p1", "limit", "", false) {
-		t.Fatal("repeated clear should skip")
-	}
-	if ShouldWriteToken("w1:p1", "context", "same", false) {
-		t.Fatal("limit clear must not disturb context state")
+	if !ShouldWriteToken(current, "context", "", false) {
+		t.Fatal("clearing a present token should be allowed")
 	}
 }
 
-func TestMarkTokenWritten_RemovesLegacyStatusFile(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", dir)
-	legacy := filepath.Join(dir, "last-status-w1_p1.txt")
-	if err := os.WriteFile(legacy, []byte("old"), 0o644); err != nil {
-		t.Fatal(err)
+func TestShouldWriteToken_AbsentKeyReadsAsEmpty(t *testing.T) {
+	current := map[string]string{"context": "same"}
+	if !ShouldWriteToken(current, "limit", "5h 72%", false) {
+		t.Fatal("value for an absent token must be written")
 	}
-
-	MarkTokenWritten("w1:p1", "context", "new")
-	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
-		t.Fatalf("legacy state still exists: %v", err)
+	if ShouldWriteToken(current, "limit", "", false) {
+		t.Fatal("clearing an absent token is a no-op")
 	}
 }
 
-func TestShouldWriteToken_ServerRestartInvalidatesState(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
-	sock := filepath.Join(t.TempDir(), "herdr.sock")
-	if err := os.WriteFile(sock, nil, 0o644); err != nil {
-		t.Fatal(err)
+func TestShouldWriteToken_NilMap(t *testing.T) {
+	if !ShouldWriteToken(nil, "provider", "claude", false) {
+		t.Fatal("nil map must not suppress a value write")
 	}
-	t.Setenv("HERDR_SOCKET_PATH", sock)
-
-	MarkTokenWritten("w1:p1", "provider", "claude")
-	if ShouldWriteToken("w1:p1", "provider", "claude", false) {
-		t.Fatal("identical value within one server generation should skip")
+	if ShouldWriteToken(nil, "provider", "", false) {
+		t.Fatal("clearing against a nil map is a no-op")
 	}
-
-	// A restarted server recreates its socket and wipes its in-memory
-	// tokens, so the unchanged value must be re-reported.
-	restarted := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sock, restarted, restarted); err != nil {
-		t.Fatal(err)
-	}
-	if !ShouldWriteToken("w1:p1", "provider", "claude", false) {
-		t.Fatal("state from a previous server generation must not suppress writes")
-	}
-}
-
-func TestShouldWriteToken_EpochlessLegacyStateIsStale(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", dir)
-	t.Setenv("HERDR_SOCKET_PATH", "")
-	legacy := filepath.Join(dir, "last-token-w1_p1-provider.txt")
-	if err := os.WriteFile(legacy, []byte("claude"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if !ShouldWriteToken("w1:p1", "provider", "claude", false) {
-		t.Fatal("pre-epoch state files must not suppress writes")
-	}
-	MarkTokenWritten("w1:p1", "provider", "claude")
-	if ShouldWriteToken("w1:p1", "provider", "claude", false) {
-		t.Fatal("rewritten state should dedupe again within the same generation")
+	if !ShouldWriteToken(nil, "provider", "", true) {
+		t.Fatal("force should write even a clear against a nil map")
 	}
 }

--- a/internal/core/throttle_test.go
+++ b/internal/core/throttle_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestShouldWriteToken(t *testing.T) {
@@ -58,5 +59,47 @@ func TestMarkTokenWritten_RemovesLegacyStatusFile(t *testing.T) {
 	MarkTokenWritten("w1:p1", "context", "new")
 	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
 		t.Fatalf("legacy state still exists: %v", err)
+	}
+}
+
+func TestShouldWriteToken_ServerRestartInvalidatesState(t *testing.T) {
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
+	sock := filepath.Join(t.TempDir(), "herdr.sock")
+	if err := os.WriteFile(sock, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_SOCKET_PATH", sock)
+
+	MarkTokenWritten("w1:p1", "provider", "claude")
+	if ShouldWriteToken("w1:p1", "provider", "claude", false) {
+		t.Fatal("identical value within one server generation should skip")
+	}
+
+	// A restarted server recreates its socket and wipes its in-memory
+	// tokens, so the unchanged value must be re-reported.
+	restarted := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(sock, restarted, restarted); err != nil {
+		t.Fatal(err)
+	}
+	if !ShouldWriteToken("w1:p1", "provider", "claude", false) {
+		t.Fatal("state from a previous server generation must not suppress writes")
+	}
+}
+
+func TestShouldWriteToken_EpochlessLegacyStateIsStale(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_STATE_DIR", dir)
+	t.Setenv("HERDR_SOCKET_PATH", "")
+	legacy := filepath.Join(dir, "last-token-w1_p1-provider.txt")
+	if err := os.WriteFile(legacy, []byte("claude"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !ShouldWriteToken("w1:p1", "provider", "claude", false) {
+		t.Fatal("pre-epoch state files must not suppress writes")
+	}
+	MarkTokenWritten("w1:p1", "provider", "claude")
+	if ShouldWriteToken("w1:p1", "provider", "claude", false) {
+		t.Fatal("rewritten state should dedupe again within the same generation")
 	}
 }

--- a/internal/herdrcli/herdr.go
+++ b/internal/herdrcli/herdr.go
@@ -52,6 +52,7 @@ type PaneInfo struct {
 	Label         *string // raw pane rename (unlike RowLabel, no agent/displayAgent fallback)
 	TabID         *string
 	WorkspaceID   *string
+	Tokens        map[string]string // current server-side metadata tokens; nil when none
 }
 
 // RawPaneListEntry is a pane list row from herdr (for pure buildOpenAgentPanes).
@@ -149,14 +150,15 @@ func GetPaneInfo(paneID string) PaneInfo {
 	var parsed struct {
 		Result *struct {
 			Pane *struct {
-				Agent         *string `json:"agent"`
-				AgentStatus   *string `json:"agent_status"`
-				Label         *string `json:"label"`
-				DisplayAgent  *string `json:"display_agent"`
-				Cwd           *string `json:"cwd"`
-				ForegroundCwd *string `json:"foreground_cwd"`
-				TabID         *string `json:"tab_id"`
-				WorkspaceID   *string `json:"workspace_id"`
+				Agent         *string           `json:"agent"`
+				AgentStatus   *string           `json:"agent_status"`
+				Label         *string           `json:"label"`
+				DisplayAgent  *string           `json:"display_agent"`
+				Cwd           *string           `json:"cwd"`
+				ForegroundCwd *string           `json:"foreground_cwd"`
+				TabID         *string           `json:"tab_id"`
+				WorkspaceID   *string           `json:"workspace_id"`
+				Tokens        map[string]string `json:"tokens"`
 				AgentSession  *struct {
 					Kind  *string `json:"kind"`
 					Value *string `json:"value"`
@@ -188,6 +190,7 @@ func GetPaneInfo(paneID string) PaneInfo {
 		Label:         p.Label,
 		TabID:         p.TabID,
 		WorkspaceID:   p.WorkspaceID,
+		Tokens:        p.Tokens,
 	}
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -149,22 +149,18 @@ var herdrMetadataTokenWriter = metadataTokenWriter{
 	clear: herdrcli.ClearMetadataToken,
 }
 
-func writeMetadataToken(paneID, name, value string, force bool) {
-	writeMetadataTokenWith(herdrMetadataTokenWriter, paneID, name, value, force)
+func writeMetadataToken(current map[string]string, paneID, name, value string, force bool) {
+	writeMetadataTokenWith(herdrMetadataTokenWriter, current, paneID, name, value, force)
 }
 
-func writeMetadataTokenWith(writer metadataTokenWriter, paneID, name, value string, force bool) {
-	if !core.ShouldWriteToken(paneID, name, value, force) {
+func writeMetadataTokenWith(writer metadataTokenWriter, current map[string]string, paneID, name, value string, force bool) {
+	if !core.ShouldWriteToken(current, name, value, force) {
 		return
 	}
-	ok := false
 	if value == "" {
-		ok = writer.clear(paneID, herdrcli.Source, name)
+		writer.clear(paneID, herdrcli.Source, name)
 	} else {
-		ok = writer.set(paneID, herdrcli.Source, name, value)
-	}
-	if ok {
-		core.MarkTokenWritten(paneID, name, value)
+		writer.set(paneID, herdrcli.Source, name, value)
 	}
 }
 
@@ -196,7 +192,7 @@ func RunUpdate(force bool) {
 	// name so the row is never empty.
 	naming := herdrcli.GetPaneNaming(pane)
 	title := core.ResolveSidebarTitle(naming.PaneLabel, naming.TabLabel, naming.TabNumber, naming.WorkspaceLabel)
-	writeMetadataToken(paneID, "title", title, force)
+	writeMetadataToken(pane.Tokens, paneID, "title", title, force)
 
 	cwd := paneCwdForUpdate(pane)
 	nowMs := time.Now().UnixMilli()
@@ -219,9 +215,9 @@ func RunUpdate(force bool) {
 	if !resolved {
 		// Cannot tell which account this pane belongs to: clear rather than
 		// guess into the wrong account's limits/tokens.
-		writeMetadataToken(paneID, "limit", "", force)
-		writeMetadataToken(paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
-		writeMetadataToken(paneID, "context", "", force)
+		writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
+		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+		writeMetadataToken(pane.Tokens, paneID, "context", "", force)
 		return
 	}
 
@@ -264,11 +260,11 @@ func RunUpdate(force bool) {
 			limitToken = accountText
 		}
 	}
-	writeMetadataToken(paneID, "limit", limitToken, force)
+	writeMetadataToken(pane.Tokens, paneID, "limit", limitToken, force)
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
-	writeMetadataToken(paneID, "provider", providerText, force)
+	writeMetadataToken(pane.Tokens, paneID, "provider", providerText, force)
 
 	// Context tokens: claude is read from its resolved profile's own transcript
 	// root (bypassing the registry's default-root lookup) so a non-default
@@ -294,7 +290,7 @@ func RunUpdate(force bool) {
 	}
 
 	if usage == nil {
-		writeMetadataToken(paneID, "context", contextPrefix, force)
+		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
 		return
 	}
 
@@ -303,5 +299,5 @@ func RunUpdate(force bool) {
 	maxCols := core.EstimateStatusMaxColumns(&sidebarW, pane.RowLabel)
 	maxCols = reserveColumnsFor(maxCols, contextPrefix)
 	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{MaxColumns: maxCols})
-	writeMetadataToken(paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
+	writeMetadataToken(pane.Tokens, paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -42,8 +42,7 @@ func TestPaneCwdForUpdate_OtherAgentsPreferForegroundCwd(t *testing.T) {
 	}
 }
 
-func TestWriteMetadataTokenWith_SetSuccessDeduplicates(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
+func TestWriteMetadataTokenWith_SkipsWhenServerCurrent(t *testing.T) {
 	setCalls := 0
 	clearCalls := 0
 	writer := metadataTokenWriter{
@@ -57,15 +56,34 @@ func TestWriteMetadataTokenWith_SetSuccessDeduplicates(t *testing.T) {
 		},
 	}
 
-	writeMetadataTokenWith(writer, "w1:p1", "limit", "5h 72%", false)
-	writeMetadataTokenWith(writer, "w1:p1", "limit", "5h 72%", false)
+	current := map[string]string{"limit": "5h 72%"}
+	writeMetadataTokenWith(writer, current, "w1:p1", "limit", "5h 72%", false)
+	if setCalls != 0 || clearCalls != 0 {
+		t.Fatalf("set=%d clear=%d", setCalls, clearCalls)
+	}
+	writeMetadataTokenWith(writer, current, "w1:p1", "limit", "5h 60%", false)
 	if setCalls != 1 || clearCalls != 0 {
 		t.Fatalf("set=%d clear=%d", setCalls, clearCalls)
 	}
 }
 
-func TestWriteMetadataTokenWith_ClearSuccessDeduplicates(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
+func TestWriteMetadataTokenWith_WritesWhenServerLacksToken(t *testing.T) {
+	setCalls := 0
+	writer := metadataTokenWriter{
+		set: func(_, _, _, _ string) bool {
+			setCalls++
+			return true
+		},
+		clear: func(_, _, _ string) bool { return true },
+	}
+
+	writeMetadataTokenWith(writer, nil, "w1:p1", "provider", "claude", false)
+	if setCalls != 1 {
+		t.Fatalf("set=%d", setCalls)
+	}
+}
+
+func TestWriteMetadataTokenWith_ClearOfAbsentTokenIsNoOp(t *testing.T) {
 	setCalls := 0
 	clearCalls := 0
 	writer := metadataTokenWriter{
@@ -79,28 +97,13 @@ func TestWriteMetadataTokenWith_ClearSuccessDeduplicates(t *testing.T) {
 		},
 	}
 
-	writeMetadataTokenWith(writer, "w1:p1", "context", "", false)
-	writeMetadataTokenWith(writer, "w1:p1", "context", "", false)
-	if setCalls != 0 || clearCalls != 1 {
+	writeMetadataTokenWith(writer, nil, "w1:p1", "context", "", false)
+	if setCalls != 0 || clearCalls != 0 {
 		t.Fatalf("set=%d clear=%d", setCalls, clearCalls)
 	}
-}
-
-func TestWriteMetadataTokenWith_FailureRetries(t *testing.T) {
-	t.Setenv("HERDR_PLUGIN_STATE_DIR", t.TempDir())
-	setCalls := 0
-	writer := metadataTokenWriter{
-		set: func(_, _, _, _ string) bool {
-			setCalls++
-			return false
-		},
-		clear: func(_, _, _ string) bool { return false },
-	}
-
-	writeMetadataTokenWith(writer, "w1:p1", "limit", "7d 42%", false)
-	writeMetadataTokenWith(writer, "w1:p1", "limit", "7d 42%", false)
-	if setCalls != 2 {
-		t.Fatalf("set=%d want 2 retries", setCalls)
+	writeMetadataTokenWith(writer, map[string]string{"context": "old"}, "w1:p1", "context", "", false)
+	if setCalls != 0 || clearCalls != 1 {
+		t.Fatalf("set=%d clear=%d", setCalls, clearCalls)
 	}
 }
 


### PR DESCRIPTION
Fixes #44.

Herdr keeps metadata tokens in server memory, but the plugin's write-dedup state survived on disk. After a server restart, `RunUpdate` recomputed the same value, `ShouldWriteToken` saw it matched the recorded one, and skipped the write — so wiped rows (agent name, title) stayed blank until a forced refresh.

**Approach** (as suggested in review): dedupe against the pane's current server-side tokens instead of a persisted mirror. `RunUpdate` already calls `pane get`, whose response includes the pane's `tokens`; diffing the value-to-write against `tokens[name]` (absent key reads as `""`, matching the empty-value convention) reproduces the dedup with no state directory at all. The server's own state is the reference, so anything it lost — restart, expiry — reads as absent and is re-reported on the next event. Also drops one redundant clear of never-set tokens.

Verified on 0.8.0: `pane get` reports all four token names when set, absent when not; live-tested including restore-after-wipe within the same server session.

**Tests:** `ShouldWriteToken` is now a pure function covered for nil map, absent key, empty value, match, mismatch, and force; `writeMetadataTokenWith` tests cover skip-when-current, write-when-server-lacks-token, and clear-of-absent-is-no-op. `go test ./...` passes.
