### PR TITLE
fix(grok): recover stale session binds and color context tiers

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -72,6 +72,82 @@ func formatTokenCount(tokens int) string {
 	return fmt.Sprintf("%.0fk", thousands)
 }
 
+// FormatTokenCount formats a token count for compact sidebar display ("94k", "5.0k").
+func FormatTokenCount(tokens int) string {
+	return formatTokenCount(tokens)
+}
+
+// Absolute context-size thresholds for sidebar coloring (Herdr styles each
+// tier token with a fixed fg in config; only one tier is non-empty at a time).
+const (
+	ContextSoftTokens     = 100_000 // light yellow
+	ContextWarnTokens     = 150_000 // deep yellow
+	ContextCriticalTokens = 180_000 // red
+)
+
+// Context tier metadata token names written to the sidebar.
+const (
+	ContextTokenOK       = "ctx"    // < 100k (default muted style)
+	ContextTokenSoft     = "ctx_y"  // ≥ 100k
+	ContextTokenWarn     = "ctx_yy" // ≥ 150k
+	ContextTokenCritical = "ctx_r"  // ≥ 180k
+)
+
+// AllContextTierTokenNames is the exclusive set of context-count tokens.
+var AllContextTierTokenNames = []string{
+	ContextTokenOK,
+	ContextTokenSoft,
+	ContextTokenWarn,
+	ContextTokenCritical,
+}
+
+// ContextTierTokenName picks which exclusive sidebar token should carry the
+// compact context count for the given absolute token total. Empty when there
+// is nothing to show.
+func ContextTierTokenName(contextTokens int) string {
+	if contextTokens <= 0 {
+		return ""
+	}
+	switch {
+	case contextTokens >= ContextCriticalTokens:
+		return ContextTokenCritical
+	case contextTokens >= ContextWarnTokens:
+		return ContextTokenWarn
+	case contextTokens >= ContextSoftTokens:
+		return ContextTokenSoft
+	default:
+		return ContextTokenOK
+	}
+}
+
+// FormatCompactContextTokens is the shortest useful context meter: disk icon
+// plus absolute token count (no window %). Herdr joins adjacent sidebar
+// tokens with a space, so no leading padding is needed ("7d 77% ⛁ 94k").
+func FormatCompactContextTokens(usage ContextUsage) string {
+	if usage.ContextTokens <= 0 {
+		return ""
+	}
+	return "⛁ " + formatTokenCount(usage.ContextTokens)
+}
+
+// ContextTierTokenValues returns the exclusive tier map for compact context
+// display. Exactly one key is non-empty when usage is present; all empty when
+// there are no context tokens. Callers write every key so stale tiers clear.
+func ContextTierTokenValues(usage ContextUsage) map[string]string {
+	out := map[string]string{
+		ContextTokenOK:       "",
+		ContextTokenSoft:     "",
+		ContextTokenWarn:     "",
+		ContextTokenCritical: "",
+	}
+	name := ContextTierTokenName(usage.ContextTokens)
+	if name == "" {
+		return out
+	}
+	out[name] = FormatCompactContextTokens(usage)
+	return out
+}
+
 // UsageStatusCandidates returns candidates in priority order (longest -> shortest).
 // The first element is the full representation.
 func UsageStatusCandidates(usage ContextUsage) []string {

--- a/internal/core/format_test.go
+++ b/internal/core/format_test.go
@@ -140,6 +140,55 @@ func TestFormatUsageStatus_Below1000NoK(t *testing.T) {
 	}
 }
 
+func TestFormatCompactContextTokens(t *testing.T) {
+	if got := FormatCompactContextTokens(usage(94_000, intPtr(200_000))); got != "⛁ 94k" {
+		t.Fatalf("got %q want ⛁ 94k", got)
+	}
+	if got := FormatCompactContextTokens(usage(5_000, nil)); got != "⛁ 5.0k" {
+		t.Fatalf("got %q want ⛁ 5.0k", got)
+	}
+	if got := FormatCompactContextTokens(usage(0, intPtr(200_000))); got != "" {
+		t.Fatalf("got %q want empty", got)
+	}
+}
+
+func TestContextTierTokenName(t *testing.T) {
+	cases := []struct {
+		tokens int
+		want   string
+	}{
+		{0, ""},
+		{99_999, ContextTokenOK},
+		{100_000, ContextTokenSoft},
+		{149_999, ContextTokenSoft},
+		{150_000, ContextTokenWarn},
+		{179_999, ContextTokenWarn},
+		{180_000, ContextTokenCritical},
+		{250_000, ContextTokenCritical},
+	}
+	for _, tc := range cases {
+		if got := ContextTierTokenName(tc.tokens); got != tc.want {
+			t.Fatalf("ContextTierTokenName(%d)=%q want %q", tc.tokens, got, tc.want)
+		}
+	}
+}
+
+func TestContextTierTokenValues_Exclusive(t *testing.T) {
+	got := ContextTierTokenValues(usage(185_000, nil))
+	if got[ContextTokenCritical] != "⛁ 185k" {
+		t.Fatalf("crit=%q", got[ContextTokenCritical])
+	}
+	if got[ContextTokenOK] != "" || got[ContextTokenSoft] != "" || got[ContextTokenWarn] != "" {
+		t.Fatalf("non-exclusive: %#v", got)
+	}
+	empty := ContextTierTokenValues(usage(0, nil))
+	for _, name := range AllContextTierTokenNames {
+		if empty[name] != "" {
+			t.Fatalf("%s should be empty", name)
+		}
+	}
+}
+
 func TestFormatUsageStatus_Exactly1000OneDecimal(t *testing.T) {
 	got := FormatUsageStatus(usage(1000, intPtr(1_000_000)), FormatUsageOptions{})
 	if got != "⛁ 0% (1.0k)" {

--- a/internal/providers/grok/findsession.go
+++ b/internal/providers/grok/findsession.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/pathutil"
@@ -61,7 +60,10 @@ func readActiveSessions() []activeSessionEntry {
 	return parsed
 }
 
-// FindActiveSessionID returns the most recent session_id whose cwd matches.
+// FindActiveSessionID returns a session_id for cwd only when the match is
+// unambiguous. Multiple concurrent Grok panes often share the same cwd
+// (especially $HOME); picking the "most recently opened" would pin every
+// unbound pane to one sibling's context meter.
 func FindActiveSessionID(cwd *string) string {
 	if cwd == nil || *cwd == "" {
 		return ""
@@ -82,56 +84,113 @@ func FindActiveSessionID(cwd *string) string {
 	if len(pick) == 0 {
 		pick = weak
 	}
-	if len(pick) == 0 {
+	if len(pick) != 1 {
+		// 0 → nothing; 2+ → ambiguous (do not guess).
 		return ""
 	}
-	sort.Slice(pick, func(i, j int) bool {
-		return pick[i].OpenedAt > pick[j].OpenedAt
-	})
 	return pick[0].SessionID
 }
 
-func newestSessionInGroup(groupDir string) (sessionID string, mtimeMs int64) {
+// isActiveSessionID reports whether sessionID appears in active_sessions.json.
+// Herdr only binds agent_session at session_start; after resume/switch the
+// bound id goes stale while active_sessions stays current.
+func isActiveSessionID(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	for _, entry := range readActiveSessions() {
+		if entry.SessionID == sessionID {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionDirForID resolves a session directory, preferring the pane cwd group.
+func sessionDirForID(sessionID string, cwd *string) string {
+	if sessionID == "" {
+		return ""
+	}
+	if cwd != nil && *cwd != "" {
+		direct := filepath.Join(sessionsRoot(), encodeCwd(*cwd), sessionID)
+		if st, err := os.Stat(direct); err == nil && st.IsDir() {
+			return direct
+		}
+	}
+	return FindSessionDirBySessionID(sessionID)
+}
+
+// sessionsInGroup returns every session id under groupDir that has usable
+// context files (signals.json and/or updates.jsonl), plus the newest id/mtime
+// for callers that still need a single-session pick.
+func sessionsInGroup(groupDir string) (ids []string, newestID string, newestMT int64) {
 	names, err := os.ReadDir(groupDir)
 	if err != nil {
-		return "", 0
+		return nil, "", 0
 	}
 	for _, name := range names {
 		if !name.IsDir() {
 			continue
 		}
-		signalsPath := filepath.Join(groupDir, name.Name(), "signals.json")
-		st, err := os.Stat(signalsPath)
-		if err != nil || !st.Mode().IsRegular() {
+		dir := filepath.Join(groupDir, name.Name())
+		if !sessionDirHasUsageFiles(dir) {
 			continue
 		}
-		mt := st.ModTime().UnixMilli()
-		if sessionID == "" || mt > mtimeMs {
-			sessionID = name.Name()
-			mtimeMs = mt
+		id := name.Name()
+		ids = append(ids, id)
+		// Prefer the newest usage file mtime within the session.
+		mt := int64(0)
+		for _, fname := range []string{"signals.json", "updates.jsonl"} {
+			if st, err := os.Stat(filepath.Join(dir, fname)); err == nil {
+				if t := st.ModTime().UnixMilli(); t > mt {
+					mt = t
+				}
+			}
+		}
+		if newestID == "" || mt > newestMT {
+			newestID = id
+			newestMT = mt
 		}
 	}
+	return ids, newestID, newestMT
+}
+
+func newestSessionInGroup(groupDir string) (sessionID string, mtimeMs int64) {
+	_, sessionID, mtimeMs = sessionsInGroup(groupDir)
 	return sessionID, mtimeMs
 }
 
-// FindLatestSessionIDUnderCwd returns the session_id under the matching cwd
-// group with the newest signals.json mtime.
+// uniqueSessionInGroup returns the sole session under groupDir, or "" when
+// zero/multiple sessions exist. Multi-session groups are common under $HOME;
+// "newest by mtime" there steals another pane's meter (e.g. a busy coding
+// agent at 146k while a fresh brew-scan pane is only 23k).
+func uniqueSessionInGroup(groupDir string) string {
+	ids, _, _ := sessionsInGroup(groupDir)
+	if len(ids) != 1 {
+		return ""
+	}
+	return ids[0]
+}
+
+// FindLatestSessionIDUnderCwd returns a session only when the cwd group has
+// exactly one session with signals.json. Previously it returned the newest
+// by mtime, which mis-attributed context across panes sharing a cwd.
 func FindLatestSessionIDUnderCwd(cwd *string) string {
 	if cwd == nil || *cwd == "" {
 		return ""
 	}
 	// Fast path: encoded pane cwd directory.
-	if id, _ := newestSessionInGroup(filepath.Join(sessionsRoot(), encodeCwd(*cwd))); id != "" {
+	if id := uniqueSessionInGroup(filepath.Join(sessionsRoot(), encodeCwd(*cwd))); id != "" {
 		return id
 	}
 	// Scan all groups: decode folder names and match with pathutil.
+	// Only accept a unique session within an exact (then weak) match group.
 	root := sessionsRoot()
 	groups, err := os.ReadDir(root)
 	if err != nil {
 		return ""
 	}
-	var bestExactID, bestWeakID string
-	var bestExactMT, bestWeakMT int64
+	var exactIDs, weakIDs []string
 	for _, group := range groups {
 		if !group.IsDir() {
 			continue
@@ -140,26 +199,26 @@ func FindLatestSessionIDUnderCwd(cwd *string) string {
 		if err != nil || decoded == "" {
 			continue
 		}
-		id, mt := newestSessionInGroup(filepath.Join(root, group.Name()))
+		id := uniqueSessionInGroup(filepath.Join(root, group.Name()))
 		if id == "" {
+			// Group has 0 or 2+ sessions — never invent a pick from mtime.
 			continue
 		}
 		if pathutil.Equal(decoded, *cwd) {
-			if bestExactID == "" || mt > bestExactMT {
-				bestExactID, bestExactMT = id, mt
-			}
+			exactIDs = append(exactIDs, id)
 			continue
 		}
 		if pathutil.SameProject(decoded, *cwd) {
-			if bestWeakID == "" || mt > bestWeakMT {
-				bestWeakID, bestWeakMT = id, mt
-			}
+			weakIDs = append(weakIDs, id)
 		}
 	}
-	if bestExactID != "" {
-		return bestExactID
+	if len(exactIDs) == 1 {
+		return exactIDs[0]
 	}
-	return bestWeakID
+	if len(exactIDs) == 0 && len(weakIDs) == 1 {
+		return weakIDs[0]
+	}
+	return ""
 }
 
 // resolveGroupDirForCwd returns the sessions/<encoded-cwd> directory for pane cwd.
@@ -203,8 +262,9 @@ func resolveGroupDirForCwd(cwd string) string {
 	return weakDir
 }
 
-// FindSignalsPathBySessionID searches every cwd group for a session_id match.
-func FindSignalsPathBySessionID(sessionID string) string {
+// FindSessionDirBySessionID searches every cwd group for a session directory.
+// The dir may lack signals.json (some live sessions only stream updates.jsonl).
+func FindSessionDirBySessionID(sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
@@ -214,54 +274,100 @@ func FindSignalsPathBySessionID(sessionID string) string {
 		return ""
 	}
 	for _, group := range groups {
-		candidate := filepath.Join(root, group.Name(), sessionID, "signals.json")
-		if st, err := os.Stat(candidate); err == nil && st.Mode().IsRegular() {
+		if !group.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, group.Name(), sessionID)
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
 			return candidate
 		}
 	}
 	return ""
 }
 
-// ResolveSignalsPath resolves the signals.json path from session id and/or cwd.
-func ResolveSignalsPath(sessionID, cwd *string) string {
-	if sessionID != nil && *sessionID != "" {
-		if cwd != nil && *cwd != "" {
-			direct := filepath.Join(sessionsRoot(), encodeCwd(*cwd), *sessionID, "signals.json")
-			if st, err := os.Stat(direct); err == nil && st.Mode().IsRegular() {
-				return direct
-			}
-			// Cwd may have been renamed; still try the session id under any group.
-		}
-		if path := FindSignalsPathBySessionID(*sessionID); path != "" {
-			return path
+// FindSignalsPathBySessionID searches every cwd group for a session_id match.
+func FindSignalsPathBySessionID(sessionID string) string {
+	dir := FindSessionDirBySessionID(sessionID)
+	if dir == "" {
+		return ""
+	}
+	candidate := filepath.Join(dir, "signals.json")
+	if st, err := os.Stat(candidate); err == nil && st.Mode().IsRegular() {
+		return candidate
+	}
+	return ""
+}
+
+// sessionDirHasUsageFiles reports whether the dir can yield a context meter
+// (signals and/or updates). Empty dirs must not win unique-session fallbacks.
+func sessionDirHasUsageFiles(dir string) bool {
+	for _, name := range []string{"signals.json", "updates.jsonl"} {
+		if st, err := os.Stat(filepath.Join(dir, name)); err == nil && st.Mode().IsRegular() && st.Size() > 0 {
+			return true
 		}
 	}
+	return false
+}
 
-	activeID := FindActiveSessionID(cwd)
-	if activeID != "" {
-		if path := FindSignalsPathBySessionID(activeID); path != "" {
-			return path
+// ResolveSessionDir resolves the on-disk session directory for a pane.
+//
+// Priority:
+//  1. Explicit session id (Herdr agent_session):
+//     - If still listed in active_sessions.json → use bound (multi-pane same
+//     cwd must not steal each other's meter).
+//     - If stale (absent from active_sessions) and FindActiveSessionID(cwd)
+//     yields a unique active id different from bound → recover to that dir.
+//     - Otherwise stick with bound (prefer stale/empty over guessing sibling).
+//  2. Without a bound id: only when the cwd group has exactly one session with
+//     usage files. We deliberately do NOT trust active_sessions alone here —
+//     Grok often records a single $HOME entry while many panes share that cwd,
+//     and using it pins every unbound pane to the wrong meter.
+func ResolveSessionDir(sessionID, cwd *string) string {
+	if sessionID != nil && *sessionID != "" {
+		// Stale bind recovery: Grok herdr hook only reports session id at
+		// session_start; after resume/switch, active_sessions is authoritative
+		// when the cwd match is unique.
+		if !isActiveSessionID(*sessionID) {
+			if active := FindActiveSessionID(cwd); active != "" && active != *sessionID {
+				if dir := sessionDirForID(active, cwd); dir != "" {
+					return dir
+				}
+			}
 		}
+		return sessionDirForID(*sessionID, cwd)
 	}
 
 	if cwd == nil || *cwd == "" {
 		return ""
 	}
-	latestID := FindLatestSessionIDUnderCwd(cwd)
-	if latestID == "" {
+	uniqueID := FindLatestSessionIDUnderCwd(cwd)
+	if uniqueID == "" {
 		return ""
 	}
-	// Prefer group dir resolved via path matching (handles rename / encode drift).
 	if group := resolveGroupDirForCwd(*cwd); group != "" {
-		path := filepath.Join(group, latestID, "signals.json")
-		if st, err := os.Stat(path); err == nil && st.Mode().IsRegular() {
-			return path
+		dir := filepath.Join(group, uniqueID)
+		if st, err := os.Stat(dir); err == nil && st.IsDir() && sessionDirHasUsageFiles(dir) {
+			return dir
 		}
 	}
-	path := filepath.Join(sessionsRoot(), encodeCwd(*cwd), latestID, "signals.json")
+	dir := filepath.Join(sessionsRoot(), encodeCwd(*cwd), uniqueID)
+	if st, err := os.Stat(dir); err == nil && st.IsDir() && sessionDirHasUsageFiles(dir) {
+		return dir
+	}
+	return FindSessionDirBySessionID(uniqueID)
+}
+
+// ResolveSignalsPath resolves the signals.json path from session id and/or cwd.
+// Kept for tests/callers that only care about signals; live resolution uses
+// ResolveSessionDir + UsageFromSessionDir so updates.jsonl can fill gaps.
+func ResolveSignalsPath(sessionID, cwd *string) string {
+	dir := ResolveSessionDir(sessionID, cwd)
+	if dir == "" {
+		return ""
+	}
+	path := filepath.Join(dir, "signals.json")
 	if st, err := os.Stat(path); err == nil && st.Mode().IsRegular() {
 		return path
 	}
-	// Last resort: id alone anywhere under sessions.
-	return FindSignalsPathBySessionID(latestID)
+	return ""
 }

--- a/internal/providers/grok/findsession_test.go
+++ b/internal/providers/grok/findsession_test.go
@@ -37,19 +37,34 @@ func writeSession(t *testing.T, home, sessionID string, signals map[string]any, 
 	return path
 }
 
-func TestFindActiveSessionID(t *testing.T) {
+func TestFindActiveSessionID_UniqueOnly(t *testing.T) {
 	home := withTempGrokHome(t)
 	b, _ := json.Marshal([]map[string]any{
-		{"session_id": "old-id", "cwd": testCwd, "opened_at": "2026-07-14T10:00:00Z"},
-		{"session_id": "new-id", "cwd": testCwd, "opened_at": "2026-07-15T10:00:00Z"},
+		{"session_id": "only-id", "cwd": testCwd, "opened_at": "2026-07-15T10:00:00Z"},
 		{"session_id": "other", "cwd": "/other", "opened_at": "2026-07-15T12:00:00Z"},
 	})
 	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cwd := testCwd
-	if got := FindActiveSessionID(&cwd); got != "new-id" {
+	if got := FindActiveSessionID(&cwd); got != "only-id" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindActiveSessionID_AmbiguousSameCwd(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Two panes under $HOME / same project: never pick "most recent".
+	b, _ := json.Marshal([]map[string]any{
+		{"session_id": "old-id", "cwd": testCwd, "opened_at": "2026-07-14T10:00:00Z"},
+		{"session_id": "new-id", "cwd": testCwd, "opened_at": "2026-07-15T10:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	if got := FindActiveSessionID(&cwd); got != "" {
+		t.Fatalf("ambiguous active sessions must not guess, got %q", got)
 	}
 }
 
@@ -64,13 +79,23 @@ func TestFindActiveSessionID_NoMatch(t *testing.T) {
 	}
 }
 
-func TestFindLatestSessionIDUnderCwd(t *testing.T) {
+func TestFindLatestSessionIDUnderCwd_UniqueOnly(t *testing.T) {
 	home := withTempGrokHome(t)
-	writeSession(t, home, "a", map[string]any{"contextTokensUsed": 1}, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
-	writeSession(t, home, "b", map[string]any{"contextTokensUsed": 2}, time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
+	writeSession(t, home, "only", map[string]any{"contextTokensUsed": 1}, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
 	cwd := testCwd
-	if got := FindLatestSessionIDUnderCwd(&cwd); got != "b" {
+	if got := FindLatestSessionIDUnderCwd(&cwd); got != "only" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindLatestSessionIDUnderCwd_AmbiguousSkipsNewest(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Newer busy sibling must not be chosen when the group has multiple sessions.
+	writeSession(t, home, "a", map[string]any{"contextTokensUsed": 23_000}, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+	writeSession(t, home, "b", map[string]any{"contextTokensUsed": 146_000}, time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
+	cwd := testCwd
+	if got := FindLatestSessionIDUnderCwd(&cwd); got != "" {
+		t.Fatalf("multi-session cwd must not pick newest, got %q", got)
 	}
 }
 
@@ -84,11 +109,14 @@ func TestResolveSignalsPath_Direct(t *testing.T) {
 	}
 }
 
-func TestResolveSignalsPath_ViaActive(t *testing.T) {
+func TestResolveSignalsPath_ViaUniqueOnDisk(t *testing.T) {
 	home := withTempGrokHome(t)
-	path := writeSession(t, home, "active-sid", map[string]any{"contextTokensUsed": 50}, time.Now())
+	// Without agent_session, only a unique on-disk session is trusted.
+	// active_sessions alone is not enough (incomplete under multi-pane $HOME).
+	path := writeSession(t, home, "only-sid", map[string]any{"contextTokensUsed": 50}, time.Now())
 	b, _ := json.Marshal([]map[string]any{
-		{"session_id": "active-sid", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+		{"session_id": "only-sid", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+		// A second active entry would previously have blocked; on-disk is still unique.
 	})
 	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
 		t.Fatal(err)
@@ -96,6 +124,23 @@ func TestResolveSignalsPath_ViaActive(t *testing.T) {
 	cwd := testCwd
 	if got := ResolveSignalsPath(nil, &cwd); got != path {
 		t.Fatalf("got %q want %q", got, path)
+	}
+}
+
+func TestResolveSessionDir_ActiveAloneNotEnoughWhenDiskMulti(t *testing.T) {
+	home := withTempGrokHome(t)
+	writeSession(t, home, "a", map[string]any{"contextTokensUsed": 10}, time.Now())
+	writeSession(t, home, "b", map[string]any{"contextTokensUsed": 200_000}, time.Now())
+	b, _ := json.Marshal([]map[string]any{
+		// Only one active — historically wrong for multi-pane same cwd.
+		{"session_id": "b", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	if got := ResolveSessionDir(nil, &cwd); got != "" {
+		t.Fatalf("must not use sole active when disk has multiple sessions, got %q", got)
 	}
 }
 
@@ -116,6 +161,8 @@ func TestFindActiveSessionID_TrailingSlash(t *testing.T) {
 func TestResolveSignalsPath_BasenameAfterRename(t *testing.T) {
 	home := withTempGrokHome(t)
 	// Sessions stored under old cwd leaf; pane reports renamed parent path.
+	// With a bound session id this still resolves; without id, basename weak
+	// match only works when the group is unique (single session).
 	oldCwd := "/Users/example/workspace/my-app"
 	newCwd := "/Users/example/archive/my-app"
 	dir := filepath.Join(home, "sessions", encodeCwd(oldCwd), "sess-1")
@@ -126,13 +173,149 @@ func TestResolveSignalsPath_BasenameAfterRename(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"contextTokensUsed":10,"contextWindowTokens":100}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	sid := "sess-1"
+	if got := ResolveSignalsPath(&sid, &newCwd); got != path {
+		t.Fatalf("bound id: got %q want %q", got, path)
+	}
+	// Unbound: unique session under same-project group still resolves.
+	if got := ResolveSignalsPath(nil, &newCwd); got != path {
+		t.Fatalf("unique weak cwd: got %q want %q", got, path)
+	}
+}
+
+func TestResolveSessionDir_StaleBindRecoversToUniqueActive(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Herdr still holds the session_start id (48k); real active session is 216k.
+	stale := writeSession(t, home, "stale-48k", map[string]any{"contextTokensUsed": 48_000}, time.Now())
+	activePath := writeSession(t, home, "active-216k", map[string]any{"contextTokensUsed": 216_000}, time.Now())
 	b, _ := json.Marshal([]map[string]any{
-		{"session_id": "sess-1", "cwd": oldCwd, "opened_at": "2026-07-16T00:00:00Z"},
+		{"session_id": "active-216k", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
 	})
 	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := ResolveSignalsPath(nil, &newCwd); got != path {
-		t.Fatalf("got %q want %q", got, path)
+	cwd := testCwd
+	sid := "stale-48k"
+	gotDir := ResolveSessionDir(&sid, &cwd)
+	wantDir := filepath.Dir(activePath)
+	if gotDir != wantDir {
+		t.Fatalf("stale bind should recover to unique active, got %q want %q (stale was %q)", gotDir, wantDir, filepath.Dir(stale))
+	}
+	if got := ResolveSignalsPath(&sid, &cwd); got != activePath {
+		t.Fatalf("signals path: got %q want %q", got, activePath)
+	}
+	u := ResolveUsageForGrok(&sid, &cwd)
+	if u == nil || u.ContextTokens != 216_000 {
+		t.Fatalf("usage: got %+v want 216k", u)
+	}
+}
+
+func TestResolveSessionDir_BoundStillActiveKeepsBound(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Multi-pane same cwd: each bound id is active — never steal sibling.
+	boundPath := writeSession(t, home, "pane-a-23k", map[string]any{"contextTokensUsed": 23_000}, time.Now())
+	writeSession(t, home, "pane-b-146k", map[string]any{"contextTokensUsed": 146_000}, time.Now())
+	b, _ := json.Marshal([]map[string]any{
+		{"session_id": "pane-a-23k", "cwd": testCwd, "opened_at": "2026-07-14T00:00:00Z"},
+		{"session_id": "pane-b-146k", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	sid := "pane-a-23k"
+	if got := ResolveSignalsPath(&sid, &cwd); got != boundPath {
+		t.Fatalf("bound still active must keep bound, got %q want %q", got, boundPath)
+	}
+}
+
+func TestResolveSessionDir_StaleBindNoUniqueActiveKeepsBound(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Stale bound + ambiguous actives → stick with bound (no sibling guess).
+	boundPath := writeSession(t, home, "stale-bound", map[string]any{"contextTokensUsed": 10_000}, time.Now())
+	writeSession(t, home, "active-a", map[string]any{"contextTokensUsed": 100_000}, time.Now())
+	writeSession(t, home, "active-b", map[string]any{"contextTokensUsed": 200_000}, time.Now())
+	b, _ := json.Marshal([]map[string]any{
+		{"session_id": "active-a", "cwd": testCwd, "opened_at": "2026-07-14T00:00:00Z"},
+		{"session_id": "active-b", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	sid := "stale-bound"
+	if got := ResolveSignalsPath(&sid, &cwd); got != boundPath {
+		t.Fatalf("no unique active: keep bound, got %q want %q", got, boundPath)
+	}
+}
+
+func TestResolveSessionDir_MissingBoundRecoversToUniqueActive(t *testing.T) {
+	home := withTempGrokHome(t)
+	// Bound id missing on disk + unique active → recover (stale bind path).
+	activePath := writeSession(t, home, "sibling-146k", map[string]any{"contextTokensUsed": 146_000}, time.Now())
+	b, _ := json.Marshal([]map[string]any{
+		{"session_id": "sibling-146k", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	missing := "missing-bound-id"
+	if got := ResolveSignalsPath(&missing, &cwd); got != activePath {
+		t.Fatalf("stale missing bound + unique active should recover, got %q want %q", got, activePath)
+	}
+}
+
+func TestResolveSessionDir_MissingBoundAmbiguousActiveStaysEmpty(t *testing.T) {
+	home := withTempGrokHome(t)
+	writeSession(t, home, "a", map[string]any{"contextTokensUsed": 10}, time.Now())
+	writeSession(t, home, "b", map[string]any{"contextTokensUsed": 200_000}, time.Now())
+	b, _ := json.Marshal([]map[string]any{
+		{"session_id": "a", "cwd": testCwd, "opened_at": "2026-07-14T00:00:00Z"},
+		{"session_id": "b", "cwd": testCwd, "opened_at": "2026-07-15T00:00:00Z"},
+	})
+	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	missing := "missing-bound-id"
+	if dir := ResolveSessionDir(&missing, &cwd); dir != "" {
+		t.Fatalf("missing bound + ambiguous active must stay empty, got %q", dir)
+	}
+}
+
+func TestResolveSessionDir_BoundWithoutSignals(t *testing.T) {
+	home := withTempGrokHome(t)
+	sid := "no-signals-yet"
+	dir := filepath.Join(home, "sessions", encodeCwd(testCwd), sid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Only updates.jsonl — still a valid session dir.
+	if err := os.WriteFile(filepath.Join(dir, "updates.jsonl"), []byte(`{"params":{"_meta":{"totalTokens":9000}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := testCwd
+	if got := ResolveSessionDir(&sid, &cwd); got != dir {
+		t.Fatalf("got %q want %q", got, dir)
+	}
+	// signals path empty, but usage still resolves via updates.
+	if ResolveSignalsPath(&sid, &cwd) != "" {
+		t.Fatal("expected no signals path")
+	}
+	u := ResolveUsageForGrok(&sid, &cwd)
+	if u == nil || u.ContextTokens != 9000 {
+		t.Fatalf("got %+v", u)
+	}
+}
+
+func TestResolveSignalsPath_BoundSessionBeatsNewerSibling(t *testing.T) {
+	home := withTempGrokHome(t)
+	old := writeSession(t, home, "brew-23k", map[string]any{"contextTokensUsed": 23_000}, time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC))
+	writeSession(t, home, "coding-146k", map[string]any{"contextTokensUsed": 146_000}, time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC))
+	cwd := testCwd
+	sid := "brew-23k"
+	if got := ResolveSignalsPath(&sid, &cwd); got != old {
+		t.Fatalf("got %q want brew session %q", got, old)
 	}
 }

--- a/internal/providers/grok/provider_test.go
+++ b/internal/providers/grok/provider_test.go
@@ -41,9 +41,9 @@ func TestProvider_FromSessionID(t *testing.T) {
 	}
 }
 
-func TestProvider_ViaActiveSessions(t *testing.T) {
+func TestProvider_ViaUniqueOnDiskSession(t *testing.T) {
 	home := withTempGrokHome(t)
-	sid := "active-only"
+	sid := "only-on-disk"
 	dir := filepath.Join(home, "sessions", encodeCwd(provCwd), sid)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
@@ -52,13 +52,8 @@ func TestProvider_ViaActiveSessions(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "signals.json"), b, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	active, _ := json.Marshal([]map[string]any{
-		{"session_id": sid, "cwd": provCwd, "opened_at": "2026-07-15T00:00:00Z"},
-	})
-	if err := os.WriteFile(filepath.Join(home, "active_sessions.json"), active, 0o644); err != nil {
-		t.Fatal(err)
-	}
 	cwd := provCwd
+	// No agent_session: unique on-disk session under cwd is enough.
 	got := Provider.ResolveUsage(provider.UsageResolveInput{Cwd: &cwd})
 	if got == nil || got.ContextTokens != 12_000 || got.WindowTokens == nil || *got.WindowTokens != 200_000 {
 		t.Fatalf("got %+v", got)

--- a/internal/providers/grok/resolve.go
+++ b/internal/providers/grok/resolve.go
@@ -1,27 +1,52 @@
 /**
- * Reads a signals.json and returns a ContextUsage.
+ * Resolves Grok context usage for a pane.
+ *
+ * Sources (same session only — never a sibling under the same cwd):
+ *  1. signals.json contextTokensUsed — the UI window meter ("Nk / 500K")
+ *  2. updates.jsonl `_meta.totalTokens` — only when signals are missing
+ *
+ * The last `_meta.totalTokens` in updates.jsonl is NOT the UI window meter:
+ * it often sits far below the real context (or near a pre-compaction total).
+ * When signals exist, use them directly — never let last totalTokens override.
  */
 package grok
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 // ResolveUsageForGrok resolves usage from session id and/or cwd.
 func ResolveUsageForGrok(sessionID, cwd *string) *core.ContextUsage {
-	path := ResolveSignalsPath(sessionID, cwd)
-	if path == "" {
+	dir := ResolveSessionDir(sessionID, cwd)
+	if dir == "" {
 		return nil
 	}
-	raw, err := os.ReadFile(path)
-	if err != nil {
+	return UsageFromSessionDir(dir)
+}
+
+// UsageFromSessionDir builds usage from one session directory's signals and/or updates.
+func UsageFromSessionDir(dir string) *core.ContextUsage {
+	if dir == "" {
 		return nil
 	}
-	signals, ok := ParseSignalsJSON(string(raw))
-	if !ok {
-		return nil
+	sigPath := filepath.Join(dir, "signals.json")
+	if st, err := os.Stat(sigPath); err == nil && st.Mode().IsRegular() {
+		if raw, err := os.ReadFile(sigPath); err == nil {
+			if s, ok := ParseSignalsJSON(string(raw)); ok {
+				if u := UsageFromSignals(*s); u != nil {
+					return u
+				}
+			}
+		}
 	}
-	return UsageFromSignals(*signals)
+
+	// No usable signals: fall back to live stream meter only.
+	meta, _ := LatestContextTokensFromUpdates(filepath.Join(dir, "updates.jsonl"))
+	if meta > 0 {
+		return &core.ContextUsage{ContextTokens: meta}
+	}
+	return nil
 }

--- a/internal/providers/grok/signals.go
+++ b/internal/providers/grok/signals.go
@@ -12,9 +12,11 @@ import (
 
 // Signals is the parsed shape of signals.json.
 type Signals struct {
-	ContextTokensUsed   *float64 `json:"contextTokensUsed"`
-	ContextWindowTokens *float64 `json:"contextWindowTokens"`
-	ContextWindowUsage  *float64 `json:"contextWindowUsage"`
+	ContextTokensUsed           *float64 `json:"contextTokensUsed"`
+	ContextWindowTokens         *float64 `json:"contextWindowTokens"`
+	ContextWindowUsage          *float64 `json:"contextWindowUsage"`
+	TotalTokensBeforeCompaction *float64 `json:"totalTokensBeforeCompaction"`
+	CompactionCount             *float64 `json:"compactionCount"`
 }
 
 // UsageFromSignals builds usage from a parsed signals.json object.

--- a/internal/providers/grok/updates.go
+++ b/internal/providers/grok/updates.go
@@ -1,0 +1,91 @@
+/**
+ * Fallback context estimate from updates.jsonl when signals.json is missing.
+ *
+ * Grok streams `_meta.totalTokens` on thought/message/tool chunks. The last
+ * value is not the UI window meter (often far below real contextTokensUsed
+ * in signals.json). Callers must only use this when signals are absent.
+ */
+package grok
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// How much of the tail of updates.jsonl we scan. Files can be multi-MB; the
+// latest totalTokens always lands near the end.
+const updatesTailScanBytes = 512 * 1024
+
+// LatestContextTokensFromUpdates returns the last `_meta.totalTokens` seen in
+// updates.jsonl and the file's mtime in ms. total=0 means nothing usable.
+func LatestContextTokensFromUpdates(path string) (total int, mtimeMs int64) {
+	st, err := os.Stat(path)
+	if err != nil || !st.Mode().IsRegular() {
+		return 0, 0
+	}
+	mtimeMs = st.ModTime().UnixMilli()
+	raw, err := readFileTail(path, updatesTailScanBytes)
+	if err != nil || len(raw) == 0 {
+		return 0, mtimeMs
+	}
+	// If we truncated mid-line, drop the partial first line.
+	if len(raw) == updatesTailScanBytes {
+		if i := bytes.IndexByte(raw, '\n'); i >= 0 && i+1 < len(raw) {
+			raw = raw[i+1:]
+		}
+	}
+	last := 0
+	for _, line := range bytes.Split(raw, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || !bytes.Contains(line, []byte("totalTokens")) {
+			continue
+		}
+		var envelope struct {
+			Params *struct {
+				Meta *struct {
+					TotalTokens *float64 `json:"totalTokens"`
+				} `json:"_meta"`
+			} `json:"params"`
+		}
+		if err := json.Unmarshal(line, &envelope); err != nil {
+			continue
+		}
+		if envelope.Params == nil || envelope.Params.Meta == nil || envelope.Params.Meta.TotalTokens == nil {
+			continue
+		}
+		n := *envelope.Params.Meta.TotalTokens
+		if !isFinite(n) || n <= 0 {
+			continue
+		}
+		last = int(n)
+	}
+	return last, mtimeMs
+}
+
+func readFileTail(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := st.Size()
+	if size <= 0 {
+		return nil, nil
+	}
+	start := size - maxBytes
+	if start < 0 {
+		start = 0
+	}
+	if start > 0 {
+		if _, err := f.Seek(start, io.SeekStart); err != nil {
+			return nil, err
+		}
+	}
+	return io.ReadAll(f)
+}

--- a/internal/providers/grok/updates_test.go
+++ b/internal/providers/grok/updates_test.go
@@ -1,0 +1,84 @@
+/**
+ * Tests for updates.jsonl live context extraction.
+ */
+package grok
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLatestContextTokensFromUpdates_LastWins(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "updates.jsonl")
+	content := "" +
+		`{"params":{"_meta":{"totalTokens":1000}}}` + "\n" +
+		`{"params":{"update":{"sessionUpdate":"agent_message_chunk"}}}` + "\n" +
+		`{"params":{"_meta":{"totalTokens":23000},"update":{"sessionUpdate":"tool_call"}}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, mt := LatestContextTokensFromUpdates(path)
+	if got != 23_000 {
+		t.Fatalf("got %d want 23000", got)
+	}
+	if mt <= 0 {
+		t.Fatal("expected mtime")
+	}
+}
+
+func TestLatestContextTokensFromUpdates_Missing(t *testing.T) {
+	got, mt := LatestContextTokensFromUpdates(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if got != 0 || mt != 0 {
+		t.Fatalf("got %d %d", got, mt)
+	}
+}
+
+func TestUsageFromSessionDir_SignalsWinsOverHigherMeta(t *testing.T) {
+	dir := t.TempDir()
+	// signals is the UI window meter; last totalTokens must not override.
+	upd := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(upd, []byte(`{"params":{"_meta":{"totalTokens":210000}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sig := filepath.Join(dir, "signals.json")
+	if err := os.WriteFile(sig, []byte(`{"contextTokensUsed":23000,"contextWindowTokens":500000,"totalTokensBeforeCompaction":216407,"compactionCount":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := UsageFromSessionDir(dir)
+	if got == nil || got.ContextTokens != 23_000 {
+		t.Fatalf("got %+v want signals 23k", got)
+	}
+}
+
+func TestUsageFromSessionDir_UpdatesWhenSignalsMissing(t *testing.T) {
+	dir := t.TempDir()
+	upd := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(upd, []byte(`{"params":{"_meta":{"totalTokens":22871}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := UsageFromSessionDir(dir)
+	if got == nil || got.ContextTokens != 22_871 {
+		t.Fatalf("got %+v want updates 22871", got)
+	}
+}
+
+func TestUsageFromSessionDir_SignalsNotOverriddenByHigherMeta(t *testing.T) {
+	dir := t.TempDir()
+	sig := filepath.Join(dir, "signals.json")
+	if err := os.WriteFile(sig, []byte(`{"contextTokensUsed":20000,"contextWindowTokens":500000}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	upd := filepath.Join(dir, "updates.jsonl")
+	if err := os.WriteFile(upd, []byte(`{"params":{"_meta":{"totalTokens":35000}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := UsageFromSessionDir(dir)
+	if got == nil || got.ContextTokens != 20_000 {
+		t.Fatalf("got %+v want signals 20k (meta must not override)", got)
+	}
+	if got.WindowTokens == nil || *got.WindowTokens != 500_000 {
+		t.Fatalf("should keep window from signals, got %+v", got)
+	}
+}

--- a/internal/setup/herdrconfig.go
+++ b/internal/setup/herdrconfig.go
@@ -52,17 +52,25 @@ func ToastConfigSnippet() string {
 // ("space") name in that case, then appends a pane rename when present
 // ("space・pane").
 //
-// $provider replaces the built-in `agent` token: it renders the subscription
-// provider ("opencode-go", "grok", "claude") when one owns the pane's
-// limit, and the backend name ("deepseek") on a pay-as-you-go pane.
+// $limit is the shortest account window ("7d 77%") or pay-as-you-go burn.
+// Absolute context size is a separate exclusive tier token so Herdr can color
+// it by fg: $ctx (<100k), $ctx_y (≥100k light yellow), $ctx_yy (≥150k deep
+// yellow), $ctx_r (≥180k red). $provider is still written for layouts that
+// want it on a separate row, but the default snippet omits it to save width.
 func SidebarRowsSnippet() string {
 	return strings.Join([]string{
 		"[ui.sidebar.agents]",
 		"row_gap = 0",
 		"rows = [",
 		`  ["state_icon", "$title"],`,
-		`  ["$provider", "$limit"],`,
-		`  ["$context"],`,
+		`  [`,
+		`    { token = "$limit", dim = true },`,
+		`    { token = "$window", dim = true },`,
+		`    { token = "$ctx", dim = true },`,
+		`    { token = "$ctx_y", fg = "#ebcb8b", dim = false },`,
+		`    { token = "$ctx_yy", fg = "#d08770", dim = false },`,
+		`    { token = "$ctx_r", fg = "#bf616a", dim = false },`,
+		`  ],`,
 		"]",
 		"",
 	}, "\n")

--- a/internal/setup/runsetup_test.go
+++ b/internal/setup/runsetup_test.go
@@ -32,7 +32,7 @@ func TestRunSetup_SeedsAndSnippets(t *testing.T) {
 	for _, want := range []string{
 		"seeded plugin config", "toast: NOT configured", "[ui.toast]",
 		"[ui.sidebar.agents]", `["state_icon", "$title"]`,
-		`"$limit"`, `"$context"`,
+		`"$limit"`, `"$ctx_y"`, `"$ctx_r"`,
 		"usagebar.open-limits", "--write-toast",
 	} {
 		if !strings.Contains(text, want) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -27,10 +27,6 @@ func findClaudeProfile(profiles []claude.ClaudeProfile, id string) (claude.Claud
 	return claude.ClaudeProfile{}, false
 }
 
-func isSettledStatus(status string) bool {
-	return status != "working"
-}
-
 // paneCwdForUpdate chooses the directory used to resolve agent-local session
 // files. OMP/Pi may put a language-server process in the foreground, whose
 // cwd is inside a virtual environment rather than the agent's project. Their
@@ -76,6 +72,76 @@ func combineLimitAndContext(limitText, statusText string) string {
 		return limitText
 	}
 	return limitText + " · " + statusText
+}
+
+// combineLimitAndCompactContext joins a limit window with compact context
+// tokens for a single-row sidebar meter: "7d 77%  ⛁ 94k". Two spaces separate
+// the account window from context so the groups read apart without an icon.
+// Kept for tests and any caller that still needs a plain combined string;
+// live sidebar writes use exclusive $ctx_* tier tokens instead (Herdr strips
+// ANSI, so color comes from per-token fg in config).
+func combineLimitAndCompactContext(limitText, compactTokens string) string {
+	if limitText == "" {
+		return compactTokens
+	}
+	if compactTokens == "" {
+		return limitText
+	}
+	return limitText + "  " + compactTokens
+}
+
+// writeContextTierTokens writes the exclusive $ctx / $ctx_y / $ctx_yy / $ctx_r
+// map so only the matching absolute-size tier is non-empty.
+//
+// usage == nil clears every tier. Prefer blank over a sibling pane's count:
+// Grok panes often share $HOME as cwd, and a failed/ambiguous resolve used to
+// leave a stale 146k from another session while the UI showed 23k.
+func writeContextTierTokens(current map[string]string, paneID string, usage *core.ContextUsage, force bool) {
+	values := map[string]string{
+		core.ContextTokenOK:       "",
+		core.ContextTokenSoft:     "",
+		core.ContextTokenWarn:     "",
+		core.ContextTokenCritical: "",
+	}
+	if usage != nil {
+		values = core.ContextTierTokenValues(*usage)
+	}
+	for _, name := range core.AllContextTierTokenNames {
+		writeMetadataToken(current, paneID, name, values[name], force)
+	}
+}
+
+// writeLimitToken writes $limit, but refuses to clear it on a transient
+// subscription collect miss. Empty limitText only clears when we know the
+// pane truly has no window (pay-as-you-go with no burn, or collected limits
+// with no windows).
+func writeLimitToken(
+	current map[string]string,
+	paneID, limitText string,
+	billingMode limits.BillingMode,
+	collected bool,
+	force bool,
+) {
+	if limitText != "" {
+		writeMetadataToken(current, paneID, "limit", limitText, force)
+		return
+	}
+	if billingMode == limits.BillingPayAsYouGo {
+		// No session burn → clear is correct.
+		writeMetadataToken(current, paneID, "limit", "", force)
+		return
+	}
+	if collected {
+		// Provider responded with no usable windows.
+		writeMetadataToken(current, paneID, "limit", "", force)
+		return
+	}
+	// Subscription collect returned nothing — keep the previous $limit so a
+	// flaky fetch cannot leave the row as "only red context".
+	if force && current["limit"] == "" {
+		// force + already empty: nothing to do
+		return
+	}
 }
 
 // formatSidebarProvider renders the sidebar's agent line: the backend name on
@@ -165,7 +231,11 @@ func writeMetadataTokenWith(writer metadataTokenWriter, current map[string]strin
 }
 
 // RunUpdate resolves usage for HERDR_PANE_ID and updates its sidebar tokens.
-// force=true (plugin action) updates even while working.
+//
+// Always refreshes (including while status is "working"): Grok compaction and
+// mid-turn context drops update signals.json before the agent settles, and
+// skipping those events left the sidebar stuck on the pre-compress count.
+// force=true still forces token writes even when values are unchanged.
 func RunUpdate(force bool) {
 	paneID := os.Getenv("HERDR_PANE_ID")
 	if paneID == "" {
@@ -179,10 +249,6 @@ func RunUpdate(force bool) {
 
 	p := providers.FindProvider(*pane.Agent)
 	if p == nil {
-		return
-	}
-
-	if pane.AgentStatus != nil && !isSettledStatus(*pane.AgentStatus) && !force {
 		return
 	}
 
@@ -216,7 +282,9 @@ func RunUpdate(force bool) {
 		// Cannot tell which account this pane belongs to: clear rather than
 		// guess into the wrong account's limits/tokens.
 		writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
+		writeMetadataToken(pane.Tokens, paneID, "window", "", force)
 		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+		writeContextTierTokens(pane.Tokens, paneID, nil, force)
 		writeMetadataToken(pane.Tokens, paneID, "context", "", force)
 		return
 	}
@@ -226,8 +294,10 @@ func RunUpdate(force bool) {
 	displayProviderID := limits.SubscriptionDisplayProviderID(providerID, snapshot)
 	var providerLimits *limits.ProviderLimits
 	var totalTokens, totalCostUSD float64
+	collectedLimits := false
 	if billingMode == limits.BillingPayAsYouGo {
 		totalTokens, totalCostUSD = limits.PaneTotalUsage(providerID, snapshot, nowMs)
+		collectedLimits = true // pay-as-you-go path is authoritative even when burn is 0
 	} else {
 		collectOptions := limits.DefaultCollectOptions()
 		// Sidebar refresh deliberately collects only this pane's provider and leaves
@@ -236,6 +306,7 @@ func RunUpdate(force bool) {
 		collected := limits.CollectAllProviderLimits(cwd, nowMs, collectOptions)
 		if len(collected) > 0 {
 			providerLimits = &collected[0]
+			collectedLimits = true
 		}
 	}
 	fallbackProviderText := formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot)
@@ -247,8 +318,8 @@ func RunUpdate(force bool) {
 	// With 2+ configured Claude accounts, the $limit row's job shifts from
 	// "show the limit" to "show which account this pane is" (joined with
 	// $provider as "claude · you@example.com") since that's otherwise
-	// invisible in the sidebar. The limit percentage moves down into
-	// $context instead, as this pane's own account is already unambiguous.
+	// invisible in the sidebar. The limit percentage moves into $window,
+	// as this pane's own account is already unambiguous.
 	multiProfile := *pane.Agent == "claude" && len(claudeProfiles) > 1
 	accountText := ""
 	limitToken := limitText
@@ -260,10 +331,10 @@ func RunUpdate(force bool) {
 			limitToken = accountText
 		}
 	}
-	writeMetadataToken(pane.Tokens, paneID, "limit", limitToken, force)
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
+	// Optional in sidebar rows — narrow agent panels usually omit $provider.
 	writeMetadataToken(pane.Tokens, paneID, "provider", providerText, force)
 
 	// Context tokens: claude is read from its resolved profile's own transcript
@@ -284,20 +355,25 @@ func RunUpdate(force bool) {
 		})
 	}
 
-	contextPrefix := ""
+	// Split account/limit window from the absolute context count so Herdr can
+	// color only the count via per-token fg ($ctx / $ctx_y / $ctx_yy / $ctx_r).
+	// Metadata values cannot carry ANSI (Herdr strips escapes).
+	// Multi-profile Claude: $limit = account, $window = "5h 88%", $ctx_* = count.
+	// Single-profile: $limit = window, $window cleared, $ctx_* = count.
+	// Always clear legacy $context so old two-row layouts do not show stale text.
 	if accountText != "" {
-		contextPrefix = limitText
+		// Account identity is always known once multiProfile resolved; write it.
+		writeMetadataToken(pane.Tokens, paneID, "limit", limitToken, force)
+		if limitText != "" {
+			writeMetadataToken(pane.Tokens, paneID, "window", limitText, force)
+		} else if collectedLimits {
+			writeMetadataToken(pane.Tokens, paneID, "window", "", force)
+		}
+		// else: keep previous $window on collect miss
+	} else {
+		writeLimitToken(pane.Tokens, paneID, limitToken, billingMode, collectedLimits, force)
+		writeMetadataToken(pane.Tokens, paneID, "window", "", force)
 	}
-
-	if usage == nil {
-		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
-		return
-	}
-
-	liveWidth := herdrcli.GetSidebarWidthColumns(paneID)
-	sidebarW := core.ResolveSidebarWidth(liveWidth, core.ResolveConfigSidebarWidth())
-	maxCols := core.EstimateStatusMaxColumns(&sidebarW, pane.RowLabel)
-	maxCols = reserveColumnsFor(maxCols, contextPrefix)
-	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{MaxColumns: maxCols})
-	writeMetadataToken(pane.Tokens, paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
+	writeContextTierTokens(pane.Tokens, paneID, usage, force)
+	writeMetadataToken(pane.Tokens, paneID, "context", "", force)
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -271,6 +271,82 @@ func TestCombineLimitAndContext(t *testing.T) {
 	}
 }
 
+func TestWriteLimitToken_PreservesOnCollectMiss(t *testing.T) {
+	setCalls := 0
+	clearCalls := 0
+	var lastSet string
+	writer := metadataTokenWriter{
+		set: func(_, _, _, value string) bool {
+			setCalls++
+			lastSet = value
+			return true
+		},
+		clear: func(_, _, _ string) bool {
+			clearCalls++
+			return true
+		},
+	}
+	// Temporarily swap the package writer used by writeLimitToken → writeMetadataToken.
+	// writeLimitToken goes through writeMetadataToken → herdrMetadataTokenWriter.
+	old := herdrMetadataTokenWriter
+	herdrMetadataTokenWriter = writer
+	t.Cleanup(func() { herdrMetadataTokenWriter = old })
+
+	current := map[string]string{"limit": "7d 73%"}
+	// Transient collect miss must not clear.
+	writeLimitToken(current, "w1:p1", "", limits.BillingSubscription, false, false)
+	if setCalls != 0 || clearCalls != 0 {
+		t.Fatalf("collect miss wrote set=%d clear=%d", setCalls, clearCalls)
+	}
+	// Real empty (collected, no windows) clears.
+	writeLimitToken(current, "w1:p1", "", limits.BillingSubscription, true, false)
+	if clearCalls != 1 {
+		t.Fatalf("expected clear, clear=%d set=%d last=%q", clearCalls, setCalls, lastSet)
+	}
+	// Non-empty always writes.
+	writeLimitToken(current, "w1:p1", "7d 70%", limits.BillingSubscription, true, false)
+	if setCalls != 1 || lastSet != "7d 70%" {
+		t.Fatalf("set=%d last=%q", setCalls, lastSet)
+	}
+}
+
+func TestWriteContextTierTokens_NilUsageClearsStale(t *testing.T) {
+	clearCalls := 0
+	old := herdrMetadataTokenWriter
+	herdrMetadataTokenWriter = metadataTokenWriter{
+		set: func(_, _, _, _ string) bool { return true },
+		clear: func(_, _, _ string) bool {
+			clearCalls++
+			return true
+		},
+	}
+	t.Cleanup(func() { herdrMetadataTokenWriter = old })
+
+	// Stale sibling meter must not stick when resolve returns nil.
+	current := map[string]string{"ctx_r": "⛁ 146k"}
+	writeContextTierTokens(current, "w1:p1", nil, false)
+	if clearCalls != 1 {
+		// only ctx_r is present so ShouldWriteToken clears that one; empty tiers skip
+		t.Fatalf("expected clear of stale ctx_r, clear=%d", clearCalls)
+	}
+}
+
+func TestCombineLimitAndCompactContext(t *testing.T) {
+	cases := []struct{ limitText, compact, want string }{
+		{"7d 77%", "⛁ 94k", "7d 77%  ⛁ 94k"},
+		{"5h 88%", "⛁ 136k", "5h 88%  ⛁ 136k"},
+		{"", "⛁ 94k", "⛁ 94k"},
+		{"7d 77%", "", "7d 77%"},
+		{"Σ 425k", "⛁ 94k", "Σ 425k  ⛁ 94k"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		if got := combineLimitAndCompactContext(c.limitText, c.compact); got != c.want {
+			t.Fatalf("combineLimitAndCompactContext(%q, %q) = %q, want %q", c.limitText, c.compact, got, c.want)
+		}
+	}
+}
+
 func TestReserveColumnsFor(t *testing.T) {
 	base := 20
 	got := reserveColumnsFor(&base, "you@example.com")


### PR DESCRIPTION
## Summary

Grok sidebar context can stick on an old session and under-report the live window after resume/switch. This PR:

- **Recovers stale binds**: when `agent_session` is no longer in `active_sessions.json` and the cwd has exactly one active session, resolve to that session instead of the stale bound id.
- **Signals-first context**: prefer `signals.json` `contextTokensUsed` (matches the UI window meter); fall back to `updates.jsonl` `_meta.totalTokens` only when signals are missing.
- **Exclusive `$ctx_*` tiers**: write only one of `$ctx` / `$ctx_y` / `$ctx_yy` / `$ctx_r` non-empty so Herdr can color the count by threshold; clear legacy `$context`.
- **Refresh while working**: update context mid-turn when signals change before the agent settles.
- **Preserve `$limit` on collect miss**: avoid flashing empty rate-limit text when collection temporarily fails.

## Change graph

```mermaid
flowchart TD
  A[pane agent_session + cwd] --> B{bound id exists on disk?}
  B -->|yes| C{bound in active_sessions?}
  B -->|no| D[FindActiveSessionID cwd]
  C -->|yes| E[use bound session dir]
  C -->|no| F{unique active for cwd?}
  F -->|yes, different id| G[recover to active session dir]
  F -->|no / multi-active| E
  D --> H{unique session with usage files?}
  H -->|yes| I[use that dir]
  H -->|no| J[no session / clear context]
  E --> K[UsageFromSessionDir]
  G --> K
  I --> K
  K --> L{signals.json contextTokensUsed?}
  L -->|yes| M[use signals meter]
  L -->|no| N{updates.jsonl totalTokens?}
  N -->|yes| O[fallback updates tail]
  N -->|no| J
  M --> P[exclusive ctx tier tokens + optional limit]
  O --> P
```

## Related issue

Related issue: N/A (focused bugfix + small presentation fix; no prior issue required per CONTRIBUTING)

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./internal/core/ ./internal/providers/grok/ ./internal/setup/ ./internal/update/`
- [x] `go test ./internal/core/ ./internal/providers/grok/ ./internal/setup/ ./internal/update/`
- [x] `go build ./...`
- [x] Tests were added or updated where appropriate

Verification commands actually run in this branch:

```sh
gofmt -w internal/core/format.go internal/core/format_test.go \
  internal/providers/grok/*.go internal/setup/herdrconfig.go \
  internal/setup/runsetup_test.go internal/update/update.go \
  internal/update/update_test.go
gofmt -l .
go test ./internal/core/ ./internal/providers/grok/ ./internal/setup/ ./internal/update/
go vet ./internal/core/ ./internal/providers/grok/ ./internal/setup/ ./internal/update/
go build ./...
```

## User and compatibility impact

- Grok panes: more accurate context after session resume/switch when the bound id is stale and a unique active session exists for the cwd.
- Sidebar templates from setup: default layout can use exclusive `$ctx` / `$ctx_y` / `$ctx_yy` / `$ctx_r` with per-token colors; legacy `$context` is cleared so old two-row text does not linger.
- No persisted-state format change; no secrets or credentials involved.

## AI assistance

Assisted drafting of the recovery path, tests, and this PR description. Changes were reviewed and verified with the commands above.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed (setup default layout comments / tokens)
- [x] The PR title follows Conventional Commits (e.g. `fix: ...`, `feat(providers): ...`) — see CONTRIBUTING.md for the allowed types