### PR TITLE
fix(claude): resolve usage without a session id via cwd fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 - Auto-refreshes every **15s**. Press **`r`** to refresh, **`q`** to quit.
 - OpenCode Go may show three windows (**5h / 7d / 30d**). Other providers show whichever usage windows their data sources make available.
 - Open pane **token share** is local activity share within the shortest window (including a **closed / other** bucket for usage outside open panes). It is not account quota attribution.
-- Sidebar meters update after the agent has **settled** (not while `working`), so they match the last completed turn. If the session cannot be resolved, the `$context` token is cleared rather than showing another session’s numbers.
+- Sidebar meters update after each completed assistant turn — including while the agent is still `working`, so long runs stay current. If the session cannot be resolved once the agent has **settled**, the `$context` token is cleared rather than showing another session’s numbers; a transient resolution failure mid-run keeps the last good value instead of blanking the meter.
 
 ```bash
 herdr plugin action invoke usagebar.open-limits

--- a/internal/providers/claude/provider.go
+++ b/internal/providers/claude/provider.go
@@ -1,6 +1,7 @@
 /**
  * UsageProvider for Claude Code.
- * Uses the UUID from herdr's agent_session (kind === "id") as the session key.
+ * Uses the UUID from herdr's agent_session (kind === "id") as the session key,
+ * falling back to the newest transcript for the pane's cwd.
  */
 package claude
 
@@ -16,11 +17,15 @@ var Provider = provider.FuncProvider{
 }
 
 func resolveClaudeUsage(input provider.UsageResolveInput) *core.ContextUsage {
-	session := input.Session
-	if session == nil || session.Kind != "id" || session.Value == "" {
-		return nil
+	var transcript *TranscriptUsage
+	if sid := provider.SessionID(input); sid != nil {
+		transcript = ResolveUsageForSession(*sid)
 	}
-	transcript := ResolveUsageForSession(session.Value)
+	// No session ID (snatched/adopted panes) or its transcript is gone: follow
+	// the most recently active session in the pane's cwd, like codex does.
+	if transcript == nil && input.Cwd != nil {
+		transcript = ResolveLatestUsageForCwd(*input.Cwd)
+	}
 	if transcript == nil {
 		return nil
 	}

--- a/internal/providers/claude/provider_test.go
+++ b/internal/providers/claude/provider_test.go
@@ -4,7 +4,10 @@
 package claude
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 )
@@ -33,5 +36,22 @@ func TestProvider_NullCases(t *testing.T) {
 		Session: &provider.AgentSession{Kind: "id", Value: "00000000-0000-0000-0000-000000000000"},
 	}) != nil {
 		t.Fatal("expected nil for unknown UUID")
+	}
+}
+
+func TestProvider_FallsBackToCwdWhenSessionMissing(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("CLAUDE_PROJECTS_ROOT", root)
+	dir := filepath.Join(root, "-work-proj")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := assistantLine(false, "claude-sonnet-5", map[string]int{"input_tokens": 42, "output_tokens": 1})
+	writeTranscript(t, filepath.Join(dir, "s.jsonl"), line, time.Now())
+
+	cwd := "/work/proj"
+	usage := Provider.ResolveUsage(provider.UsageResolveInput{Session: nil, Cwd: &cwd})
+	if usage == nil || usage.ContextTokens != 42 {
+		t.Fatalf("usage=%+v, want context 42 via cwd fallback", usage)
 	}
 }

--- a/internal/providers/claude/transcript.go
+++ b/internal/providers/claude/transcript.go
@@ -132,7 +132,66 @@ func ResolveUsageForSession(sessionID string) *TranscriptUsage {
 // ResolveUsageForSessionIn is ResolveUsageForSession scoped to an explicit
 // projects root.
 func ResolveUsageForSessionIn(root, sessionID string) *TranscriptUsage {
-	path := findSessionFileIn(root, sessionID)
+	return usageFromTranscript(findSessionFileIn(root, sessionID))
+}
+
+// EncodeProjectDir returns the ~/.claude/projects entry name for a cwd:
+// every non-alphanumeric character becomes "-".
+func EncodeProjectDir(cwd string) string {
+	out := []byte(cwd)
+	for i, c := range out {
+		isAlnum := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !isAlnum {
+			out[i] = '-'
+		}
+	}
+	return string(out)
+}
+
+// findLatestTranscriptForCwdIn returns the most recently modified transcript
+// in cwd's project directory under root, or empty.
+func findLatestTranscriptForCwdIn(root, cwd string) string {
+	if root == "" || cwd == "" {
+		return ""
+	}
+	dir := filepath.Join(root, EncodeProjectDir(cwd))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	newest := ""
+	var newestMod int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if mod := info.ModTime().UnixNano(); newest == "" || mod > newestMod {
+			newest = filepath.Join(dir, e.Name())
+			newestMod = mod
+		}
+	}
+	return newest
+}
+
+// ResolveLatestUsageForCwd resolves usage from the newest transcript whose
+// project directory matches cwd, under the default projects root. Fallback
+// for panes where herdr has no session ID (or the ID's transcript is gone);
+// with several sessions in one cwd it follows the most recently active one.
+func ResolveLatestUsageForCwd(cwd string) *TranscriptUsage {
+	return ResolveLatestUsageForCwdIn(projectsRoot(), cwd)
+}
+
+// ResolveLatestUsageForCwdIn is ResolveLatestUsageForCwd scoped to an explicit
+// projects root, so a multi-profile caller can search one profile's root.
+func ResolveLatestUsageForCwdIn(root, cwd string) *TranscriptUsage {
+	return usageFromTranscript(findLatestTranscriptForCwdIn(root, cwd))
+}
+
+func usageFromTranscript(path string) *TranscriptUsage {
 	if path == "" {
 		return nil
 	}

--- a/internal/providers/claude/transcript_test.go
+++ b/internal/providers/claude/transcript_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func assistantLine(isSidechain bool, model string, usage map[string]int) string {
@@ -144,5 +145,52 @@ func TestResolveProfileForSession_NoMatchRefuses(t *testing.T) {
 func TestResolveProfileForSession_EmptySessionID(t *testing.T) {
 	if _, ok := ResolveProfileForSession("", map[string]string{"claude": t.TempDir()}); ok {
 		t.Fatal("empty session id must not match")
+	}
+}
+
+func TestEncodeProjectDir(t *testing.T) {
+	cases := map[string]string{
+		"/home/user/tmp/box.like_x": "-home-user-tmp-box-like-x",
+		"/repo/.worktrees/cel-1pky": "-repo--worktrees-cel-1pky",
+	}
+	for in, want := range cases {
+		if got := EncodeProjectDir(in); got != want {
+			t.Fatalf("EncodeProjectDir(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveLatestUsageForCwd_PicksNewestTranscript(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("CLAUDE_PROJECTS_ROOT", root)
+	dir := filepath.Join(root, "-work-proj")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := assistantLine(false, "claude-sonnet-5", map[string]int{"input_tokens": 100, "output_tokens": 1})
+	fresh := assistantLine(false, "claude-sonnet-5", map[string]int{"input_tokens": 999, "output_tokens": 1})
+	writeTranscript(t, filepath.Join(dir, "aaa.jsonl"), old, time.Now().Add(-time.Hour))
+	writeTranscript(t, filepath.Join(dir, "bbb.jsonl"), fresh, time.Now())
+
+	usage := ResolveLatestUsageForCwd("/work/proj")
+	if usage == nil || usage.InputTokens != 999 {
+		t.Fatalf("usage=%+v, want newest transcript (input 999)", usage)
+	}
+}
+
+func TestResolveLatestUsageForCwd_NoProjectDir(t *testing.T) {
+	t.Setenv("CLAUDE_PROJECTS_ROOT", t.TempDir())
+	if usage := ResolveLatestUsageForCwd("/no/such/cwd"); usage != nil {
+		t.Fatalf("usage=%+v, want nil", usage)
+	}
+}
+
+func writeTranscript(t *testing.T, path, line string, mtime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -165,7 +165,9 @@ func writeMetadataTokenWith(writer metadataTokenWriter, current map[string]strin
 }
 
 // RunUpdate resolves usage for HERDR_PANE_ID and updates its sidebar tokens.
-// force=true (plugin action) updates even while working.
+// Working panes update too (a fresh pane may never have settled yet); the only
+// thing a working pane cannot do is clear a previously-written context value,
+// so a transiently unresolvable session mid-run keeps its last good meter.
 func RunUpdate(force bool) {
 	paneID := os.Getenv("HERDR_PANE_ID")
 	if paneID == "" {
@@ -182,9 +184,7 @@ func RunUpdate(force bool) {
 		return
 	}
 
-	if pane.AgentStatus != nil && !isSettledStatus(*pane.AgentStatus) && !force {
-		return
-	}
+	settled := pane.AgentStatus == nil || isSettledStatus(*pane.AgentStatus)
 
 	// Row 1 stands in for Herdr's built-in `tab`/`pane` tokens, which render
 	// blank whenever a tab keeps its auto-assigned numeric label and the
@@ -214,10 +214,14 @@ func RunUpdate(force bool) {
 	providerID, resolved := limits.BuildClaudePaneProviderResolver(claudeProfiles)(snapshot)
 	if !resolved {
 		// Cannot tell which account this pane belongs to: clear rather than
-		// guess into the wrong account's limits/tokens.
-		writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
-		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
-		writeMetadataToken(pane.Tokens, paneID, "context", "", force)
+		// guess into the wrong account's limits/tokens — but only once the
+		// pane has settled, so a mid-run resolution hiccup keeps the last
+		// good values.
+		if settled || force {
+			writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
+			writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
+			writeMetadataToken(pane.Tokens, paneID, "context", "", force)
+		}
 		return
 	}
 
@@ -271,8 +275,18 @@ func RunUpdate(force bool) {
 	// account's context display doesn't fall back to ~/.claude/projects.
 	var usage *core.ContextUsage
 	if *pane.Agent == "claude" {
-		if profile, ok := findClaudeProfile(claudeProfiles, providerID); ok && sid != nil {
-			if transcript := claudeprovider.ResolveUsageForSessionIn(profile.ProjectsRoot, *sid); transcript != nil {
+		if profile, ok := findClaudeProfile(claudeProfiles, providerID); ok {
+			var transcript *claudeprovider.TranscriptUsage
+			if sid != nil {
+				transcript = claudeprovider.ResolveUsageForSessionIn(profile.ProjectsRoot, *sid)
+			}
+			// No session ID (snatched/adopted panes) or its transcript is
+			// gone: follow the most recently active session in the pane's
+			// cwd, like codex does — still scoped to this profile's root.
+			if transcript == nil && cwd != nil {
+				transcript = claudeprovider.ResolveLatestUsageForCwdIn(profile.ProjectsRoot, *cwd)
+			}
+			if transcript != nil {
 				u := claudeprovider.ToContextUsage(*transcript)
 				usage = &u
 			}
@@ -290,7 +304,9 @@ func RunUpdate(force bool) {
 	}
 
 	if usage == nil {
-		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
+		if settled || force {
+			writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
+		}
 		return
 	}
 


### PR DESCRIPTION
## What

Two gaps left panes with a blank or stale context meter:

1. **Panes without a session id never resolve.** When herdr has no `agent_session` for a pane (e.g. a pane whose agent was adopted after start), the Claude provider bailed out immediately. Now it falls back to the most recently modified transcript in the pane's cwd project directory (`~/.claude/projects/<encoded-cwd>/`) — the same approach the codex provider already uses for its session fallback. In the profile-aware path in `RunUpdate` the fallback stays scoped to the resolved profile's own projects root, so multi-account setups never read another account's transcripts.
2. **Working panes never update.** `RunUpdate` returned early while `agent_status` was `working`, so a pane that had not settled since the plugin started showed nothing for the whole run — precisely when you most want to watch context grow. Now working panes update from the latest complete assistant row. The one thing a working pane cannot do is *clear* a previously-written value: a transient mid-run resolution failure keeps the last good meter instead of blanking it, and the ambiguous-profile clear path is likewise gated on settled.

## Behavior

| Situation | Before | After |
| --- | --- | --- |
| Pane with session id, settled | works | works (unchanged) |
| Pane without session id | meter blank forever | follows newest transcript in the pane's cwd |
| Long-running turn | meter frozen at previous turn | live meter as usage rows land |
| Session transiently unresolvable mid-run | (no writes while working) | keeps last good meter |
| Unresolvable once settled | cleared | cleared (unchanged) |

`EncodeProjectDir` mirrors Claude Code's project-directory encoding (every non-alphanumeric byte becomes `-`). With several sessions in one cwd the fallback follows the most recently active one, which matches what the sidebar should show for the pane's foreground activity.

## Tests

Cwd fallback through the registry provider, newest-transcript selection, missing project dir, and the encoding table. README's note about meters only updating after settle is updated to match. `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass.

---

Related: #52 and #53 — independent, but they share files (`transcript.go` / `RunUpdate`), so expect a trivial conflict for whichever merges last.
