### PR TITLE
feat(display): configurable sidebar context meter styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Created on first `usagebar.setup` (or when missing):
 [notify]
 enabled = true
 remaining_thresholds = [50, 20, 10, 5]
+
+[display]
+context_display = "percent"
+context_max_columns = 0
+context_icon_style = "database"
+context_level_tokens = false
+context_align = "left"
 ```
 
 `enabled = false` suppresses all Agent Usage toasts, including remaining-limit
@@ -187,6 +194,25 @@ warnings and update-available notices; statusLine summaries and cached limits
 continue to refresh. `remaining_thresholds` accepts remaining percentages from
 1 through 100 (for example `[30, 10]`); each threshold can notify once per
 window, from least to most severe.
+
+`[display]` controls the sidebar context meter:
+
+- `context_display` — `"percent"` renders `⛁ 65% (130k)`; `"fraction"` renders
+  `⛁ 130k/200k`.
+- `context_max_columns` — fixed width budget for the `$context` token; `0`
+  (default) estimates it from the sidebar width and pane label, which assumes
+  Herdr's default layout. Set it explicitly when custom sidebar rows put
+  `$context` next to a token other than the pane label.
+- `context_icon_style` — the meter's leading glyph: `"database"` (⛁, switching
+  to ⚠️ from 80%), `"gauge"` (▁▂▄▆█ by fill level), or `"none"`.
+- `context_level_tokens` — when `true`, a ≥60% meter moves to `$context_warm`
+  and a ≥85% meter to `$context_hot` (instead of `$context`), so sidebar rows
+  can color fill levels differently. Rows must then reference all three
+  tokens, e.g. `["$context", "$context_warm", "$context_hot"]` with per-token
+  colors; only one carries a value at a time.
+- `context_align` — `"right"` left-pads the meter with blank glyphs so its
+  right edge sits flush with the sidebar. Assumes a row of the form
+  `[agent, "$context"]` (the agent display name directly before the meter).
 
 ### Multiple Claude accounts
 

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -13,6 +13,7 @@ package core
 import (
 	"fmt"
 	"math"
+	"strings"
 )
 
 const warningThresholdPercent = 80
@@ -22,6 +23,12 @@ type FormatUsageOptions struct {
 	// MaxColumns is the maximum display width usable by the context token.
 	// When nil, returns the full representation.
 	MaxColumns *int
+	// Fraction renders "130k/200k" instead of "65% (130k)" when the window
+	// size is known ([display] context_display = "fraction" in plugin config).
+	Fraction bool
+	// IconStyle selects the leading glyph: "database" (⛁, ⚠️ from 80%),
+	// "gauge" (▁▂▄▆█ by fill level), or "none".
+	IconStyle string
 }
 
 // DisplayWidth approximates terminal cell width. Emoji and Misc Symbols count as 2;
@@ -61,9 +68,75 @@ func iconFor(percent *int) string {
 	return "⛁"
 }
 
+// gaugeGlyphs are Block Elements: a single font renders the whole set, so the
+// glyphs stay the same size (unlike the mixed-block circle set ○◔◑◕●).
+var gaugeGlyphs = []string{"▁", "▂", "▄", "▆", "█"}
+
+// GaugeLevelHotPercent is where the gauge shows a full block; it matches the
+// "hot" context-level threshold so glyph and color escalate together.
+const GaugeLevelHotPercent = 85
+
+// GaugeLevelWarmPercent is where the gauge reaches its second-highest glyph
+// and the context level turns "warm".
+const GaugeLevelWarmPercent = 60
+
+func gaugeFor(percent int) string {
+	switch {
+	case percent >= GaugeLevelHotPercent:
+		return gaugeGlyphs[4]
+	case percent >= GaugeLevelWarmPercent:
+		return gaugeGlyphs[3]
+	case percent >= 40:
+		return gaugeGlyphs[2]
+	case percent >= 20:
+		return gaugeGlyphs[1]
+	default:
+		return gaugeGlyphs[0]
+	}
+}
+
+// ContextLevelFor classifies window fill for level-token routing: "" (normal),
+// "warm", or "hot". Thresholds are shared with the gauge glyphs so color and
+// glyph escalate together.
+func ContextLevelFor(percent *int) string {
+	if percent == nil {
+		return ""
+	}
+	switch {
+	case *percent >= GaugeLevelHotPercent:
+		return "hot"
+	case *percent >= GaugeLevelWarmPercent:
+		return "warm"
+	}
+	return ""
+}
+
+// iconForStyle returns the leading glyph for the chosen style, or "" when the
+// style shows no icon (style "none", or a gauge with an unknown window).
+func iconForStyle(style string, percent *int) string {
+	switch style {
+	case "gauge":
+		if percent == nil {
+			return ""
+		}
+		return gaugeFor(*percent)
+	case "none":
+		return ""
+	default:
+		return iconFor(percent)
+	}
+}
+
 func formatTokenCount(tokens int) string {
 	if tokens < 1000 {
 		return fmt.Sprintf("%d", tokens)
+	}
+	if tokens >= 1_000_000 {
+		millions := float64(tokens) / 1_000_000
+		if millions < 10 {
+			return fmt.Sprintf("%.1fm", millions)
+		}
+		return fmt.Sprintf("%.0fm", millions)
 	}
 	thousands := float64(tokens) / 1000
 	if thousands < 10 {
@@ -72,30 +145,73 @@ func formatTokenCount(tokens int) string {
 	return fmt.Sprintf("%.0fk", thousands)
 }
 
+// UsagePercent returns the window fill percentage (capped at 100), or nil
+// when the window size is unknown.
+func UsagePercent(usage ContextUsage) *int {
+	if usage.WindowTokens == nil || *usage.WindowTokens <= 0 {
+		return nil
+	}
+	percent := int(math.Min(100, math.Round(float64(usage.ContextTokens)/float64(*usage.WindowTokens)*100)))
+	return &percent
+}
+
 // UsageStatusCandidates returns candidates in priority order (longest -> shortest).
 // The first element is the full representation.
 func UsageStatusCandidates(usage ContextUsage) []string {
+	return usageStatusCandidates(usage, false, "")
+}
+
+// withIcon prefixes label with the style's glyph; a style without a glyph
+// contributes no extra candidate.
+func withIcon(iconStyle string, percent *int, label string, shorter ...string) []string {
+	candidates := []string{label}
+	if icon := iconForStyle(iconStyle, percent); icon != "" {
+		candidates = []string{fmt.Sprintf("%s %s", icon, label), label}
+	}
+	return append(candidates, shorter...)
+}
+
+func usageStatusCandidates(usage ContextUsage, fraction bool, iconStyle string) []string {
 	tokenLabel := formatTokenCount(usage.ContextTokens)
+	percent := UsagePercent(usage)
 
-	if usage.WindowTokens == nil {
-		return []string{fmt.Sprintf("⛁ %s", tokenLabel), tokenLabel}
+	if percent == nil {
+		return withIcon(iconStyle, nil, tokenLabel)
 	}
 
-	window := *usage.WindowTokens
-	percent := int(math.Min(100, math.Round(float64(usage.ContextTokens)/float64(window)*100)))
-	percentLabel := fmt.Sprintf("%d%%", percent)
+	if fraction {
+		fractionLabel := fmt.Sprintf("%s/%s", tokenLabel, formatTokenCount(*usage.WindowTokens))
+		return withIcon(iconStyle, percent, fractionLabel, tokenLabel)
+	}
+	percentLabel := fmt.Sprintf("%d%%", *percent)
 	withTokens := fmt.Sprintf("%s (%s)", percentLabel, tokenLabel)
-	return []string{
-		fmt.Sprintf("%s %s", iconFor(&percent), withTokens),
-		withTokens,
-		percentLabel,
+	return withIcon(iconStyle, percent, withTokens, percentLabel)
+}
+
+// sidebarTokenSeparatorColumns is the " · " Herdr renders between sidebar row
+// tokens (herdr 0.7.5).
+const sidebarTokenSeparatorColumns = 3
+
+// alignPadRune fills the right-align gap. Braille Pattern Blank renders as an
+// empty cell but is not Unicode White_Space, so Herdr's token-value trim
+// leaves it alone (regular spaces get stripped).
+const alignPadRune = '⠀'
+
+// PadStatusRight left-pads status so that leftLabel + separator + status spans
+// exactly rowColumns, putting the meter's right edge flush with the sidebar.
+// Returns status unchanged when it already fills or overflows the row.
+func PadStatusRight(status string, leftLabelColumns, rowColumns int) string {
+	pad := rowColumns - leftLabelColumns - sidebarTokenSeparatorColumns - DisplayWidth(status)
+	if pad <= 0 {
+		return status
 	}
+	return strings.Repeat(string(alignPadRune), pad) + status
 }
 
 // FormatUsageStatus picks the longest candidate that fits in MaxColumns.
 // Falls back to the shortest if nothing fits.
 func FormatUsageStatus(usage ContextUsage, options FormatUsageOptions) string {
-	candidates := UsageStatusCandidates(usage)
+	candidates := usageStatusCandidates(usage, options.Fraction, options.IconStyle)
 	if len(candidates) == 0 {
 		return ""
 	}

--- a/internal/core/format_test.go
+++ b/internal/core/format_test.go
@@ -146,3 +146,106 @@ func TestFormatUsageStatus_Exactly1000OneDecimal(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestFormatUsageStatus_FractionFull(t *testing.T) {
+	got := FormatUsageStatus(usage(33_000, intPtr(200_000)), FormatUsageOptions{Fraction: true})
+	if got != "⛁ 33k/200k" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_FractionDegradesToCountAlone(t *testing.T) {
+	max := 5
+	got := FormatUsageStatus(usage(33_000, intPtr(200_000)), FormatUsageOptions{MaxColumns: &max, Fraction: true})
+	if got != "33k" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_FractionKeepsWarningIcon(t *testing.T) {
+	got := FormatUsageStatus(usage(160_000, intPtr(200_000)), FormatUsageOptions{Fraction: true})
+	if got != "⚠️ 160k/200k" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_FractionMillionWindow(t *testing.T) {
+	got := FormatUsageStatus(usage(33_000, intPtr(1_000_000)), FormatUsageOptions{Fraction: true})
+	if got != "⛁ 33k/1.0m" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_FractionNoWindowAbsolute(t *testing.T) {
+	got := FormatUsageStatus(usage(5_000, nil), FormatUsageOptions{Fraction: true})
+	if got != "⛁ 5.0k" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatUsageStatus_GaugeStyle(t *testing.T) {
+	window := 200_000
+	cases := map[int]string{
+		12_000:  "▁ 12k/200k",
+		55_000:  "▂ 55k/200k",
+		102_000: "▄ 102k/200k",
+		130_000: "▆ 130k/200k",
+		180_000: "█ 180k/200k",
+	}
+	for tokens, want := range cases {
+		usage := ContextUsage{ContextTokens: tokens, WindowTokens: &window}
+		got := FormatUsageStatus(usage, FormatUsageOptions{Fraction: true, IconStyle: "gauge"})
+		if got != want {
+			t.Fatalf("tokens=%d got %q want %q", tokens, got, want)
+		}
+	}
+}
+
+func TestFormatUsageStatus_GaugeUnknownWindowHasNoIcon(t *testing.T) {
+	got := FormatUsageStatus(ContextUsage{ContextTokens: 97_000}, FormatUsageOptions{Fraction: true, IconStyle: "gauge"})
+	if got != "97k" {
+		t.Fatalf("got %q want %q", got, "97k")
+	}
+}
+
+func TestFormatUsageStatus_NoneStyle(t *testing.T) {
+	window := 200_000
+	usage := ContextUsage{ContextTokens: 102_000, WindowTokens: &window}
+	got := FormatUsageStatus(usage, FormatUsageOptions{Fraction: true, IconStyle: "none"})
+	if got != "102k/200k" {
+		t.Fatalf("got %q want %q", got, "102k/200k")
+	}
+}
+
+func TestPadStatusRight(t *testing.T) {
+	// "claude"(6) + " · "(3) + "▄ 95k/200k"(10) = 19; row 30 → 11 pad cells
+	got := PadStatusRight("▄ 95k/200k", 6, 30)
+	if got != "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀▄ 95k/200k" {
+		t.Fatalf("got %q", got)
+	}
+	if DisplayWidth(got) != 30-6-3 {
+		t.Fatalf("padded width=%d, want %d", DisplayWidth(got), 30-6-3)
+	}
+}
+
+func TestPadStatusRight_NoRoomLeavesUnchanged(t *testing.T) {
+	if got := PadStatusRight("▄ 95k/200k", 20, 30); got != "▄ 95k/200k" {
+		t.Fatalf("got %q", got)
+	}
+	if got := PadStatusRight("▄ 95k/200k", 17, 30); got != "▄ 95k/200k" {
+		t.Fatalf("exact fit: got %q", got)
+	}
+}
+
+func TestContextLevelFor(t *testing.T) {
+	if got := ContextLevelFor(nil); got != "" {
+		t.Fatalf("nil percent: got %q", got)
+	}
+	cases := map[int]string{0: "", 59: "", 60: "warm", 84: "warm", 85: "hot", 100: "hot"}
+	for percent, want := range cases {
+		p := percent
+		if got := ContextLevelFor(&p); got != want {
+			t.Fatalf("percent=%d got %q want %q", percent, got, want)
+		}
+	}
+}

--- a/internal/herdrcli/herdr.go
+++ b/internal/herdrcli/herdr.go
@@ -339,6 +339,31 @@ func GetSidebarWidthColumns(paneID string) *int {
 	return &v
 }
 
+// GetAgentDisplayName returns what Herdr's sidebar `agent` token renders for
+// the pane: the agent's custom name when set (herdr agent rename), else the
+// agent kind ("claude"). Empty when the pane has no agent entry.
+func GetAgentDisplayName(paneID string) string {
+	stdout, ok := spawnHerdr("agent", "get", paneID)
+	if !ok || stdout == "" {
+		return ""
+	}
+	var parsed struct {
+		Result *struct {
+			Agent *struct {
+				Agent *string `json:"agent"`
+				Name  *string `json:"name"`
+			} `json:"agent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil || parsed.Result == nil || parsed.Result.Agent == nil {
+		return ""
+	}
+	if name := deref(parsed.Result.Agent.Name); name != "" {
+		return name
+	}
+	return deref(parsed.Result.Agent.Agent)
+}
+
 // SetMetadataToken reports one named presentation token for use in configurable
 // Herdr 0.7.4+ sidebar rows (for example $limit).
 func SetMetadataToken(paneID, source, name, value string) bool {

--- a/internal/setup/pluginconfig.go
+++ b/internal/setup/pluginconfig.go
@@ -29,12 +29,35 @@ type PluginConfig struct {
 	// ClaudeProfiles are the configured [[claude.profiles]] entries (unresolved).
 	// Empty means the single implicit "claude" profile is synthesized downstream.
 	ClaudeProfiles []claude.ProfileSpec
+	// ContextDisplay selects the sidebar context meter style:
+	// "percent" (⛁ 65% (130k)) or "fraction" (⛁ 130k/200k).
+	ContextDisplay string
+	// ContextMaxColumns fixes the width budget for the context token.
+	// 0 estimates from sidebar width and pane label, which assumes Herdr's
+	// default sidebar layout; set it explicitly when custom sidebar rows put
+	// $context next to a token other than the pane label.
+	ContextMaxColumns int
+	// ContextIconStyle selects the meter's leading glyph: "database"
+	// (⛁, ⚠️ from 80%), "gauge" (▁▂▄▆█ by fill level), or "none".
+	ContextIconStyle string
+	// ContextLevelTokens routes the meter to $context_warm (≥60%) or
+	// $context_hot (≥85%) instead of $context, so herdr sidebar rows can
+	// style fill levels with different colors. Rows must then reference all
+	// three tokens, which is why this is opt-in.
+	ContextLevelTokens bool
+	// ContextAlign "right" left-pads the meter with blank glyphs so its right
+	// edge sits flush with the sidebar. Assumes a sidebar row of the form
+	// [agent, $context...] (the agent display name directly before the meter).
+	ContextAlign string
 }
 
 // DefaultPluginConfig is the seed default.
 var DefaultPluginConfig = PluginConfig{
 	RemainingThresholds: append([]int(nil), DefaultRemainingThresholds...),
 	NotifyEnabled:       true,
+	ContextDisplay:      "percent",
+	ContextIconStyle:    "database",
+	ContextAlign:        "left",
 }
 
 // pluginConfigWire mirrors the on-disk TOML shape for decoding.
@@ -43,6 +66,13 @@ type pluginConfigWire struct {
 		Enabled             *bool `toml:"enabled"`
 		RemainingThresholds []int `toml:"remaining_thresholds"`
 	} `toml:"notify"`
+	Display struct {
+		ContextDisplay     string `toml:"context_display"`
+		ContextMaxColumns  int    `toml:"context_max_columns"`
+		ContextIconStyle   string `toml:"context_icon_style"`
+		ContextLevelTokens bool   `toml:"context_level_tokens"`
+		ContextAlign       string `toml:"context_align"`
+	} `toml:"display"`
 	Claude struct {
 		Profiles []profileWire `toml:"profiles"`
 	} `toml:"claude"`
@@ -87,6 +117,18 @@ func DefaultPluginConfigTOML(config PluginConfig) string {
 	if config.NotifyEnabled {
 		enabled = "true"
 	}
+	contextDisplay := config.ContextDisplay
+	if contextDisplay == "" {
+		contextDisplay = DefaultPluginConfig.ContextDisplay
+	}
+	contextIconStyle := config.ContextIconStyle
+	if contextIconStyle == "" {
+		contextIconStyle = DefaultPluginConfig.ContextIconStyle
+	}
+	contextAlign := config.ContextAlign
+	if contextAlign == "" {
+		contextAlign = DefaultPluginConfig.ContextAlign
+	}
 	return strings.Join([]string{
 		"# Agent Usage (usagebar) plugin config",
 		"# Path: herdr plugin config-dir usagebar",
@@ -95,6 +137,21 @@ func DefaultPluginConfigTOML(config PluginConfig) string {
 		"enabled = " + enabled,
 		"# remaining % thresholds that may fire a toast (once per window/bucket)",
 		"remaining_thresholds = [" + thresholds + "]",
+		"",
+		"[display]",
+		"# context meter style: \"percent\" (⛁ 65% (130k)) or \"fraction\" (⛁ 130k/200k)",
+		"context_display = \"" + contextDisplay + "\"",
+		"# fixed width budget for the context token; 0 estimates from sidebar",
+		"# width and pane label (assumes Herdr's default sidebar layout)",
+		"context_max_columns = " + strconv.Itoa(config.ContextMaxColumns),
+		"# leading glyph: \"database\" (⛁, ⚠️ from 80%), \"gauge\" (▁▂▄▆█ by fill), \"none\"",
+		"context_icon_style = \"" + contextIconStyle + "\"",
+		"# route the meter to $context_warm (≥60%) / $context_hot (≥85%) so sidebar",
+		"# rows can color fill levels; rows must reference all three tokens",
+		"context_level_tokens = " + strconv.FormatBool(config.ContextLevelTokens),
+		"# \"right\" pads the meter flush with the sidebar's right edge (assumes",
+		"# a sidebar row of [agent, $context...])",
+		"context_align = \"" + contextAlign + "\"",
 		"",
 		"# Multi-account Claude: uncomment and add one block per account.",
 		"# Absence of any profile keeps the single default account (fully backward",
@@ -140,6 +197,9 @@ func ParsePluginConfigTOML(raw string) PluginConfig {
 	cfg := PluginConfig{
 		NotifyEnabled:       DefaultPluginConfig.NotifyEnabled,
 		RemainingThresholds: append([]int(nil), DefaultPluginConfig.RemainingThresholds...),
+		ContextDisplay:      DefaultPluginConfig.ContextDisplay,
+		ContextIconStyle:    DefaultPluginConfig.ContextIconStyle,
+		ContextAlign:        DefaultPluginConfig.ContextAlign,
 	}
 	var wire pluginConfigWire
 	if _, err := toml.Decode(raw, &wire); err != nil {
@@ -150,6 +210,19 @@ func ParsePluginConfigTOML(raw string) PluginConfig {
 	}
 	if thr, ok := validThresholds(wire.Notify.RemainingThresholds); ok {
 		cfg.RemainingThresholds = thr
+	}
+	if wire.Display.ContextDisplay == "percent" || wire.Display.ContextDisplay == "fraction" {
+		cfg.ContextDisplay = wire.Display.ContextDisplay
+	}
+	if wire.Display.ContextMaxColumns >= 0 && wire.Display.ContextMaxColumns <= 200 {
+		cfg.ContextMaxColumns = wire.Display.ContextMaxColumns
+	}
+	if wire.Display.ContextIconStyle == "database" || wire.Display.ContextIconStyle == "gauge" || wire.Display.ContextIconStyle == "none" {
+		cfg.ContextIconStyle = wire.Display.ContextIconStyle
+	}
+	cfg.ContextLevelTokens = wire.Display.ContextLevelTokens
+	if wire.Display.ContextAlign == "left" || wire.Display.ContextAlign == "right" {
+		cfg.ContextAlign = wire.Display.ContextAlign
 	}
 	for _, p := range wire.Claude.Profiles {
 		cfg.ClaudeProfiles = append(cfg.ClaudeProfiles, claude.ProfileSpec{

--- a/internal/setup/pluginconfig_test.go
+++ b/internal/setup/pluginconfig_test.go
@@ -83,8 +83,8 @@ func TestSeedPluginConfigIfMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !contains(string(text), "[notify]") {
-		t.Fatal("missing [notify]")
+	if !contains(string(text), "[notify]") || !contains(string(text), "[display]") {
+		t.Fatal("missing config section")
 	}
 	if !LoadPluginConfig(dir).NotifyEnabled {
 		t.Fatal("expected enabled")
@@ -101,4 +101,41 @@ func contains(s, sub string) bool {
 			}
 			return false
 		}())
+}
+
+func TestParsePluginConfigTOML_Display(t *testing.T) {
+	cfg := ParsePluginConfigTOML(`
+[display]
+context_display = "fraction"
+context_max_columns = 20
+context_icon_style = "gauge"
+context_level_tokens = true
+context_align = "right"
+`)
+	if cfg.ContextDisplay != "fraction" || cfg.ContextMaxColumns != 20 ||
+		cfg.ContextIconStyle != "gauge" || !cfg.ContextLevelTokens || cfg.ContextAlign != "right" {
+		t.Fatalf("display config = %+v", cfg)
+	}
+}
+
+func TestParsePluginConfigTOML_DisplayDefaults(t *testing.T) {
+	cfg := ParsePluginConfigTOML("")
+	if cfg.ContextDisplay != "percent" || cfg.ContextMaxColumns != 0 ||
+		cfg.ContextIconStyle != "database" || cfg.ContextLevelTokens || cfg.ContextAlign != "left" {
+		t.Fatalf("display defaults = %+v", cfg)
+	}
+}
+
+func TestParsePluginConfigTOML_DisplayInvalidKeepsDefaults(t *testing.T) {
+	cfg := ParsePluginConfigTOML(`
+[display]
+context_display = "bogus"
+context_max_columns = 9999
+context_icon_style = "sparkles"
+context_align = "center"
+`)
+	if cfg.ContextDisplay != "percent" || cfg.ContextMaxColumns != 0 ||
+		cfg.ContextIconStyle != "database" || cfg.ContextAlign != "left" {
+		t.Fatalf("display validation = %+v", cfg)
+	}
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers"
 	claudeprovider "github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/setup"
 )
 
 // findClaudeProfile looks up one resolved profile by provider id.
@@ -217,7 +218,9 @@ func RunUpdate(force bool) {
 		// guess into the wrong account's limits/tokens.
 		writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
 		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
-		writeMetadataToken(pane.Tokens, paneID, "context", "", force)
+		for _, name := range contextTokenNames {
+			writeMetadataToken(pane.Tokens, paneID, name, "", force)
+		}
 		return
 	}
 
@@ -290,14 +293,86 @@ func RunUpdate(force bool) {
 	}
 
 	if usage == nil {
-		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
+		for _, name := range contextTokenNames {
+			value := ""
+			if name == "context" {
+				value = contextPrefix
+			}
+			writeMetadataToken(pane.Tokens, paneID, name, value, force)
+		}
 		return
 	}
 
+	pluginCfg := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(map[string]string{
+		"HERDR_PLUGIN_CONFIG_DIR": os.Getenv("HERDR_PLUGIN_CONFIG_DIR"),
+		"XDG_CONFIG_HOME":         os.Getenv("XDG_CONFIG_HOME"),
+	}))
+	maxCols := contextMaxColumns(pluginCfg.ContextMaxColumns, paneID, pane.RowLabel)
+	maxCols = reserveColumnsFor(maxCols, contextPrefix)
+	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{
+		MaxColumns: maxCols,
+		Fraction:   pluginCfg.ContextDisplay == "fraction",
+		IconStyle:  pluginCfg.ContextIconStyle,
+	})
+	statusText = combineLimitAndContext(contextPrefix, statusText)
+	if pluginCfg.ContextAlign == "right" && statusText != "" {
+		statusText = alignStatusRight(statusText, paneID, *pane.Agent)
+	}
+	target := contextTokenTarget(pluginCfg.ContextLevelTokens, core.UsagePercent(*usage))
+	for _, name := range contextTokenNames {
+		value := ""
+		if name == target {
+			value = statusText
+		}
+		writeMetadataToken(pane.Tokens, paneID, name, value, force)
+	}
+}
+
+// contextTokenNames are every token the meter may occupy; each write fills the
+// target and clears the rest (deduplicated, so steady state costs nothing).
+var contextTokenNames = []string{"context", "context_warm", "context_hot"}
+
+// contextTokenTarget picks the metadata token that carries the meter. With
+// level tokens enabled, warm/hot fills move to $context_warm / $context_hot so
+// herdr sidebar rows can style them differently.
+func contextTokenTarget(levelTokens bool, percent *int) string {
+	if !levelTokens {
+		return "context"
+	}
+	if level := core.ContextLevelFor(percent); level != "" {
+		return "context_" + level
+	}
+	return "context"
+}
+
+// sidebarRowOverheadColumns is what Herdr 0.7.5 reserves around an
+// agents-sidebar row (left indent + right margin): a row's usable content
+// width is the sidebar width minus this. Measured empirically at sidebar
+// width 36 → 30 usable columns.
+const sidebarRowOverheadColumns = 6
+
+// alignStatusRight pads the meter so its right edge lands on the sidebar's
+// right edge, assuming the row renders as `<agent name> · <meter>`.
+func alignStatusRight(status, paneID, agentName string) string {
+	label := herdrcli.GetAgentDisplayName(paneID)
+	if label == "" {
+		label = agentName
+	}
 	liveWidth := herdrcli.GetSidebarWidthColumns(paneID)
 	sidebarW := core.ResolveSidebarWidth(liveWidth, core.ResolveConfigSidebarWidth())
-	maxCols := core.EstimateStatusMaxColumns(&sidebarW, pane.RowLabel)
-	maxCols = reserveColumnsFor(maxCols, contextPrefix)
-	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{MaxColumns: maxCols})
-	writeMetadataToken(pane.Tokens, paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
+	return core.PadStatusRight(status, core.DisplayWidth(label), sidebarW-sidebarRowOverheadColumns)
+}
+
+// contextMaxColumns picks the width budget for the context token: the
+// configured fixed budget when set, else the estimate from sidebar width and
+// pane label. The estimate assumes Herdr's default sidebar layout (label and
+// status share a line); custom rows that place $context elsewhere should set
+// display.context_max_columns.
+func contextMaxColumns(configured int, paneID string, rowLabel *string) *int {
+	if configured > 0 {
+		return &configured
+	}
+	liveWidth := herdrcli.GetSidebarWidthColumns(paneID)
+	sidebarW := core.ResolveSidebarWidth(liveWidth, core.ResolveConfigSidebarWidth())
+	return core.EstimateStatusMaxColumns(&sidebarW, rowLabel)
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -295,3 +295,29 @@ func TestReserveColumnsFor(t *testing.T) {
 		t.Fatal("empty prefix must not shrink the budget")
 	}
 }
+
+func TestContextMaxColumns_ConfiguredOverridesEstimate(t *testing.T) {
+	got := contextMaxColumns(20, "w1:p1", stringPtr("claude: some very long pane label"))
+	if got == nil || *got != 20 {
+		t.Fatalf("got %v, want 20", got)
+	}
+}
+
+func TestContextTokenTarget(t *testing.T) {
+	pct := func(n int) *int { return &n }
+	if got := contextTokenTarget(false, pct(90)); got != "context" {
+		t.Fatalf("disabled: got %q", got)
+	}
+	if got := contextTokenTarget(true, nil); got != "context" {
+		t.Fatalf("nil percent: got %q", got)
+	}
+	if got := contextTokenTarget(true, pct(59)); got != "context" {
+		t.Fatalf("59%%: got %q", got)
+	}
+	if got := contextTokenTarget(true, pct(60)); got != "context_warm" {
+		t.Fatalf("60%%: got %q", got)
+	}
+	if got := contextTokenTarget(true, pct(85)); got != "context_hot" {
+		t.Fatalf("85%%: got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a `[display]` section to the plugin config controlling how the sidebar context meter renders. Every key defaults to today's behavior — an existing `config.toml` without a `[display]` section renders exactly as before.

```toml
[display]
context_display = "percent"      # or "fraction": ⛁ 130k/200k
context_max_columns = 0          # fixed width budget; 0 keeps the sidebar estimate
context_icon_style = "database"  # or "gauge" (▁▂▄▆█ by fill), or "none"
context_level_tokens = false     # route ≥60% / ≥85% through $context_warm / $context_hot
context_align = "left"           # or "right": pad the meter flush with the sidebar edge
```

## Why

- `fraction` — some of us parse `130k/200k` faster than `65% (130k)`, and it's narrower.
- `gauge` — a fill-level glyph gives an at-a-glance read across many panes; Block Elements were chosen over the circle set (○◔◑◕●) because a single font renders all five at the same size.
- `context_level_tokens` — herdr styles sidebar tokens per token name, so routing warm/hot fills through `$context_warm` / `$context_hot` lets rows color the meter by urgency. The gauge and level thresholds are shared so glyph and color escalate together. Opt-in because rows must then reference all three tokens (only one carries a value at a time; the others are cleared, deduplicated by the existing `ShouldWriteToken` path so steady state costs nothing).
- `context_align = "right"` — pads with Braille Pattern Blank, which renders as an empty cell but is not Unicode `White_Space`, so herdr's token-value trim leaves it alone.
- `context_max_columns` — the built-in width estimate assumes herdr's default sidebar layout; custom rows that place `$context` elsewhere can set an explicit budget.

Also adds `formatTokenCount` support for `m` units (`33k/1.0m` instead of `33k/1000k`) and `herdrcli.GetAgentDisplayName` (used to size the right-align padding against the agent's rendered name).

## Tests

Formatting (fraction, gauge levels, none style, million windows, right-pad width math, level classification), config parsing (values, defaults, invalid values fall back), seed content, and the update-side token routing (`contextTokenTarget`, configured width override). `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass.

README documents the new keys under "Plugin config".

Happy to split this further (e.g. level tokens or alignment into their own PRs) if you'd prefer smaller pieces — CONTRIBUTING suggests an issue first for config changes, so consider this the written-up proposal; no hard feelings if parts of it don't fit the project's direction.

---

Related: #52 (same candidates function in `format.go`) and #54 (both touch the `RunUpdate` tail). Independent PRs; whichever lands last will need a trivial rebase.
