### PR TITLE
fix(omp): preserve pane usage attribution

### DIFF
--- a/internal/limits/billingmode_io.go
+++ b/internal/limits/billingmode_io.go
@@ -563,12 +563,21 @@ func paneSubscriptionRoute(providerID string, pane OpenPaneSnapshot) (Subscripti
 	}
 }
 
-// ompSessionPath resolves the OMP jsonl path from SessionID, else newest cwd session.
+// ompSessionPath resolves an OMP transcript path without borrowing another
+// pane's latest session. An opaque Herdr session ID is not a filesystem key.
 func ompSessionPath(pane OpenPaneSnapshot) string {
 	if pane.SessionID != nil {
-		if path := omp.SessionPathFromSnapshotValue(*pane.SessionID); path != "" {
+		path := omp.SessionPathFromSnapshotValue(*pane.SessionID)
+		if path == "" {
+			return ""
+		}
+		if _, err := os.Stat(path); err == nil {
 			return path
 		}
+		if pane.Cwd != nil {
+			return omp.FindOMPSessionForCwdByFilename(*pane.Cwd, path)
+		}
+		return ""
 	}
 	if pane.Cwd != nil {
 		return omp.FindLatestOMPSessionForCwd(*pane.Cwd)

--- a/internal/limits/billingmode_io_test.go
+++ b/internal/limits/billingmode_io_test.go
@@ -367,3 +367,21 @@ func TestIO_MultipleClaudeProfiles_IndependentBilling(t *testing.T) {
 		t.Fatalf("profile B (subscription) should be kept: %#v", set)
 	}
 }
+
+func TestOMPPath_DoesNotUseLatestSessionForIDOnlyPane(t *testing.T) {
+	root := t.TempDir()
+	cwd := ioTestCwd
+	dir := filepath.Join(root, "-tmp-herdr-usage-smoke-cwd")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "2026-08-11T01-00-00Z_other-pane.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OMP_SESSIONS_ROOT", root)
+
+	got := ompSessionPath(OpenPaneSnapshot{SessionID: sp("opaque-session-id"), Cwd: sp(cwd)})
+	if got != "" {
+		t.Fatalf("got %q; ID-only session must not inherit another pane's transcript", got)
+	}
+}

--- a/internal/providers/omp/context_contract_test.go
+++ b/internal/providers/omp/context_contract_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/core"
+	"github.com/senna-lang/herdr-agent-usage/internal/provider"
 )
 
 // OMP and Pi share this adapter. The sidebar percentage must use the latest
@@ -53,5 +54,51 @@ func TestSidebarContextContract_UsesLatestModelWindow(t *testing.T) {
 	status := core.FormatUsageStatus(*usage, core.FormatUsageOptions{})
 	if !strings.Contains(status, "25%") || !strings.Contains(status, "250k") {
 		t.Fatalf("status %q does not reflect 250k / 1M", status)
+	}
+}
+
+func TestOMPProvider_RehomesStaleSessionPath(t *testing.T) {
+	root := t.TempDir()
+	cwd := "/Users/senna/Documents/Repos/life"
+	filename := "2026-08-10T01-06-25-252Z_019fe934-e364-7000-a8e5-6c59127e8a7a.jsonl"
+	dir := filepath.Join(root, EncodeOMPSessionDir(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(`{"type":"message","message":{"role":"assistant","provider":"openai","model":"gpt-5","contextSnapshot":{"promptTokens":59000}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OMP_SESSIONS_ROOT", root)
+
+	usage := Provider.ResolveUsage(provider.UsageResolveInput{
+		Session: &provider.AgentSession{
+			Kind:  "path",
+			Value: filepath.Join(root, "home-life-legacy", filename),
+		},
+		Cwd: &cwd,
+	})
+	if usage == nil || usage.ContextTokens != 59000 {
+		t.Fatalf("usage = %+v", usage)
+	}
+}
+
+func TestOMPProvider_DoesNotUseLatestSessionForIDOnlyInput(t *testing.T) {
+	root := t.TempDir()
+	cwd := "/Users/senna/Documents/Repos/life"
+	dir := filepath.Join(root, EncodeOMPSessionDir(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "2026-08-11T01-00-00Z_other-pane.jsonl"), []byte(`{"type":"message","message":{"role":"assistant","provider":"openai","model":"gpt-5","contextSnapshot":{"promptTokens":59000}}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OMP_SESSIONS_ROOT", root)
+
+	usage := Provider.ResolveUsage(provider.UsageResolveInput{
+		Session: &provider.AgentSession{Kind: "id", Value: "missing-session-id"},
+		Cwd:     &cwd,
+	})
+	if usage != nil {
+		t.Fatalf("usage = %+v; ID-only session must not inherit another pane's transcript", usage)
 	}
 }

--- a/internal/providers/omp/findsession.go
+++ b/internal/providers/omp/findsession.go
@@ -106,6 +106,31 @@ func FindLatestPiSessionForCwd(cwd string) string {
 	return FindLatestSessionInDir(filepath.Join(root, enc))
 }
 
+// FindOMPSessionForCwdByFilename finds a session in the pane's current OMP
+// session directory when Herdr's stored absolute path was created before the
+// session directory moved or changed encoding. It only accepts the exact
+// transcript filename, so it cannot attribute another pane's newest session.
+func FindOMPSessionForCwdByFilename(cwd, sessionPath string) string {
+	root := ompSessionsRoot()
+	filename := filepath.Base(strings.TrimSpace(sessionPath))
+	if root == "" || filename == "." || filename == string(filepath.Separator) || !strings.HasSuffix(filename, ".jsonl") {
+		return ""
+	}
+
+	encodings := [2]string{EncodeOMPSessionDir(cwd), EncodePiSessionDir(cwd)}
+	for _, encoding := range encodings {
+		if encoding == "" {
+			continue
+		}
+		candidate := filepath.Join(root, encoding, filename)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // FindLatestOMPSessionForCwd looks under ~/.omp/agent/sessions/<encoded>/.
 func FindLatestOMPSessionForCwd(cwd string) string {
 	root := ompSessionsRoot()

--- a/internal/providers/omp/findsession_test.go
+++ b/internal/providers/omp/findsession_test.go
@@ -15,6 +15,26 @@ func TestEncodePiSessionDir(t *testing.T) {
 	}
 }
 
+func TestFindOMPSessionForCwdByFilename_RehomesStalePath(t *testing.T) {
+	root := t.TempDir()
+	cwd := "/Users/senna/Documents/Repos/life"
+	filename := "2026-08-10T01-06-25-252Z_019fe934-e364-7000-a8e5-6c59127e8a7a.jsonl"
+	wantDir := filepath.Join(root, EncodeOMPSessionDir(cwd))
+	if err := os.MkdirAll(wantDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(wantDir, filename)
+	if err := os.WriteFile(want, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OMP_SESSIONS_ROOT", root)
+
+	got := FindOMPSessionForCwdByFilename(cwd, filepath.Join(root, "home-life-legacy", filename))
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
 func TestFindLatestSessionInDir(t *testing.T) {
 	dir := t.TempDir()
 	older := filepath.Join(dir, "2026-01-01T00-00-00Z_old.jsonl")

--- a/internal/providers/omp/provider.go
+++ b/internal/providers/omp/provider.go
@@ -26,13 +26,26 @@ var PiProvider = provider.FuncProvider{
 
 func resolveOMPUsage(input provider.UsageResolveInput) *core.ContextUsage {
 	path := SessionPathFromInput(input)
-	if path == "" && input.Cwd != nil {
-		path = FindLatestOMPSessionForCwd(*input.Cwd)
+	if path != "" {
+		if usage := ResolveUsageForPath(path); usage != nil {
+			return usage
+		}
+		if input.Cwd == nil {
+			return nil
+		}
+
+		// Resumptions can preserve a historical absolute path after OMP moves the
+		// transcript into the current cwd's directory. Recover only the exact
+		// filename; selecting that cwd's newest transcript could cross panes.
+		return ResolveUsageForPath(FindOMPSessionForCwdByFilename(*input.Cwd, path))
 	}
-	if path == "" {
+
+	// An ID-only session cannot be associated with an OMP jsonl file. Do not
+	// substitute the cwd's newest file: concurrent panes routinely share a cwd.
+	if input.Session != nil || input.Cwd == nil {
 		return nil
 	}
-	return ResolveUsageForPath(path)
+	return ResolveUsageForPath(FindLatestOMPSessionForCwd(*input.Cwd))
 }
 
 func resolvePiUsage(input provider.UsageResolveInput) *core.ContextUsage {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -160,8 +160,8 @@ func writeMetadataTokenWith(writer metadataTokenWriter, current map[string]strin
 	}
 }
 
-// RunUpdate resolves usage for HERDR_PANE_ID and updates its sidebar tokens.
-// force=true (plugin action) updates even while working.
+// RunUpdate resolves usage for HERDR_PANE_ID and refreshes its sidebar tokens,
+// including while the agent is working. force bypasses unchanged-value checks.
 func RunUpdate(force bool) {
 	paneID := os.Getenv("HERDR_PANE_ID")
 	if paneID == "" {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -27,10 +27,6 @@ func findClaudeProfile(profiles []claude.ClaudeProfile, id string) (claude.Claud
 	return claude.ClaudeProfile{}, false
 }
 
-func isSettledStatus(status string) bool {
-	return status != "working"
-}
-
 // paneCwdForUpdate chooses the directory used to resolve agent-local session
 // files. OMP/Pi may put a language-server process in the foreground, whose
 // cwd is inside a virtual environment rather than the agent's project. Their
@@ -179,10 +175,6 @@ func RunUpdate(force bool) {
 
 	p := providers.FindProvider(*pane.Agent)
 	if p == nil {
-		return
-	}
-
-	if pane.AgentStatus != nil && !isSettledStatus(*pane.AgentStatus) && !force {
 		return
 	}
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -5,6 +5,8 @@ package update
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/claude"
@@ -39,6 +41,39 @@ func TestPaneCwdForUpdate_OtherAgentsPreferForegroundCwd(t *testing.T) {
 	})
 	if got == nil || *got != foregroundCwd {
 		t.Fatalf("got %v want %q", got, foregroundCwd)
+	}
+}
+
+func TestRunUpdate_RefreshesWorkingPane(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "metadata.log")
+	binPath := filepath.Join(root, "fake-herdr")
+	script := `#!/bin/sh
+if [ "$1" = pane ] && [ "$2" = get ]; then
+  printf '%s\n' '{"result":{"pane":{"agent":"omp","agent_status":"working","label":"review-pane","cwd":"/tmp","tokens":{}}}}'
+  exit 0
+fi
+if [ "$1" = pane ] && [ "$2" = report-metadata ]; then
+  printf '%s\n' "$*" >> "$REVIEW_METADATA_LOG"
+fi
+`
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_PANE_ID", "test-pane")
+	t.Setenv("HERDR_BIN_PATH", binPath)
+	t.Setenv("REVIEW_METADATA_LOG", logPath)
+	t.Setenv("OMP_SESSIONS_ROOT", filepath.Join(root, "sessions"))
+	t.Setenv("HOME", root)
+
+	RunUpdate(false)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("working pane produced no metadata refresh: %v", err)
+	}
+	if !strings.Contains(string(data), "--token title=review-pane") {
+		t.Fatalf("metadata calls = %q", data)
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover OMP transcript paths after session-directory relocation using the exact filename
- refresh sidebar metadata while an agent is working
- never substitute another pane's latest transcript for an opaque OMP session ID

## Verification
- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- live Herdr checks: recovered the stale-path pane; ID-only pane clears metadata rather than showing another pane's usage