### PR TITLE
chore: Release v0.5.6

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.5"
+version = "0.5.6"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
Bumps `herdr-plugin.toml` version for the next release.

## Included since v0.5.5
- fix(core): dedupe sidebar tokens against live pane state (#46)
- fix(limits): prefer the fresher of claude.json and the statusLine cache (#45)
- chore(deps): bump modernc.org/sqlite from 1.54.0 to 1.55.0 (#42)
- chore: ignore the local Serena agent-tool directory (#41)

Patch bump — no `feat` commits since v0.5.5.