### PR TITLE
fix(plugin): provision bin/usagebar via herdr-plugin.toml build hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@
 test:
 	go test ./...
 
+# --build always compiles from source and fails hard, so a broken tree is
+# reported rather than papered over with a prebuilt release download. The
+# herdr-plugin.toml [[build]] hook calls the same script with --in-tree.
 build:
-	mkdir -p bin
-	go build -o bin/usagebar ./cmd/usagebar
+	bash bin/ensure-binary.sh --build
 	chmod +x bin/*.sh
 
 tidy:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ herdr plugin action invoke usagebar.enable-toast
 herdr server reload-config
 ```
 
-`usagebar.setup` resolves the `usagebar` binary automatically on first run: it builds with the local Go toolchain (≥ 1.25) when available, and otherwise downloads a prebuilt binary from [GitHub Releases](https://github.com/senna-lang/herdr-agent-usage/releases) (macOS / Linux, arm64 / amd64). To build manually instead, run `make build` in the plugin root.
+`herdr plugin install` provisions the `usagebar` binary automatically as part of install/update (via the manifest's `[[build]]` hook): it builds with the local Go toolchain (≥ 1.25) when available, and otherwise downloads a prebuilt binary from [GitHub Releases](https://github.com/senna-lang/herdr-agent-usage/releases) (macOS / Linux, arm64 / amd64). `usagebar.setup` repeats this resolution as a fallback for installs predating the build hook. To build manually instead, run `make build` in the plugin root.
 
 ## Let an LLM set it up
 

--- a/bin/ensure-binary.sh
+++ b/bin/ensure-binary.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Provision the usagebar binary. Three modes, because the callers ask three
+# different questions:
+#
+#   --in-tree  Guarantee THIS checkout carries bin/usagebar. Used by the
+#              herdr-plugin.toml [[build]] hook, which runs on every
+#              `herdr plugin install` — including reinstall/update, the only
+#              way to update — against a fresh checkout that never carries the
+#              gitignored binary. $USAGEBAR_BIN and a usagebar on PATH
+#              deliberately do NOT satisfy this mode: they come from the
+#              install-time shell, which need not match the Herdr server
+#              environment that later runs the event hooks. Treating them as
+#              satisfying would reintroduce issue #48 silently.
+#
+#   --build    Always compile from source, and fail hard. Used by `make build`,
+#              where falling back to a prebuilt release would mask a broken
+#              tree instead of reporting it.
+#
+#   (default)  Ensure usagebar is resolvable the way run-usagebar.sh resolves
+#              it: $USAGEBAR_BIN -> sibling bin/usagebar -> PATH. Used by
+#              run-setup.sh as the fallback for installs predating the build
+#              hook.
+#
+# Build-or-download modes compile with the local Go toolchain and fall back to
+# a prebuilt release binary.
+# See https://github.com/senna-lang/herdr-agent-usage/issues/48
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REPO="senna-lang/herdr-agent-usage"
+# The manifest is the source of truth for a checkout's version: locally built
+# binaries intentionally do not receive release ldflags (see
+# bin/run-update-check.sh).
+VERSION="$(awk -F '"' '/^version = / { print $2; exit }' "$ROOT/herdr-plugin.toml")"
+
+# Normalize uname output to the Go GOOS/GOARCH names used by release assets
+# (.github/workflows/release.yml): usagebar-<os>-<arch>.
+release_asset_name() {
+  local os arch
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux) os="linux" ;;
+    *) return 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64) arch="amd64" ;;
+    arm64 | aarch64) arch="arm64" ;;
+    *) return 1 ;;
+  esac
+  echo "usagebar-${os}-${arch}"
+}
+
+# Fetch $asset from release $tag ("" = latest) into $tmp, leaving no partial
+# file behind on failure. gh works for private and public repos (it uses the
+# user's auth); curl covers public repos without gh installed.
+fetch_release_asset() {
+  local tag="$1" asset="$2" tmp="$3"
+  local gh_args=(release download) curl_path
+  if [[ -n "$tag" ]]; then
+    gh_args+=("$tag")
+    curl_path="download/$tag"
+  else
+    curl_path="latest/download"
+  fi
+  gh_args+=(--repo "$REPO" --pattern "$asset" -O "$tmp")
+
+  if command -v gh >/dev/null 2>&1; then
+    gh "${gh_args[@]}" 2>/dev/null || rm -f "$tmp"
+  fi
+  if [[ ! -s "$tmp" ]] && command -v curl >/dev/null 2>&1; then
+    curl -fsSL "https://github.com/$REPO/releases/$curl_path/$asset" -o "$tmp" || rm -f "$tmp"
+  fi
+  [[ -s "$tmp" ]]
+}
+
+# Install a prebuilt binary into bin/usagebar. Prefers the release matching
+# this checkout's manifest version — `herdr plugin install --ref` can install
+# source that is older or newer than the latest release — and falls back to
+# latest when that tag carries no assets (an unreleased main, say).
+download_release_binary() {
+  local asset dest tmp
+  asset="$(release_asset_name)" || return 1
+  dest="$ROOT/bin/usagebar"
+  tmp="$dest.download"
+  rm -f "$tmp"
+
+  echo "usagebar: downloading prebuilt binary ($asset)..." >&2
+  # The version-matched attempt is speculative — a 404 here just means this
+  # checkout is ahead of the last release — so keep its noise off stderr.
+  if [[ -n "$VERSION" ]]; then
+    fetch_release_asset "v$VERSION" "$asset" "$tmp" 2>/dev/null || true
+  fi
+  if [[ ! -s "$tmp" ]] && ! fetch_release_asset "" "$asset" "$tmp"; then
+    return 1
+  fi
+
+  chmod +x "$tmp"
+  # Sanity check before installing: the binary must run on this machine.
+  "$tmp" version >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$dest"
+}
+
+build_from_source() {
+  command -v go >/dev/null 2>&1 || return 1
+  echo "usagebar: building bin/usagebar (go build)..." >&2
+  mkdir -p "$ROOT/bin"
+  (cd "$ROOT" && go build -o bin/usagebar ./cmd/usagebar)
+}
+
+# Guarantee $ROOT/bin/usagebar exists, by any available means. A source build
+# failing (cold module cache, no network, no toolchain) is not fatal on its
+# own — the prebuilt download is a real second chance.
+install_binary() {
+  if build_from_source; then
+    return 0
+  fi
+  if command -v go >/dev/null 2>&1; then
+    echo "usagebar: go build failed; trying the prebuilt release binary..." >&2
+  fi
+  if download_release_binary; then
+    echo "usagebar: prebuilt binary installed to bin/usagebar" >&2
+    return 0
+  fi
+  echo "usagebar: could not build or download the usagebar binary." >&2
+  echo "Fix one of:" >&2
+  echo "  - install Go (https://go.dev/dl/), then run: make build  (in the plugin root)" >&2
+  echo "  - install gh (https://cli.github.com/) and authenticate, then re-run setup" >&2
+  return 127
+}
+
+# True when usagebar is already resolvable the way run-usagebar.sh resolves it.
+usagebar_resolvable() {
+  [[ -n "${USAGEBAR_BIN:-}" && -x "$USAGEBAR_BIN" ]] && return 0
+  [[ -x "$ROOT/bin/usagebar" ]] && return 0
+  command -v usagebar >/dev/null 2>&1
+}
+
+case "${1:-}" in
+  --in-tree)
+    if [[ ! -x "$ROOT/bin/usagebar" ]]; then
+      install_binary
+    fi
+    ;;
+  --build)
+    build_from_source || {
+      echo "usagebar: go build failed (is the Go toolchain installed?)" >&2
+      exit 1
+    }
+    ;;
+  "")
+    if ! usagebar_resolvable; then
+      install_binary
+    fi
+    ;;
+  *)
+    echo "usage: ensure-binary.sh [--in-tree|--build]" >&2
+    exit 2
+    ;;
+esac

--- a/bin/run-setup.sh
+++ b/bin/run-setup.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 # Setup action entry. Resolves the usagebar binary on first run when it is
-# missing (bin/usagebar is not shipped in the repo): build with the local Go
-# toolchain, else download a prebuilt release binary. The resolution lives
-# here — a user-initiated, latency-tolerant action — and NOT in
+# missing — this is a fallback for installs that predate the
+# herdr-plugin.toml [[build]] hook (see bin/ensure-binary.sh), or that ran
+# it offline with no Go toolchain. The resolution lives in a separate
+# script — a user-initiated, latency-tolerant path — and NOT in
 # run-usagebar.sh, which is also the hot path for concurrent event handlers.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-REPO="senna-lang/herdr-agent-usage"
-
-# Normalize uname output to the Go GOOS/GOARCH names used by release assets
-# (.github/workflows/release.yml): usagebar-<os>-<arch>.
-release_asset_name() {
-  local os arch
-  case "$(uname -s)" in
-    Darwin) os="darwin" ;;
-    Linux) os="linux" ;;
-    *) return 1 ;;
-  esac
-  case "$(uname -m)" in
-    x86_64) arch="amd64" ;;
-    arm64 | aarch64) arch="arm64" ;;
-    *) return 1 ;;
-  esac
-  echo "usagebar-${os}-${arch}"
-}
-
-download_release_binary() {
-  local asset dest tmp
-  asset="$(release_asset_name)" || return 1
-  dest="$ROOT/bin/usagebar"
-  tmp="$dest.download"
-
-  # gh works for private and public repos (uses the user's auth);
-  # curl covers public repos without gh installed.
-  if command -v gh >/dev/null 2>&1; then
-    echo "usagebar: downloading prebuilt binary ($asset) via gh..." >&2
-    gh release download --repo "$REPO" --pattern "$asset" -O "$tmp" 2>/dev/null || rm -f "$tmp"
-  fi
-  if [[ ! -s "$tmp" ]] && command -v curl >/dev/null 2>&1; then
-    echo "usagebar: downloading prebuilt binary ($asset) via curl..." >&2
-    curl -fsSL "https://github.com/$REPO/releases/latest/download/$asset" -o "$tmp" || rm -f "$tmp"
-  fi
-  [[ -s "$tmp" ]] || return 1
-  chmod +x "$tmp"
-  # Sanity check before installing: the binary must run on this machine.
-  "$tmp" version >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
-  mv -f "$tmp" "$dest"
-}
-
-if [[ -z "${USAGEBAR_BIN:-}" && ! -x "$ROOT/bin/usagebar" ]] \
-   && ! command -v usagebar >/dev/null 2>&1; then
-  if command -v go >/dev/null 2>&1; then
-    echo "usagebar: binary not found; building it now (go build)..." >&2
-    (cd "$ROOT" && go build -o bin/usagebar ./cmd/usagebar)
-  elif download_release_binary; then
-    echo "usagebar: prebuilt binary installed to bin/usagebar" >&2
-  else
-    echo "usagebar: binary not found; no Go toolchain and the prebuilt download failed." >&2
-    echo "Fix one of:" >&2
-    echo "  - install Go (https://go.dev/dl/), then run: make build  (in the plugin root)" >&2
-    echo "  - install gh (https://cli.github.com/) and authenticate, then re-run setup" >&2
-    exit 127
-  fi
-fi
+"$SCRIPT_DIR/ensure-binary.sh"
 
 exec "$SCRIPT_DIR/run-usagebar.sh" setup "$@"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,6 +6,17 @@ min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"
 platforms = ["macos", "linux"]
 
+# Runs on every `herdr plugin install` (including reinstall/update — there is
+# no separate update command). Install replaces the whole managed directory
+# with a fresh checkout, which never carries the gitignored bin/usagebar, so
+# without this hook the meters, rate-limit cache, and statusLine bridge go
+# silently dead until the user runs `make build` by hand. If the hook fails
+# (offline, no Go, no gh/curl) the install aborts and the previous working
+# install is left untouched.
+# See https://github.com/senna-lang/herdr-agent-usage/issues/48
+[[build]]
+command = ["bash", "bin/ensure-binary.sh", "--in-tree"]
+
 [[events]]
 on = "pane.agent_status_changed"
 command = ["bash", "bin/run-status.sh"]


### PR DESCRIPTION
## Summary

- `herdr plugin install` (also the only update path — there's no separate update command) replaces the whole managed plugin directory with a fresh checkout, which never carries the gitignored `bin/usagebar`. The wrapper scripts then fail with `usagebar: binary not found` on stderr, which event hooks and statusLine consumers silently discard — sidebar meters, the rate-limit cache, and the Claude Code statusLine bridge go dead with no visible error until the user manually runs `make build`.
- Adds a `herdr-plugin.toml` `[[build]]` hook (supported by Herdr since v0.7.0, well under this plugin's `min_herdr_version = "0.7.4"`). Herdr runs `[[build]]` commands on every `herdr plugin install`/reinstall, before swapping the new checkout into place, and leaves the previous working install untouched if the hook fails.
- Extracts the existing build-or-download resolution logic into `bin/ensure-binary.sh` with three modes:
  - `--in-tree` (used by the build hook): guarantees *this* checkout has `bin/usagebar`. Deliberately ignores `$USAGEBAR_BIN`/PATH from the install-time shell, since those don't necessarily match the Herdr server's runtime environment — trusting them would silently reintroduce this same bug.
  - `--build` (used by `make build`): always compiles from source and fails hard, so a broken tree is reported instead of papered over with a stale release download.
  - default (used by `run-setup.sh`): resolves the binary the same way `run-usagebar.sh` does, as a fallback for installs that predate the build hook.
- Updates `README.md` to describe automatic provisioning at install time instead of only on first `setup` invocation.

## Test plan

- [x] `go vet ./...`, `go build ./...`, `go test ./...`, `gofmt -l .` all pass
- [x] Simulated a fresh checkout (rsync copy without the gitignored `bin/usagebar`) and ran `bin/ensure-binary.sh --in-tree` directly:
  - clean environment → builds successfully
  - `USAGEBAR_BIN` set in the install-time shell → still builds in-tree (does not skip)
  - a stub `usagebar` earlier on `PATH` → still builds in-tree (does not skip)
  - reproduced the original (pre-fix) guard logic against the same two cases to confirm it *would* have skipped the build, reintroducing #48
- [x] Version-mismatched install (older/unreleased manifest version) correctly falls back from the tag-matched release asset to `latest`
- [x] All provisioning routes unavailable (no `go`, `gh`, `curl`) → exits 127, no partial binary written, so `herdr plugin install` aborts and keeps the previous working install
- [x] `make build` still produces a working `bin/usagebar`
- [ ] Not yet verified end-to-end via the real `herdr plugin install senna-lang/herdr-agent-usage` command (requires this branch/tag to be reachable from GitHub); the above validates the script Herdr's build hook invokes, in isolation

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)