### PR TITLE
fix(update): retain metadata during working gaps

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -145,7 +145,13 @@ var herdrMetadataTokenWriter = metadataTokenWriter{
 	clear: herdrcli.ClearMetadataToken,
 }
 
-func writeMetadataToken(current map[string]string, paneID, name, value string, force bool) {
+// writeMetadataToken applies the pane's metadata write policy before deciding
+// whether the current value needs a Herdr update. Live updates retain a
+// last-known-good value when collection temporarily yields an empty value.
+func writeMetadataToken(current map[string]string, paneID, name, value string, force, retainExistingOnEmpty bool) {
+	if retainExistingOnEmpty && value == "" {
+		return
+	}
 	writeMetadataTokenWith(herdrMetadataTokenWriter, current, paneID, name, value, force)
 }
 
@@ -178,13 +184,19 @@ func RunUpdate(force bool) {
 		return
 	}
 
+	// A working pane can briefly have no fresh limit or context value while its
+	// collector or transcript is between complete records. Keep its last-known-
+	// good metadata until a positive update arrives; settled and forced updates
+	// may still clear stale values.
+	retainExistingOnEmpty := !force && pane.AgentStatus != nil && *pane.AgentStatus == "working"
+
 	// Row 1 stands in for Herdr's built-in `tab`/`pane` tokens, which render
 	// blank whenever a tab keeps its auto-assigned numeric label and the
 	// pane was never renamed. Fall back through the workspace ("space")
 	// name so the row is never empty.
 	naming := herdrcli.GetPaneNaming(pane)
 	title := core.ResolveSidebarTitle(naming.PaneLabel, naming.TabLabel, naming.TabNumber, naming.WorkspaceLabel)
-	writeMetadataToken(pane.Tokens, paneID, "title", title, force)
+	writeMetadataToken(pane.Tokens, paneID, "title", title, force, retainExistingOnEmpty)
 
 	cwd := paneCwdForUpdate(pane)
 	nowMs := time.Now().UnixMilli()
@@ -207,9 +219,9 @@ func RunUpdate(force bool) {
 	if !resolved {
 		// Cannot tell which account this pane belongs to: clear rather than
 		// guess into the wrong account's limits/tokens.
-		writeMetadataToken(pane.Tokens, paneID, "limit", "", force)
-		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force)
-		writeMetadataToken(pane.Tokens, paneID, "context", "", force)
+		writeMetadataToken(pane.Tokens, paneID, "limit", "", force, retainExistingOnEmpty)
+		writeMetadataToken(pane.Tokens, paneID, "provider", formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot), force, retainExistingOnEmpty)
+		writeMetadataToken(pane.Tokens, paneID, "context", "", force, retainExistingOnEmpty)
 		return
 	}
 
@@ -252,11 +264,11 @@ func RunUpdate(force bool) {
 			limitToken = accountText
 		}
 	}
-	writeMetadataToken(pane.Tokens, paneID, "limit", limitToken, force)
+	writeMetadataToken(pane.Tokens, paneID, "limit", limitToken, force, retainExistingOnEmpty)
 
 	// Stands in for Herdr's `agent` token so a pay-as-you-go pane names the
 	// backend it is actually billing ("deepseek") instead of the harness.
-	writeMetadataToken(pane.Tokens, paneID, "provider", providerText, force)
+	writeMetadataToken(pane.Tokens, paneID, "provider", providerText, force, retainExistingOnEmpty)
 
 	// Context tokens: claude is read from its resolved profile's own transcript
 	// root (bypassing the registry's default-root lookup) so a non-default
@@ -282,7 +294,7 @@ func RunUpdate(force bool) {
 	}
 
 	if usage == nil {
-		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force)
+		writeMetadataToken(pane.Tokens, paneID, "context", contextPrefix, force, retainExistingOnEmpty)
 		return
 	}
 
@@ -291,5 +303,5 @@ func RunUpdate(force bool) {
 	maxCols := core.EstimateStatusMaxColumns(&sidebarW)
 	maxCols = reserveColumnsFor(maxCols, contextPrefix)
 	statusText := core.FormatUsageStatus(*usage, core.FormatUsageOptions{MaxColumns: maxCols})
-	writeMetadataToken(pane.Tokens, paneID, "context", combineLimitAndContext(contextPrefix, statusText), force)
+	writeMetadataToken(pane.Tokens, paneID, "context", combineLimitAndContext(contextPrefix, statusText), force, retainExistingOnEmpty)
 }

--- a/internal/update/working_metadata_test.go
+++ b/internal/update/working_metadata_test.go
@@ -1,0 +1,62 @@
+/**
+ * Verifies that live sidebar updates retain last-known-good metadata during
+ * transient collection gaps, while settled and forced updates may clear it.
+ */
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunUpdate_MetadataClearingPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		force       bool
+		shouldClear bool
+	}{
+		{name: "working update retains last good values", status: "working", shouldClear: false},
+		{name: "settled update clears stale values", status: "idle", shouldClear: true},
+		{name: "forced working update clears stale values", status: "working", force: true, shouldClear: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			logPath := filepath.Join(root, "metadata.log")
+			binPath := filepath.Join(root, "fake-herdr")
+			script := `#!/bin/sh
+if [ "$1" = pane ] && [ "$2" = get ]; then
+  printf '{"result":{"pane":{"agent":"omp","agent_status":"%s","label":"review-pane","cwd":"/tmp","tokens":{"limit":"last-good-limit","context":"last-good-context"}}}}\n' "$PANE_STATUS"
+  exit 0
+fi
+if [ "$1" = pane ] && [ "$2" = report-metadata ]; then
+  printf '%s\n' "$*" >> "$REVIEW_METADATA_LOG"
+fi
+`
+			if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("HERDR_PANE_ID", "test-pane")
+			t.Setenv("HERDR_BIN_PATH", binPath)
+			t.Setenv("PANE_STATUS", tt.status)
+			t.Setenv("REVIEW_METADATA_LOG", logPath)
+			t.Setenv("OMP_SESSIONS_ROOT", filepath.Join(root, "sessions"))
+			t.Setenv("HOME", root)
+
+			RunUpdate(tt.force)
+
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("metadata calls = none: %v", err)
+			}
+			cleared := strings.Contains(string(data), "--clear-token limit") && strings.Contains(string(data), "--clear-token context")
+			if cleared != tt.shouldClear {
+				t.Fatalf("cleared=%t, want %t; metadata calls = %q", cleared, tt.shouldClear, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- retain last-known-good sidebar metadata when a non-forced working-pane update has no fresh value
- preserve normal clearing for settled and forced updates
- add an end-to-end `RunUpdate` regression test for the three write-policy states

## Verification

- `go test ./internal/update -run '^TestRunUpdate_MetadataClearingPolicy$' -count=1 -v`
- `go test ./internal/update -count=1`

## Related issue

Fixes #62.