### PR TITLE
fix(claude): Fable 5 defaults to a 200k window

### DIFF
--- a/internal/claude/modelwindows.go
+++ b/internal/claude/modelwindows.go
@@ -22,7 +22,6 @@ var contextWindowTokens = map[string]int{
 	// --- 1M (Claude Code paid default / OpenCode anthropic catalog) ---
 	"claude-sonnet-5":   1_000_000,
 	"claude-opus-5":     1_000_000,
-	"claude-fable-5":    1_000_000,
 	"claude-opus-4-8":   1_000_000,
 	"claude-opus-4-7":   1_000_000,
 	"claude-opus-4-6":   1_000_000,
@@ -32,6 +31,11 @@ var contextWindowTokens = map[string]int{
 	"claude-sonnet-4": 1_000_000,
 
 	// --- 200k ---
+	// Fable 5 sessions run a 200k window unless the 1M beta is active, in
+	// which case the usage cache reports the model with an explicit [1m]
+	// suffix — honored in ContextWindowFor before this table (verified
+	// against Claude Code's /context on a paid plan).
+	"claude-fable-5":   200_000,
 	"claude-haiku-4-5": 200_000,
 	"claude-3-5-haiku": 200_000,
 	"claude-opus-4-5":  200_000,
@@ -62,6 +66,11 @@ func NormalizeClaudeModelID(model string) string {
 // ContextWindowFor returns nil for unknown models, so the caller falls back to
 // the absolute token count alone.
 func ContextWindowFor(model string) *int {
+	// An explicit [1m] variant marker wins over the base-model table.
+	if oneMSuffix.MatchString(strings.TrimSpace(model)) {
+		v := 1_000_000
+		return &v
+	}
 	normalized := NormalizeClaudeModelID(model)
 	for _, key := range contextWindowKeysLongestFirst {
 		if strings.Contains(normalized, key) {

--- a/internal/claude/modelwindows_test.go
+++ b/internal/claude/modelwindows_test.go
@@ -18,7 +18,6 @@ func TestContextWindowFor_1MDefaults(t *testing.T) {
 	models := []string{
 		"claude-sonnet-5",
 		"claude-opus-5",
-		"claude-fable-5",
 		"claude-opus-4-8",
 		"claude-opus-4-7",
 		"claude-opus-4-6",
@@ -31,6 +30,13 @@ func TestContextWindowFor_1MDefaults(t *testing.T) {
 		if got == nil || *got != 1_000_000 {
 			t.Fatalf("%s => %#v, want 1M", m, got)
 		}
+	}
+}
+
+func TestContextWindowFor_Fable5Base200k(t *testing.T) {
+	got := ContextWindowFor("claude-fable-5")
+	if got == nil || *got != 200_000 {
+		t.Fatalf("got %#v, want 200k", got)
 	}
 }
 

--- a/internal/providers/claude/tocontext_test.go
+++ b/internal/providers/claude/tocontext_test.go
@@ -33,10 +33,14 @@ func TestToContextUsage_HaikuDateSuffix(t *testing.T) {
 	}
 }
 
-func TestToContextUsage_FableAndOpus1M(t *testing.T) {
+func TestToContextUsage_FableAndOpus(t *testing.T) {
 	fable := ToContextUsage(usage("claude-fable-5", 130_000))
-	if fable.ContextTokens != 130_000 || fable.WindowTokens == nil || *fable.WindowTokens != 1_000_000 {
+	if fable.ContextTokens != 130_000 || fable.WindowTokens == nil || *fable.WindowTokens != 200_000 {
 		t.Fatalf("fable %+v", fable)
+	}
+	fable1m := ToContextUsage(usage("claude-fable-5[1m]", 130_000))
+	if fable1m.ContextTokens != 130_000 || fable1m.WindowTokens == nil || *fable1m.WindowTokens != 1_000_000 {
+		t.Fatalf("fable[1m] %+v", fable1m)
 	}
 	opus := ToContextUsage(usage("claude-opus-4-8", 108_000))
 	if opus.ContextTokens != 108_000 || opus.WindowTokens == nil || *opus.WindowTokens != 1_000_000 {

--- a/scripts/modeldrift/main.go
+++ b/scripts/modeldrift/main.go
@@ -54,8 +54,15 @@ var ignoredModels = map[string]bool{
 // use (the context-1m beta), not LiteLLM's non-beta API default. Confirmed via
 // /context, which shows current 1M-capable models (e.g. Sonnet 5) at a ~1M
 // window on the paid plan; Sonnet 4.5 follows the same paid-plan behavior.
+//
+// claude-fable-5 — the inverse case: repo uses 200k, LiteLLM says 1M. Paid-plan
+// Fable 5 sessions run a 200k window unless the 1M beta is active, and the
+// usage cache marks 1M sessions with an explicit [1m] model suffix that
+// ContextWindowFor honors ahead of the table. Confirmed via /context against
+// the meter on a paid plan.
 var intentionalOverrides = []string{
 	"claude-sonnet-4-5",
+	"claude-fable-5",
 }
 
 type modelEntry struct {


### PR DESCRIPTION
## What

The context meter read Fable 5 sessions against a 1M window, showing roughly 5x less fill than Claude Code's `/context` reports. On my paid plan a Fable 5 session runs a 200k window unless the 1M beta is active — and when it is, the usage cache reports the model with an explicit `[1m]` suffix (`claude-fable-5[1m]`).

Two changes:

- `claude-fable-5` moves to the 200k table.
- `ContextWindowFor` honors an explicit `[1m]` suffix ahead of the base-model lookup — for every model, not just Fable. Previously the suffix was stripped by normalization and the base entry decided, so an explicit 1M marker could be overridden by a 200k table entry.

Both variants now resolve correctly: `claude-fable-5` → 200k, `claude-fable-5[1m]` → 1M.

## Model-drift checker

LiteLLM lists `claude-fable-5` at 1M, so this adds it to `intentionalOverrides` as the inverse case of the existing `claude-sonnet-4-5` entry: there the repo intentionally reports the beta window where LiteLLM has the conservative default; here LiteLLM has the beta window and the meter reports the effective paid-plan default, with `[1m]`-marked sessions still resolving 1M through the explicit suffix. I ran `go run ./scripts/modeldrift` against live LiteLLM data on this branch: no drift reported.

I verified this against `/context` on my own paid plan — if Fable 5 defaults to 1M on other plans/tiers I'm happy to adjust; the `[1m]`-suffix half of the change is worth keeping either way.

## Tests

Fable base 200k, `[1m]` variants at 1M (existing suffix test now exercises the early return), and the `ToContextUsage` mapping for both variants. `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass.
