### PR TITLE
chore: Release v0.5.7

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.6"
+version = "0.5.7"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
## Summary

- Bump `herdr-plugin.toml` version to 0.5.7 to release #50 (build hook that provisions `bin/usagebar` automatically on install/update, fixing #48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)