### PR TITLE
fix(claude): show post-compaction estimate instead of stale usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 - OpenCode Go may show three windows (**5h / 7d / 30d**). Other providers show whichever usage windows their data sources make available.
 - Open pane **token share** is local activity share within the shortest window (including a **closed / other** bucket for usage outside open panes). It is not account quota attribution.
 - Sidebar meters update after the agent has **settled** (not while `working`), so they match the last completed turn. If the session cannot be resolved, the `$context` token is cleared rather than showing another session’s numbers.
+- After a Claude Code **compaction**, the meter shows `⛁ compacted (14k)` — the boundary’s own post-compaction estimate — instead of the stale pre-compact size, until the next completed turn reports real usage again.
 
 ```bash
 herdr plugin action invoke usagebar.open-limits

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -77,6 +77,24 @@ func formatTokenCount(tokens int) string {
 func UsageStatusCandidates(usage ContextUsage) []string {
 	tokenLabel := formatTokenCount(usage.ContextTokens)
 
+	if usage.Compacted {
+		// ContextTokens is the compact boundary's own estimate here, not an
+		// API-reported size — label it instead of dressing it up as a
+		// measurement.
+		var percent *int
+		if usage.WindowTokens != nil && *usage.WindowTokens > 0 {
+			p := int(math.Min(100, math.Round(float64(usage.ContextTokens)/float64(*usage.WindowTokens)*100)))
+			percent = &p
+		}
+		label := fmt.Sprintf("compacted (%s)", tokenLabel)
+		return []string{
+			fmt.Sprintf("%s %s", iconFor(percent), label),
+			label,
+			"compacted",
+			tokenLabel,
+		}
+	}
+
 	if usage.WindowTokens == nil {
 		return []string{fmt.Sprintf("⛁ %s", tokenLabel), tokenLabel}
 	}

--- a/internal/core/format_test.go
+++ b/internal/core/format_test.go
@@ -146,3 +146,45 @@ func TestFormatUsageStatus_Exactly1000OneDecimal(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestUsageStatusCandidates_Compacted(t *testing.T) {
+	u := usage(13_820, intPtr(200_000))
+	u.Compacted = true
+	got := UsageStatusCandidates(u)
+	want := []string{"⛁ compacted (14k)", "compacted (14k)", "compacted", "14k"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidates[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFormatUsageStatus_CompactedLabel(t *testing.T) {
+	u := usage(13_820, intPtr(200_000))
+	u.Compacted = true
+	if got := FormatUsageStatus(u, FormatUsageOptions{}); got != "⛁ compacted (14k)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_CompactedDegrades(t *testing.T) {
+	u := usage(13_820, intPtr(200_000))
+	u.Compacted = true
+	max := 9
+	if got := FormatUsageStatus(u, FormatUsageOptions{MaxColumns: &max}); got != "compacted" {
+		t.Fatalf("got %q", got)
+	}
+	max = 4
+	if got := FormatUsageStatus(u, FormatUsageOptions{MaxColumns: &max}); got != "14k" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_CompactedWithoutWindow(t *testing.T) {
+	if got := FormatUsageStatus(ContextUsage{ContextTokens: 13_820, Compacted: true}, FormatUsageOptions{}); got != "⛁ compacted (14k)" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -11,4 +11,7 @@ type ContextUsage struct {
 	ContextTokens int
 	// WindowTokens is the context window size if known. When nil, only the absolute token count is shown.
 	WindowTokens *int
+	// Compacted marks a post-compaction estimate (no real usage row yet):
+	// the display shows a "compacted" label instead of a measured size.
+	Compacted bool
 }

--- a/internal/providers/claude/tocontext.go
+++ b/internal/providers/claude/tocontext.go
@@ -13,8 +13,8 @@ func ToContextUsage(usage TranscriptUsage) core.ContextUsage {
 	contextTokens := ContextTokensOf(usage)
 	window := claudemodels.ContextWindowFor(usage.Model)
 	if window == nil {
-		return core.ContextUsage{ContextTokens: contextTokens}
+		return core.ContextUsage{ContextTokens: contextTokens, Compacted: usage.Compacted}
 	}
 	w := *window
-	return core.ContextUsage{ContextTokens: contextTokens, WindowTokens: &w}
+	return core.ContextUsage{ContextTokens: contextTokens, WindowTokens: &w, Compacted: usage.Compacted}
 }

--- a/internal/providers/claude/tocontext_test.go
+++ b/internal/providers/claude/tocontext_test.go
@@ -43,3 +43,13 @@ func TestToContextUsage_FableAndOpus1M(t *testing.T) {
 		t.Fatalf("opus %+v", opus)
 	}
 }
+
+func TestToContextUsage_CompactedPassthrough(t *testing.T) {
+	u := usage("claude-sonnet-5", 0)
+	u.InputTokens = 13_820
+	u.Compacted = true
+	got := ToContextUsage(u)
+	if !got.Compacted || got.ContextTokens != 13_820 {
+		t.Fatalf("got %+v, want compacted passthrough", got)
+	}
+}

--- a/internal/providers/claude/transcript.go
+++ b/internal/providers/claude/transcript.go
@@ -72,16 +72,26 @@ func totalTokensOf(usage TranscriptUsage) int {
 
 // ExtractLatestUsageFromLines walks jsonl lines from the end and returns the
 // latest assistant usage row with isSidechain=false and real token counts.
+// A compact_boundary newer than that row supersedes it: compaction writes no
+// assistant usage row of its own, so until the next turn the latest usage
+// still reports the pre-compact context; the boundary's postTokens is the
+// live size.
 func ExtractLatestUsageFromLines(lines []string) *TranscriptUsage {
+	seenCompactBoundary := false
+	compactPostTokens := 0
 	for i := len(lines) - 1; i >= 0; i-- {
 		raw := strings.TrimSpace(lines[i])
 		if raw == "" {
 			continue
 		}
 		var parsed struct {
-			Type        string `json:"type"`
-			IsSidechain bool   `json:"isSidechain"`
-			Message     *struct {
+			Type            string `json:"type"`
+			Subtype         string `json:"subtype"`
+			IsSidechain     bool   `json:"isSidechain"`
+			CompactMetadata *struct {
+				PostTokens *float64 `json:"postTokens"`
+			} `json:"compactMetadata"`
+			Message *struct {
 				Model string `json:"model"`
 				Usage *struct {
 					InputTokens              *float64 `json:"input_tokens"`
@@ -92,6 +102,17 @@ func ExtractLatestUsageFromLines(lines []string) *TranscriptUsage {
 			} `json:"message"`
 		}
 		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			continue
+		}
+		if parsed.Type == "system" && parsed.Subtype == "compact_boundary" {
+			// Only the newest boundary counts; older ones are already
+			// superseded by whatever followed them.
+			if !seenCompactBoundary {
+				seenCompactBoundary = true
+				if parsed.CompactMetadata != nil {
+					compactPostTokens = intOrZero(parsed.CompactMetadata.PostTokens)
+				}
+			}
 			continue
 		}
 		if parsed.Type != "assistant" || parsed.IsSidechain {
@@ -111,7 +132,17 @@ func ExtractLatestUsageFromLines(lines []string) *TranscriptUsage {
 		if totalTokensOf(candidate) == 0 {
 			continue
 		}
+		if compactPostTokens > 0 {
+			// Keep the model so the context-window lookup still works.
+			return &TranscriptUsage{Model: candidate.Model, InputTokens: compactPostTokens, Compacted: true}
+		}
 		return &candidate
+	}
+	if compactPostTokens > 0 {
+		// Boundary in the tail window but the pre-compact assistant row is
+		// not (e.g. cut off by tailScanBytes): report the size without a
+		// model rather than nothing.
+		return &TranscriptUsage{InputTokens: compactPostTokens, Compacted: true}
 	}
 	return nil
 }

--- a/internal/providers/claude/transcript_test.go
+++ b/internal/providers/claude/transcript_test.go
@@ -146,3 +146,59 @@ func TestResolveProfileForSession_EmptySessionID(t *testing.T) {
 		t.Fatal("empty session id must not match")
 	}
 }
+
+func compactBoundaryLine(postTokens int) string {
+	b, _ := json.Marshal(map[string]any{
+		"type": "system", "subtype": "compact_boundary",
+		"compactMetadata": map[string]any{
+			"trigger": "manual", "preTokens": 116631, "postTokens": postTokens,
+		},
+	})
+	return string(b)
+}
+
+func TestExtractLatestUsageFromLines_CompactBoundarySupersedesOlderUsage(t *testing.T) {
+	lines := []string{
+		assistantLine(false, "claude-sonnet-5", map[string]int{"input_tokens": 5, "cache_read_input_tokens": 116000, "output_tokens": 9}),
+		compactBoundaryLine(13820),
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.InputTokens != 13820 || got.CacheReadInputTokens != 0 || !got.Compacted {
+		t.Fatalf("got %+v, want compacted postTokens 13820", got)
+	}
+	if got.Model != "claude-sonnet-5" {
+		t.Fatalf("model=%q, want carried over for window lookup", got.Model)
+	}
+}
+
+func TestExtractLatestUsageFromLines_UsageAfterCompactWins(t *testing.T) {
+	lines := []string{
+		assistantLine(false, "", map[string]int{"input_tokens": 5, "cache_read_input_tokens": 116000, "output_tokens": 9}),
+		compactBoundaryLine(13820),
+		assistantLine(false, "", map[string]int{"input_tokens": 3, "cache_read_input_tokens": 15000, "output_tokens": 7}),
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.CacheReadInputTokens != 15000 || got.Compacted {
+		t.Fatalf("got %+v, want the post-compact assistant row", got)
+	}
+}
+
+func TestExtractLatestUsageFromLines_OnlyNewestBoundaryCounts(t *testing.T) {
+	lines := []string{
+		assistantLine(false, "", map[string]int{"input_tokens": 5, "cache_read_input_tokens": 116000, "output_tokens": 9}),
+		compactBoundaryLine(50000),
+		assistantLine(false, "", map[string]int{"input_tokens": 3, "cache_read_input_tokens": 60000, "output_tokens": 7}),
+		compactBoundaryLine(13820),
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.InputTokens != 13820 {
+		t.Fatalf("got %+v, want newest boundary's postTokens", got)
+	}
+}
+
+func TestExtractLatestUsageFromLines_BoundaryWithoutOlderUsage(t *testing.T) {
+	got := ExtractLatestUsageFromLines([]string{compactBoundaryLine(13820)})
+	if got == nil || got.InputTokens != 13820 || got.Model != "" || !got.Compacted {
+		t.Fatalf("got %+v, want model-less compacted postTokens", got)
+	}
+}

--- a/internal/providers/claude/types.go
+++ b/internal/providers/claude/types.go
@@ -10,4 +10,7 @@ type TranscriptUsage struct {
 	CacheReadInputTokens     int
 	CacheCreationInputTokens int
 	OutputTokens             int
+	// Compacted means InputTokens holds a compact_boundary's postTokens
+	// estimate rather than an API-reported usage row.
+	Compacted bool
 }


### PR DESCRIPTION
## What

After a Claude Code compaction, the sidebar meter kept showing the pre-compact context size. Compaction writes a `system/compact_boundary` entry into the transcript but no assistant usage row, so "latest assistant usage" still pointed at the old, now-wrong number until the next completed turn.

This teaches `ExtractLatestUsageFromLines` about compact boundaries: when the newest entry after the last usage row is a `compact_boundary`, the meter reports its `compactMetadata.postTokens` instead, flagged as `Compacted` and rendered as a labelled estimate rather than dressed up as a measurement.

## Behavior

| Situation | Before | After |
| --- | --- | --- |
| Turn completes, no compaction | `⛁ 58% (116k)` | `⛁ 58% (116k)` (unchanged) |
| Right after compaction | `⛁ 58% (116k)` (stale) | `⛁ compacted (14k)` |
| Narrow sidebar after compaction | stale percent | degrades to `compacted`, then `14k` |
| Next turn completes | correct again | correct again (boundary superseded by the new usage row) |

Details:

- Only the newest boundary counts; older ones are already superseded by whatever followed them.
- The pre-compact assistant row's model is carried over so the context-window lookup (and the icon's percent) still work.
- If the boundary is inside the tail window but the last assistant row was cut off by `tailScanBytes`, the estimate is reported without a model rather than showing nothing.

## Tests

- Transcript extraction: boundary supersedes older usage, post-compact usage wins over the boundary, only the newest boundary counts, boundary without an older usage row.
- Rendering: full label, narrow-sidebar degradation, unknown-window case, candidate order.
- `ToContextUsage` passthrough of the `Compacted` flag.

`gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass.

---

Related: #53 (both touch `UsageStatusCandidates` in `format.go`) and #54 (both touch `transcript.go`). The three are independent; whichever lands last will need a trivial rebase.
