### PR TITLE
chore(release): prepare v0.5.8

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.7"
+version = "0.5.8"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
Bumps plugin metadata for the v0.5.8 patch release.