### PR TITLE
feat(omp): read Pi session trees, catalogs, and compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ herdr plugin action invoke usagebar.setup
 | OpenCode | Yes | Yes | The `opencode-go` subscription keeps no usage numbers on disk, so its windows come from opencode.ai, authenticated by `OPENCODE_GO_COOKIE` or a browser session imported via the Keychain ([details](#opencode-go-official-usage)); without either it degrades to a local SQLite estimate. Other backends (e.g. DeepSeek) show token/cost spend instead of plan windows |
 | Grok | Yes | Yes | Context from `signals.json`; SuperGrok credits when auth is present. Custom models (`~/.grok/config.toml` `[model.*]` with `base_url`) are pay-as-you-go and labelled from the endpoint host (openai, ollama, …) |
 | OMP (Oh My Pi) | Yes | Yes | Session jsonl plus its credential metadata. Subscription routes: OpenCode Go, Grok OAuth, Anthropic OAuth → Claude, and OpenAI Codex OAuth → Codex. API-key backends show backend-scoped session burn |
-| Pi coding agent | Yes | Yes | Session jsonl plus `~/.pi/agent/auth.json`; uses the same recognized OAuth/subscription routes and pay-as-you-go rules as OMP |
+| Pi coding agent | Yes | Yes | Session jsonl plus `~/.pi/agent/auth.json`; context windows come from Pi's `models-store.json` / `models.json`, and session trees plus compaction boundaries are respected. Uses the same recognized OAuth/subscription routes and pay-as-you-go rules as OMP |
 
 Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 
@@ -391,7 +391,7 @@ Everything is computed from files that the agents already keep on your machine:
 | OpenCode | `~/.local/share/opencode/opencode.db` (session usage), `~/.local/share/opencode/auth.json` (credential kind only), and — for OpenCode Go's official windows — the `opencode.ai` cookie in a local Chromium profile plus that browser's Keychain "Safe Storage" password (read-only, never persisted; see [OpenCode Go official usage](#opencode-go-official-usage)) |
 | Grok | `~/.grok/sessions/**/signals.json`, `~/.grok/auth.json` (credentials for the credits fetch), `~/.grok/config.toml` (custom-model base URLs) |
 | OMP | `~/.omp/agent/sessions/**/*.jsonl`, `~/.omp/agent/models.db` (context window lookup), `~/.omp/agent/agent.db` (credential kind, and the `usage_history` windows OMP records for the accounts it drives) |
-| Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models.db` when present, `~/.pi/agent/auth.json` (credential kind only) |
+| Pi coding agent | `~/.pi/agent/sessions/**/*.jsonl`, `~/.pi/agent/models-store.json` and `~/.pi/agent/models.json` (or the matching `PI_CODING_AGENT_DIR`), `~/.pi/agent/auth.json` (credential kind only) |
 
 Pay-as-you-go detection is not tied to any one harness: it reads the same
 per-harness files above (the backend a session used is already recorded there —

--- a/docs/LLM-SETUP.md
+++ b/docs/LLM-SETUP.md
@@ -76,6 +76,8 @@ End state:
 ```bash
 herdr integration install codex
 herdr integration install opencode
+herdr integration install omp
+herdr integration install pi
 ```
 
 ### 2. Install the plugin
@@ -161,8 +163,8 @@ rows = [
   `agent`, and add `$context` as the next row. Do not remove unrelated
   tokens or rows.
 - If `[ui.sidebar.agents.rows_by_agent]` contains overrides for Claude,
-  Codex, OpenCode, or Grok, merge `$limit` and `$context` into each relevant
-  override too; an override replaces the default `rows`.
+  Codex, OpenCode, Grok, OMP, or Pi, merge `$limit` and `$context` into each
+  relevant override too; an override replaces the default `rows`.
 
 After changing the config:
 

--- a/internal/providers/omp/extract.go
+++ b/internal/providers/omp/extract.go
@@ -8,23 +8,34 @@ import (
 	"strings"
 )
 
+type assistantUsage struct {
+	Input       *float64 `json:"input"`
+	Output      *float64 `json:"output"`
+	CacheRead   *float64 `json:"cacheRead"`
+	CacheWrite  *float64 `json:"cacheWrite"`
+	TotalTokens *float64 `json:"totalTokens"`
+	Cost        *struct {
+		Total *float64 `json:"total"`
+	} `json:"cost"`
+}
+
+type assistantMessage struct {
+	Role            string          `json:"role"`
+	Provider        string          `json:"provider"`
+	Model           string          `json:"model"`
+	StopReason      string          `json:"stopReason"`
+	Timestamp       int64           `json:"timestamp"`
+	Usage           *assistantUsage `json:"usage"`
+	ContextSnapshot *struct {
+		PromptTokens *float64 `json:"promptTokens"`
+	} `json:"contextSnapshot"`
+}
+
 type assistantLine struct {
-	Type    string `json:"type"`
-	Message *struct {
-		Role      string `json:"role"`
-		Provider  string `json:"provider"`
-		Model     string `json:"model"`
-		Timestamp int64  `json:"timestamp"`
-		Usage     *struct {
-			TotalTokens *float64 `json:"totalTokens"`
-			Cost        *struct {
-				Total *float64 `json:"total"`
-			} `json:"cost"`
-		} `json:"usage"`
-		ContextSnapshot *struct {
-			PromptTokens *float64 `json:"promptTokens"`
-		} `json:"contextSnapshot"`
-	} `json:"message"`
+	Type     string            `json:"type"`
+	ID       string            `json:"id"`
+	ParentID *string           `json:"parentId"`
+	Message  *assistantMessage `json:"message"`
 }
 
 func parseAssistantLine(raw string) *assistantLine {
@@ -56,40 +67,100 @@ func floatOrZero(n *float64) float64 {
 	return *n
 }
 
-// ExtractLatestUsageFromLines walks jsonl lines from the end and returns the
-// latest assistant row with context occupancy (or totalTokens as fallback).
-func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
+func totalTokensOf(usage *assistantUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if total := intOrZero(usage.TotalTokens); total > 0 {
+		return total
+	}
+	return int(floatOrZero(usage.Input) + floatOrZero(usage.Output) +
+		floatOrZero(usage.CacheRead) + floatOrZero(usage.CacheWrite))
+}
+
+func sessionUsageFromMessage(msg *assistantMessage) *SessionUsage {
+	if msg == nil || msg.Role != "assistant" || msg.StopReason == "aborted" || msg.StopReason == "error" {
+		return nil
+	}
+	contextTokens := 0
+	if msg.ContextSnapshot != nil {
+		contextTokens = intOrZero(msg.ContextSnapshot.PromptTokens)
+	}
+	totalTokens := totalTokensOf(msg.Usage)
+	cost := 0.0
+	if msg.Usage != nil && msg.Usage.Cost != nil {
+		cost = floatOrZero(msg.Usage.Cost.Total)
+	}
+	if contextTokens <= 0 {
+		contextTokens = totalTokens
+	}
+	if contextTokens <= 0 {
+		return nil
+	}
+	return &SessionUsage{
+		Provider:      msg.Provider,
+		Model:         msg.Model,
+		ContextTokens: contextTokens,
+		TotalTokens:   totalTokens,
+		CostUSD:       cost,
+	}
+}
+
+func extractLatestUsageLinear(lines []string) *SessionUsage {
 	for i := len(lines) - 1; i >= 0; i-- {
-		parsed := parseAssistantLine(lines[i])
-		if parsed == nil || parsed.Message == nil {
+		var entry assistantLine
+		if json.Unmarshal([]byte(lines[i]), &entry) != nil {
 			continue
 		}
-		msg := parsed.Message
-		contextTokens := 0
-		if msg.ContextSnapshot != nil {
-			contextTokens = intOrZero(msg.ContextSnapshot.PromptTokens)
+		if entry.Type == "compaction" {
+			return nil
 		}
-		totalTokens := 0
-		cost := 0.0
-		if msg.Usage != nil {
-			totalTokens = intOrZero(msg.Usage.TotalTokens)
-			if msg.Usage.Cost != nil {
-				cost = floatOrZero(msg.Usage.Cost.Total)
-			}
+		if usage := sessionUsageFromMessage(entry.Message); usage != nil {
+			return usage
 		}
-		if contextTokens <= 0 {
-			contextTokens = totalTokens
-		}
-		if contextTokens <= 0 {
+	}
+	return nil
+}
+
+// ExtractLatestUsageFromLines follows Pi's parentId tree from the most recently
+// appended entry (the persisted active leaf) and returns the latest valid
+// assistant usage on that branch. A compaction after the last assistant makes
+// occupancy unknown until Pi records its next response, matching Pi's footer.
+// Old OMP/Pi files without tree ids fall back to reverse line order.
+func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
+	entries := make(map[string]assistantLine)
+	leafID := ""
+	for _, line := range lines {
+		var entry assistantLine
+		if json.Unmarshal([]byte(line), &entry) != nil || entry.Type == "session" || entry.ID == "" {
 			continue
 		}
-		return &SessionUsage{
-			Provider:      msg.Provider,
-			Model:         msg.Model,
-			ContextTokens: contextTokens,
-			TotalTokens:   totalTokens,
-			CostUSD:       cost,
+		entries[entry.ID] = entry
+		leafID = entry.ID
+	}
+	if leafID == "" {
+		return extractLatestUsageLinear(lines)
+	}
+
+	visited := map[string]bool{}
+	for leafID != "" && !visited[leafID] {
+		visited[leafID] = true
+		entry, ok := entries[leafID]
+		if !ok {
+			// A very large trailing JSONL row can push ancestors outside the
+			// bounded tail read. Preserve the old best-effort behavior then.
+			return extractLatestUsageLinear(lines)
 		}
+		if entry.Type == "compaction" {
+			return nil
+		}
+		if usage := sessionUsageFromMessage(entry.Message); usage != nil {
+			return usage
+		}
+		if entry.ParentID == nil {
+			return nil
+		}
+		leafID = *entry.ParentID
 	}
 	return nil
 }
@@ -142,7 +213,7 @@ func SumUsageForProviderFromLines(lines []string, provider string, startMs, endM
 				continue
 			}
 		}
-		tokens += floatOrZero(msg.Usage.TotalTokens)
+		tokens += float64(totalTokensOf(msg.Usage))
 		if msg.Usage.Cost != nil {
 			costUSD += floatOrZero(msg.Usage.Cost.Total)
 		}

--- a/internal/providers/omp/extract.go
+++ b/internal/providers/omp/extract.go
@@ -122,14 +122,36 @@ func extractLatestUsageLinear(lines []string) *SessionUsage {
 	return nil
 }
 
-// ExtractLatestUsageFromLines follows Pi's parentId tree from the most recently
-// appended entry (the persisted active leaf) and returns the latest valid
-// assistant usage on that branch. A compaction after the last assistant makes
-// occupancy unknown until Pi records its next response, matching Pi's footer.
-// Old OMP/Pi files without tree ids fall back to reverse line order.
-func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
-	entries := make(map[string]assistantLine)
-	leafID := ""
+func extractLatestBackendLinear(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		var entry assistantLine
+		if json.Unmarshal([]byte(lines[i]), &entry) != nil {
+			continue
+		}
+		// Compaction does not change which backend the session is on; keep scanning.
+		if entry.Type == "compaction" {
+			continue
+		}
+		if provider := backendFromMessage(entry.Message); provider != "" {
+			return provider
+		}
+	}
+	return ""
+}
+
+func backendFromMessage(msg *assistantMessage) string {
+	// Match sessionUsageFromMessage's failed-row filter so billing/backend labels
+	// and the context meter agree on which assistant tip is active.
+	if msg == nil || msg.Role != "assistant" || msg.StopReason == "aborted" || msg.StopReason == "error" {
+		return ""
+	}
+	return strings.TrimSpace(msg.Provider)
+}
+
+// indexTreeEntries maps id -> entry for parentId walks. leafID is the most
+// recently appended id-bearing row (the persisted active leaf).
+func indexTreeEntries(lines []string) (entries map[string]assistantLine, leafID string) {
+	entries = make(map[string]assistantLine)
 	for _, line := range lines {
 		var entry assistantLine
 		if json.Unmarshal([]byte(line), &entry) != nil || entry.Type == "session" || entry.ID == "" {
@@ -138,57 +160,105 @@ func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
 		entries[entry.ID] = entry
 		leafID = entry.ID
 	}
-	if leafID == "" {
-		return extractLatestUsageLinear(lines)
-	}
+	return entries, leafID
+}
 
+// walkActiveBranch visits entries from the active leaf toward the root.
+// missingAncestor is true when a parent id is absent from the indexed tail
+// (truncated read); callers should fall back to linear scans then.
+func walkActiveBranch(entries map[string]assistantLine, leafID string, visit func(assistantLine) (stop bool)) (missingAncestor bool) {
 	visited := map[string]bool{}
 	for leafID != "" && !visited[leafID] {
 		visited[leafID] = true
 		entry, ok := entries[leafID]
 		if !ok {
-			// A very large trailing JSONL row can push ancestors outside the
-			// bounded tail read. Preserve the old best-effort behavior then.
-			return extractLatestUsageLinear(lines)
+			return true
 		}
-		if entry.Type == "compaction" {
-			return nil
-		}
-		if usage := sessionUsageFromMessage(entry.Message); usage != nil {
-			return usage
+		if visit(entry) {
+			return false
 		}
 		if entry.ParentID == nil {
-			return nil
+			return false
 		}
 		leafID = *entry.ParentID
 	}
-	return nil
+	return false
 }
 
-// ExtractLatestBackendFromLines returns the most recent assistant provider id.
-func ExtractLatestBackendFromLines(lines []string) string {
-	for i := len(lines) - 1; i >= 0; i-- {
-		parsed := parseAssistantLine(lines[i])
-		if parsed == nil || parsed.Message == nil {
-			continue
-		}
-		if provider := strings.TrimSpace(parsed.Message.Provider); provider != "" {
-			return provider
-		}
+// ExtractLatestUsageFromLines follows Pi's parentId tree from the most recently
+// appended entry (the persisted active leaf) and returns the latest valid
+// assistant usage on that branch. A compaction after the last assistant makes
+// occupancy unknown until Pi records its next response, matching Pi's footer.
+// Old OMP/Pi files without tree ids fall back to reverse line order.
+func ExtractLatestUsageFromLines(lines []string) *SessionUsage {
+	entries, leafID := indexTreeEntries(lines)
+	if leafID == "" {
+		return extractLatestUsageLinear(lines)
 	}
-	return ""
+
+	var found *SessionUsage
+	missing := walkActiveBranch(entries, leafID, func(entry assistantLine) bool {
+		if entry.Type == "compaction" {
+			found = nil
+			return true
+		}
+		if usage := sessionUsageFromMessage(entry.Message); usage != nil {
+			found = usage
+			return true
+		}
+		return false
+	})
+	if missing {
+		// A very large trailing JSONL row can push ancestors outside the
+		// bounded tail read. Preserve the old best-effort behavior then.
+		return extractLatestUsageLinear(lines)
+	}
+	return found
 }
 
-// SumUsageFromLines sums assistant turn totals across all backends. When
-// startMs/endMs > 0, only events with timestamps inside [startMs, endMs] are
-// counted. Timestamps of 0 are always included when a window is unset
-// (startMs==0 && endMs==0), and skipped when a window is active.
+// ExtractLatestBackendFromLines returns the provider id of the latest valid
+// assistant on the active parentId branch (same tree tip and failed-row skip as
+// ExtractLatestUsageFromLines). Compaction is not a backend boundary — walk
+// continues so subscription/billing routing still resolves after compact.
+// Files without tree ids fall back to reverse line order with the same filters.
+func ExtractLatestBackendFromLines(lines []string) string {
+	entries, leafID := indexTreeEntries(lines)
+	if leafID == "" {
+		return extractLatestBackendLinear(lines)
+	}
+
+	found := ""
+	missing := walkActiveBranch(entries, leafID, func(entry assistantLine) bool {
+		if entry.Type == "compaction" {
+			return false
+		}
+		if provider := backendFromMessage(entry.Message); provider != "" {
+			found = provider
+			return true
+		}
+		return false
+	})
+	if missing {
+		return extractLatestBackendLinear(lines)
+	}
+	return found
+}
+
+// SumUsageFromLines sums assistant turn totals across all backends in file
+// order. Unlike ExtractLatestUsageFromLines, this is a burn total: it does not
+// follow parentId branches and does not drop aborted/error rows, because those
+// turns still consumed tokens. When startMs/endMs > 0, only events with
+// timestamps inside [startMs, endMs] are counted. Timestamps of 0 are always
+// included when a window is unset (startMs==0 && endMs==0), and skipped when a
+// window is active.
 func SumUsageFromLines(lines []string, startMs, endMs int64) (tokens float64, costUSD float64) {
 	return SumUsageForProviderFromLines(lines, "", startMs, endMs)
 }
 
-// SumUsageForProviderFromLines sums assistant turn totals for one backend.
-// provider is empty to include all backends.
+// SumUsageForProviderFromLines sums assistant turn totals for one backend in
+// file order (empty provider = all backends). Same burn semantics as
+// SumUsageFromLines: no tree filtering and no aborted/error skip; only
+// totalTokens-or-component aggregation differs from the pre-tree extractor.
 func SumUsageForProviderFromLines(lines []string, provider string, startMs, endMs int64) (tokens float64, costUSD float64) {
 	provider = strings.TrimSpace(provider)
 	windowed := startMs > 0 || endMs > 0

--- a/internal/providers/omp/extract_test.go
+++ b/internal/providers/omp/extract_test.go
@@ -58,3 +58,62 @@ func TestExtractLatestBackendFromLines(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestExtractLatestUsageFromStockPi(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":100,"output":20,"cacheRead":400,"cacheWrite":0,"totalTokens":520},"stopReason":"stop"}}`,
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.ContextTokens != 520 || got.TotalTokens != 520 || got.Model != "gpt-5.6-sol" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestExtractLatestUsageFallsBackToUsageComponents(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-5","usage":{"input":100,"output":20,"cacheRead":400,"cacheWrite":10},"stopReason":"stop"}}`,
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.ContextTokens != 530 || got.TotalTokens != 530 {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestExtractLatestUsageSkipsFailedAssistant(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"good","usage":{"totalTokens":100},"stopReason":"stop"}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"anthropic","model":"failed","usage":{"totalTokens":999},"stopReason":"error"}}`,
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.ContextTokens != 100 || got.Model != "good" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestExtractLatestUsageUnknownImmediatelyAfterCompaction(t *testing.T) {
+	lines := []string{
+		`{"type":"message","id":"a1","parentId":null,"message":{"role":"assistant","usage":{"totalTokens":90000},"stopReason":"stop"}}`,
+		`{"type":"compaction","id":"cmp1","parentId":"a1","tokensBefore":90000,"summary":"summary"}`,
+	}
+	if got := ExtractLatestUsageFromLines(lines); got != nil {
+		t.Fatalf("got %#v", got)
+	}
+
+	lines = append(lines, `{"type":"message","id":"a2","parentId":"cmp1","message":{"role":"assistant","usage":{"totalTokens":22000},"stopReason":"stop"}}`)
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.ContextTokens != 22000 {
+		t.Fatalf("post-compaction got %#v", got)
+	}
+}
+
+func TestExtractLatestUsageFollowsActiveBranch(t *testing.T) {
+	lines := []string{
+		`{"type":"message","id":"root","parentId":null,"message":{"role":"assistant","model":"root-model","usage":{"totalTokens":100},"stopReason":"stop"}}`,
+		`{"type":"message","id":"old","parentId":"root","message":{"role":"assistant","model":"abandoned-model","usage":{"totalTokens":999},"stopReason":"stop"}}`,
+		`{"type":"message","id":"new-user","parentId":"root","message":{"role":"user","content":"new branch"}}`,
+	}
+	got := ExtractLatestUsageFromLines(lines)
+	if got == nil || got.ContextTokens != 100 || got.Model != "root-model" {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/internal/providers/omp/extract_test.go
+++ b/internal/providers/omp/extract_test.go
@@ -51,11 +51,67 @@ func TestSumUsageForProviderFromLines_FiltersBackend(t *testing.T) {
 
 func TestExtractLatestBackendFromLines(t *testing.T) {
 	lines := []string{
-		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"x","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1}}}`,
-		`{"type":"message","message":{"role":"assistant","provider":"openai","model":"y","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1}}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"deepseek","model":"x","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1},"stopReason":"stop"}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"openai","model":"y","usage":{"totalTokens":1},"contextSnapshot":{"promptTokens":1},"stopReason":"stop"}}`,
 	}
 	if got := ExtractLatestBackendFromLines(lines); got != "openai" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractLatestBackendSkipsFailedAssistant(t *testing.T) {
+	lines := []string{
+		`{"type":"message","message":{"role":"assistant","provider":"good-prov","model":"good","usage":{"totalTokens":100},"stopReason":"stop"}}`,
+		`{"type":"message","message":{"role":"assistant","provider":"bad-prov","model":"failed","usage":{"totalTokens":999},"stopReason":"error"}}`,
+	}
+	if got := ExtractLatestBackendFromLines(lines); got != "good-prov" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractLatestBackendFollowsActiveBranch(t *testing.T) {
+	lines := []string{
+		`{"type":"message","id":"root","parentId":null,"message":{"role":"assistant","provider":"root-prov","model":"root-model","usage":{"totalTokens":100},"stopReason":"stop"}}`,
+		`{"type":"message","id":"old","parentId":"root","message":{"role":"assistant","provider":"abandoned-prov","model":"abandoned-model","usage":{"totalTokens":999},"stopReason":"stop"}}`,
+		`{"type":"message","id":"new-user","parentId":"root","message":{"role":"user","content":"new branch"}}`,
+	}
+	if got := ExtractLatestBackendFromLines(lines); got != "root-prov" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractLatestBackendContinuesPastCompaction(t *testing.T) {
+	// Occupancy is unknown after compaction, but billing still needs the backend.
+	lines := []string{
+		`{"type":"message","id":"a1","parentId":null,"message":{"role":"assistant","provider":"anthropic","model":"pre","usage":{"totalTokens":90000},"stopReason":"stop"}}`,
+		`{"type":"compaction","id":"cmp1","parentId":"a1","tokensBefore":90000,"summary":"summary"}`,
+	}
+	if got := ExtractLatestBackendFromLines(lines); got != "anthropic" {
+		t.Fatalf("got %q", got)
+	}
+	if usage := ExtractLatestUsageFromLines(lines); usage != nil {
+		t.Fatalf("usage after compaction want nil, got %#v", usage)
+	}
+}
+
+func TestSumUsageIncludesFailedAndAbandonedBranches(t *testing.T) {
+	// Burn totals stay file-order aggregates: tree tips and failed rows still spent tokens.
+	lines := []string{
+		`{"type":"message","id":"root","parentId":null,"message":{"role":"assistant","provider":"anthropic","model":"root","timestamp":1,"usage":{"totalTokens":100},"stopReason":"stop"}}`,
+		`{"type":"message","id":"old","parentId":"root","message":{"role":"assistant","provider":"anthropic","model":"abandoned","timestamp":2,"usage":{"totalTokens":900},"stopReason":"stop"}}`,
+		`{"type":"message","id":"user","parentId":"root","message":{"role":"user","timestamp":3}}`,
+		`{"type":"message","id":"err","parentId":"user","message":{"role":"assistant","provider":"anthropic","model":"bad","timestamp":4,"usage":{"totalTokens":50},"stopReason":"error"}}`,
+	}
+	tokens, _ := SumUsageFromLines(lines, 0, 0)
+	if tokens != 1050 {
+		t.Fatalf("burn tokens=%v want 1050", tokens)
+	}
+	if got := ExtractLatestUsageFromLines(lines); got == nil || got.ContextTokens != 100 {
+		t.Fatalf("latest occupancy %#v", got)
+	}
+	if got := ExtractLatestBackendFromLines(lines); got != "anthropic" {
+		// error tip skipped; user has no provider; root on active branch
+		t.Fatalf("backend=%q", got)
 	}
 }
 

--- a/internal/providers/omp/pi_modelwindows.go
+++ b/internal/providers/omp/pi_modelwindows.go
@@ -1,0 +1,170 @@
+/**
+ * Resolves context windows for the stock Pi coding agent.
+ *
+ * Pi persists refreshed provider catalogs in models-store.json and user model
+ * definitions/overrides in models.json. Both live in PI_CODING_AGENT_DIR
+ * (normally ~/.pi/agent). The Herdr integration reports the session path, so
+ * we can also infer the matching agent directory when Pi uses a non-default
+ * config directory.
+ */
+package omp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const piDefaultContextWindow = 128_000
+
+type piCatalogModel struct {
+	ID            string `json:"id"`
+	ContextWindow *int   `json:"contextWindow"`
+}
+
+type piStoredCatalog struct {
+	Models []piCatalogModel `json:"models"`
+}
+
+type piModelOverride struct {
+	ContextWindow *int `json:"contextWindow"`
+}
+
+type piConfiguredProvider struct {
+	Models         []piCatalogModel           `json:"models"`
+	ModelOverrides map[string]piModelOverride `json:"modelOverrides"`
+}
+
+type piModelsConfig struct {
+	Providers map[string]piConfiguredProvider `json:"providers"`
+}
+
+func addUniquePath(paths []string, seen map[string]bool, path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return paths
+	}
+	path = filepath.Clean(expandHome(path))
+	if seen[path] {
+		return paths
+	}
+	seen[path] = true
+	return append(paths, path)
+}
+
+// piAgentDirs returns candidate config directories in priority order. A
+// session under <agent-dir>/sessions/<encoded-cwd>/<file>.jsonl reveals its
+// own agent dir, which keeps custom PI_CODING_AGENT_DIR installations working
+// even though Herdr's plugin process does not inherit the pane environment.
+func piAgentDirs(sessionPath string) []string {
+	var dirs []string
+	seen := map[string]bool{}
+	dirs = addUniquePath(dirs, seen, os.Getenv("PI_CODING_AGENT_DIR"))
+
+	path := filepath.Clean(expandHome(sessionPath))
+	if strings.HasSuffix(path, ".jsonl") {
+		projectDir := filepath.Dir(path)
+		sessionsDir := filepath.Dir(projectDir)
+		if filepath.Base(sessionsDir) == "sessions" {
+			dirs = addUniquePath(dirs, seen, filepath.Dir(sessionsDir))
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = addUniquePath(dirs, seen, filepath.Join(home, ".pi", "agent"))
+	}
+	return dirs
+}
+
+func setPiWindow(windows map[string]int, provider, model string, window int) {
+	provider = strings.TrimSpace(provider)
+	model = strings.TrimSpace(model)
+	if model == "" || window <= 0 {
+		return
+	}
+	windows[model] = window
+	if provider != "" {
+		windows[provider+"/"+model] = window
+	}
+}
+
+func loadPiStoredWindows(path string, windows map[string]int) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var catalogs map[string]piStoredCatalog
+	if err := json.Unmarshal(raw, &catalogs); err != nil {
+		return
+	}
+	for provider, catalog := range catalogs {
+		for _, model := range catalog.Models {
+			if model.ContextWindow != nil {
+				setPiWindow(windows, provider, model.ID, *model.ContextWindow)
+			}
+		}
+	}
+}
+
+// loadPiConfiguredWindows applies models.json after models-store.json, just as
+// Pi applies user models and modelOverrides on top of its built-in catalogs.
+func loadPiConfiguredWindows(path string, windows map[string]int) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var config piModelsConfig
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return
+	}
+	for provider, definition := range config.Providers {
+		for _, model := range definition.Models {
+			window := piDefaultContextWindow
+			if model.ContextWindow != nil {
+				window = *model.ContextWindow
+			}
+			setPiWindow(windows, provider, model.ID, window)
+		}
+		for model, override := range definition.ModelOverrides {
+			if override.ContextWindow != nil {
+				setPiWindow(windows, provider, model, *override.ContextWindow)
+			}
+		}
+	}
+}
+
+func loadPiWindows(sessionPath string) map[string]int {
+	windows := map[string]int{}
+	// Lower-priority defaults are loaded first so an inferred custom agent dir
+	// or explicit PI_CODING_AGENT_DIR can override them below.
+	dirs := piAgentDirs(sessionPath)
+	for i := len(dirs) - 1; i >= 0; i-- {
+		loadPiStoredWindows(filepath.Join(dirs[i], "models-store.json"), windows)
+		loadPiConfiguredWindows(filepath.Join(dirs[i], "models.json"), windows)
+	}
+	return windows
+}
+
+// PiContextWindowFor returns Pi's configured context window for the model.
+// Exact provider/model matches win; a bare-model fallback supports older
+// catalog rows that omitted provider metadata.
+func PiContextWindowFor(sessionPath, provider, model string) *int {
+	provider = strings.TrimSpace(provider)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	windows := loadPiWindows(sessionPath)
+	if provider != "" {
+		if n, ok := windows[provider+"/"+model]; ok {
+			v := n
+			return &v
+		}
+	}
+	if n, ok := windows[model]; ok {
+		v := n
+		return &v
+	}
+	return nil
+}

--- a/internal/providers/omp/pi_modelwindows_test.go
+++ b/internal/providers/omp/pi_modelwindows_test.go
@@ -1,0 +1,106 @@
+package omp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writePiModelFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPiContextWindowForModelsStore(t *testing.T) {
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	writePiModelFile(t, filepath.Join(agentDir, "models-store.json"), `{
+		"openai-codex": {
+			"models": [
+				{"id":"gpt-5.6-sol","provider":"openai-codex","contextWindow":272000}
+			]
+		}
+	}`)
+
+	got := PiContextWindowFor("", "openai-codex", "gpt-5.6-sol")
+	if got == nil || *got != 272_000 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestPiContextWindowForInfersAgentDirFromSession(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	agentDir := filepath.Join(t.TempDir(), "custom-agent")
+	session := filepath.Join(agentDir, "sessions", "--repo--", "session.jsonl")
+	writePiModelFile(t, filepath.Join(agentDir, "models-store.json"), `{
+		"anthropic": {"models":[{"id":"claude-sonnet-5","contextWindow":1000000}]}
+	}`)
+
+	got := PiContextWindowFor(session, "anthropic", "claude-sonnet-5")
+	if got == nil || *got != 1_000_000 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestPiContextWindowForModelsJSONOverridesStore(t *testing.T) {
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	writePiModelFile(t, filepath.Join(agentDir, "models-store.json"), `{
+		"openai": {"models":[{"id":"gpt-5.6-sol","contextWindow":272000}]}
+	}`)
+	writePiModelFile(t, filepath.Join(agentDir, "models.json"), `{
+		"providers": {
+			"openai": {
+				"modelOverrides": {
+					"gpt-5.6-sol": {"contextWindow":1050000}
+				}
+			}
+		}
+	}`)
+
+	got := PiContextWindowFor("", "openai", "gpt-5.6-sol")
+	if got == nil || *got != 1_050_000 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestPiContextWindowForCustomModelDefault(t *testing.T) {
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	writePiModelFile(t, filepath.Join(agentDir, "models.json"), `{
+		"providers": {
+			"ollama": {
+				"models": [{"id":"qwen2.5-coder:7b"}]
+			}
+		}
+	}`)
+
+	got := PiContextWindowFor("", "ollama", "qwen2.5-coder:7b")
+	if got == nil || *got != piDefaultContextWindow {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestResolvePiUsageForPathIncludesModelWindow(t *testing.T) {
+	agentDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", agentDir)
+	writePiModelFile(t, filepath.Join(agentDir, "models-store.json"), `{
+		"openai-codex": {"models":[{"id":"gpt-5.6-sol","contextWindow":272000}]}
+	}`)
+	session := filepath.Join(agentDir, "sessions", "--repo--", "session.jsonl")
+	writePiModelFile(t, session, `{"type":"session","version":3,"id":"sid","cwd":"/repo"}
+{"type":"message","id":"a1","parentId":null,"message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"totalTokens":125010},"stopReason":"stop"}}
+`)
+
+	got := ResolvePiUsageForPath(session)
+	if got == nil || got.ContextTokens != 125_010 || got.WindowTokens == nil || *got.WindowTokens != 272_000 {
+		t.Fatalf("got %+v", got)
+	}
+}

--- a/internal/providers/omp/provider.go
+++ b/internal/providers/omp/provider.go
@@ -43,5 +43,5 @@ func resolvePiUsage(input provider.UsageResolveInput) *core.ContextUsage {
 	if path == "" {
 		return nil
 	}
-	return ResolveUsageForPath(path)
+	return ResolvePiUsageForPath(path)
 }

--- a/internal/providers/omp/resolve.go
+++ b/internal/providers/omp/resolve.go
@@ -54,8 +54,9 @@ func SessionPathFromSnapshotValue(value string) string {
 	return ""
 }
 
-// ResolveUsageForPath returns ContextUsage for an OMP session jsonl path.
-func ResolveUsageForPath(path string) *core.ContextUsage {
+type contextWindowResolver func(provider, model string) *int
+
+func resolveUsageForPath(path string, resolveWindow contextWindowResolver) *core.ContextUsage {
 	path = expandHome(path)
 	if path == "" {
 		return nil
@@ -69,10 +70,23 @@ func ResolveUsageForPath(path string) *core.ContextUsage {
 		return nil
 	}
 	out := core.ContextUsage{ContextTokens: usage.ContextTokens}
-	if window := ContextWindowFor(usage.Provider, usage.Model); window != nil {
+	if window := resolveWindow(usage.Provider, usage.Model); window != nil {
 		out.WindowTokens = window
 	}
 	return &out
+}
+
+// ResolveUsageForPath returns ContextUsage for an OMP session jsonl path.
+func ResolveUsageForPath(path string) *core.ContextUsage {
+	return resolveUsageForPath(path, ContextWindowFor)
+}
+
+// ResolvePiUsageForPath returns ContextUsage for a stock Pi session. Pi uses
+// JSON model catalogs rather than OMP's models.db for context-window lookup.
+func ResolvePiUsageForPath(path string) *core.ContextUsage {
+	return resolveUsageForPath(path, func(provider, model string) *int {
+		return PiContextWindowFor(path, provider, model)
+	})
 }
 
 // BackendIDForPath returns the latest assistant provider id for the session.


### PR DESCRIPTION
## What

The stock Pi coding agent persists sessions as a `parentId` tree, resolves context windows from JSON model catalogs, and truncates occupancy at compaction — none of which the shared OMP extractor understood. This made Pi panes show the wrong branch's usage after a retry/fork, a stale size after compaction, and no window percentage for models missing from OMP's `models.db`.

- **Session trees.** `ExtractLatestUsageFromLines` now follows the `parentId` chain from the persisted active leaf instead of raw line order, so abandoned branches no longer leak into the meter. Files without tree ids (older OMP/Pi sessions) keep the old reverse-line scan, as does a truncated tail whose ancestors fell outside the bounded read.
- **Row quality.** Aborted/errored assistant rows are skipped, and when `totalTokens` is absent the extractor sums the usage components (`input`/`output`/`cacheRead`/`cacheWrite`) — in the meter and in session burn totals.
- **Compaction.** A compaction newer than the last assistant row reports no occupancy until Pi records its next response, matching Pi's own footer.
- **Pi model catalogs.** New `PiContextWindowFor` resolves windows from `models-store.json` (refreshed provider catalogs) and `models.json` (user models and `modelOverrides`, applied on top, with Pi's 128k default for user-defined models) under `PI_CODING_AGENT_DIR` — inferred from the session path for custom installs, since the plugin process doesn't inherit the pane environment. The `pi` provider now uses this; OMP keeps `models.db` unchanged.

## Behavior

| Situation | Before | After |
| --- | --- | --- |
| OMP pane | works | works (unchanged path, `models.db`) |
| Pi pane, linear session | works if model in `models.db` | works from Pi's own catalogs |
| Pi pane after retry/fork | abandoned branch's numbers | active branch's numbers |
| Pi pane right after compaction | stale pre-compact size | meter blank until next response (like Pi's footer) |
| Assistant row errored/aborted | counted | skipped |

## Tests

Tree-following (active branch, post-compaction unknown then recovery), component-sum fallback, failed-row skipping, stock-Pi row shape, catalog resolution (store, session-path inference, `models.json` overrides, custom-model default), and end-to-end `ResolvePiUsageForPath` with a window. The existing OMP contract test and provider-scoped burn tests still pass unchanged. `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` all pass.

README's Pi rows and docs/LLM-SETUP.md are updated to name the catalog files (and to include the `omp`/`pi` integration installs the README already lists).

---

Related: #52 — the Claude-side counterpart of the compaction handling here.
