### PR TITLE
fix(release): pin patched Go toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          # Match CI: use the latest supported Go 1.25 patch release.
-          go-version: '1.25'
+          # Keep the release verifier on CI's current patched Go release.
+          # A minor-only selector can resolve an older vulnerable patch.
+          go-version: '1.25.13'
 
       - name: Vet
         run: go vet ./...
@@ -55,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          go-version: '1.25.13'
 
       - name: Cross-compile
         run: |

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.9"
+version = "0.5.10"
 # Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
 min_herdr_version = "0.7.4"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
`v0.5.9` verification exposed that the release workflow's minor-only Go selector resolved to vulnerable Go 1.25.12 while CI used Go 1.25.13. Pin both release jobs to the CI patch release.

Bumps release metadata to `0.5.10`; the failed `v0.5.9` tag is retained and is not retagged.