### PR TITLE
fix(update): refresh idle sidebar $limit from shared collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The agent can install the plugin and guide you through the remaining setup.
 1. Install the plugin and run **setup** (above).
 2. Open a workspace with at least one agent pane.
 3. Add the sidebar rows printed by `usagebar.setup` to your Herdr config, then run `herdr server reload-config`.
-4. After an agent turn completes (or you focus the pane), the sidebar shows provider limit remaining above context usage.
+4. After an agent turn completes (or you focus the pane), the sidebar shows provider limit remaining above context usage. `$limit` also refreshes on its own while the pane sits idle.
 5. Open the limits pane:
 
 ```bash
@@ -106,7 +106,7 @@ herdr plugin action invoke usagebar.setup
 | Surface | What it shows |
 | --- | --- |
 | **Sidebar `$context` row** | Per-pane context usage: `⛁ 13% (130k)` when the window size is known, or the token count alone |
-| **Sidebar `$limit` row** | Shortest provider limit window (`5h 72%` remaining), or — on a pay-as-you-go pane — what that pane spent on its backend (`Σ 425k $0.04`, scoped to the pane's session and backend) |
+| **Sidebar `$limit` row** | Shortest provider limit window (`5h 72%` remaining), refreshed with the Agent Usage pane (15s) or every 60s while that pane is closed. Pay-as-you-go panes show what that pane spent on its backend (`Σ 425k $0.04`, scoped to the pane's session and backend) instead |
 | **Sidebar `$provider` row** | Subscription provider (`opencode-go`, `grok`, `claude`, …) on a subscription pane, or the backend actually billed on a pay-as-you-go pane (`deepseek`). The adjacent burn total is scoped to that same backend in the pane's session |
 | **Agent Usage pane** | One block per billing provider, independent of harness. Subscription providers show plan windows and cross-harness pane activity. Pay-as-you-go backends show one merged 24h / 7d / 30d block, model breakdown, and pane share even when multiple harnesses use the same backend |
 | **Toasts** (optional) | Remaining-limit warnings at configured thresholds (default 50 / 20 / 10 / 5 % left) |
@@ -126,7 +126,7 @@ Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 
 ## Agent Usage pane
 
-- Auto-refreshes every **15s**. Press **`r`** to refresh, **`q`** to quit.
+- Auto-refreshes every **15s**, and the same collect updates sidebar `$limit` on every open subscription pane. Press **`r`** to refresh, **`q`** to quit. With the pane closed, `$limit` still moves every **60s**. `$context` stays event-driven.
 - OpenCode Go may show three windows (**5h / 7d / 30d**). Other providers show whichever usage windows their data sources make available.
 - Open pane **token share** is local activity share within the shortest window (including a **closed / other** bucket for usage outside open panes). It is not account quota attribution.
 - Sidebar meters update after the agent has **settled** (not while `working`), so they match the last completed turn. If the session cannot be resolved, the `$context` token is cleared rather than showing another session’s numbers.

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strconv"
 	"strings"
@@ -44,6 +45,7 @@ func main() {
 		// force when invoked as a plugin action (refresh)
 		force := os.Getenv("HERDR_PLUGIN_ACTION_ID") != "" || hasFlag(args, "--force")
 		update.RunUpdate(force)
+		startIdleWatch()
 	case "setup":
 		writeToast := hasFlag(args, "--write-toast") || hasFlag(args, "--apply-toast")
 		report := setup.RunSetup(setup.SetupOptions{WriteToast: writeToast})
@@ -55,6 +57,8 @@ func main() {
 		}
 	case "notify":
 		runNotify()
+	case "watch":
+		update.RunWatch(resolveCwd(), time.Now, time.Sleep, nil)
 	case "check-update":
 		runUpdateCheck(args)
 	case "statusline":
@@ -78,6 +82,7 @@ func printUsage(w *os.File) {
 
 Usage:
   usagebar status|update [--force]   Update sidebar metadata tokens for HERDR_PANE_ID
+  usagebar watch                     Idle $limit refresh while the limits pane is closed
   usagebar limits|panel              Interactive limits panel (q quit, r refresh)
                                      Shows providers with an open agent pane;
                                      --all shows every provider
@@ -216,31 +221,8 @@ func resolveCwd() *string {
 	return &cwd
 }
 
-// openPaneSnapshots lists open agent panes; ok=false means the herdr pane
-// query failed (unknown state), as opposed to a confirmed empty pane list.
 func openPaneSnapshots() ([]limits.OpenPaneSnapshot, bool) {
-	open, ok := herdrcli.ListOpenAgentPanesOK()
-	snaps := make([]limits.OpenPaneSnapshot, 0, len(open))
-	for _, p := range open {
-		agent := ""
-		if p.Agent != nil {
-			agent = *p.Agent
-		}
-		label := agent
-		if p.RowLabel != nil {
-			label = *p.RowLabel
-		}
-		var sid *string
-		if p.AgentSession != nil {
-			sid = &p.AgentSession.Value
-		}
-		cwd := herdrcli.PaneSessionCwd(p.PaneInfo)
-		snaps = append(snaps, limits.OpenPaneSnapshot{
-			PaneID: p.PaneID, Agent: agent, Label: label,
-			SessionID: sid, Cwd: cwd,
-		})
-	}
-	return snaps, ok
+	return update.ListOpenPaneSnapshots()
 }
 
 // panelSnapshot is what one panel render needs: subscription providers plus
@@ -366,11 +348,13 @@ func runLimitsPane(args []string) error {
 		cachedSnap = collectPanel(nowMs, activeOnly)
 		cachedLoaded = true
 		cachedNowMs = nowMs
+		update.TouchPaneHeartbeat(time.Now())
+		update.PublishCollectedLimits(cachedSnap.providers, nowMs)
 		paintFrame(limits.FormatUsagePanel(cachedSnap.providers, cachedSnap.apiUsage, nowMs, layoutFor()))
 	}
 	renderFull()
 
-	ticker := time.NewTicker(15 * time.Second)
+	ticker := time.NewTicker(update.PaneRefreshInterval)
 	defer ticker.Stop()
 
 	// SIGWINCH: instant layout-only repaint (debounced full refresh after drag
@@ -468,6 +452,20 @@ func runNotify() {
 	opts.Only = limits.BillingProviderFilter(snaps, panesOK, limits.DefaultBillingDeps())
 	providers := limits.CollectAllProviderLimits(resolveCwd(), nowMs, opts)
 	limits.NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, config.RemainingThresholds)
+}
+
+func startIdleWatch() {
+	if update.WatchAlreadyRunning(time.Now()) {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, "watch")
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	_ = cmd.Start()
 }
 
 func runStatusLine() {

--- a/internal/update/heartbeat.go
+++ b/internal/update/heartbeat.go
@@ -1,0 +1,70 @@
+/**
+ * Tracks whether the Agent Usage pane is currently collecting so the idle
+ * watcher can back off instead of running a second clock.
+ */
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const (
+	// PaneRefreshInterval is the Agent Usage pane's collect tick.
+	PaneRefreshInterval = 15 * time.Second
+	// WatchRefreshInterval is the idle $limit collect tick while the pane is closed.
+	WatchRefreshInterval = 60 * time.Second
+	heartbeatFileName    = "limits-pane.heartbeat"
+	// heartbeatFreshFor is slightly longer than PaneRefreshInterval so a
+	// slow collect cannot look like the pane closed.
+	heartbeatFreshFor = 20 * time.Second
+)
+
+func pluginStateDir() string {
+	if v := os.Getenv("USAGEBAR_STATE_DIR"); v != "" {
+		_ = os.MkdirAll(v, 0o755)
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".claude", "herdr-usagebar")
+	_ = os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+func paneHeartbeatPath() string {
+	if v := os.Getenv("USAGEBAR_PANE_HEARTBEAT_PATH"); v != "" {
+		return v
+	}
+	return filepath.Join(pluginStateDir(), heartbeatFileName)
+}
+
+// TouchPaneHeartbeat records that the Agent Usage pane just collected.
+func TouchPaneHeartbeat(now time.Time) {
+	path := paneHeartbeatPath()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.WriteFile(path, []byte(strconv.FormatInt(now.UnixMilli(), 10)+"\n"), 0o644)
+}
+
+// PaneHeartbeatFresh reports whether the Agent Usage pane collected recently
+// enough that the idle watcher should skip this tick.
+func PaneHeartbeatFresh(now time.Time, freshFor time.Duration) bool {
+	raw, err := os.ReadFile(paneHeartbeatPath())
+	if err != nil {
+		return false
+	}
+	ms, err := strconv.ParseInt(trimNewline(string(raw)), 10, 64)
+	if err != nil || ms <= 0 {
+		return false
+	}
+	written := time.UnixMilli(ms)
+	return now.Sub(written) >= 0 && now.Sub(written) <= freshFor
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/update/heartbeat_test.go
+++ b/internal/update/heartbeat_test.go
@@ -1,0 +1,54 @@
+/**
+ * Tests for the Agent Usage pane heartbeat used to back off the idle watcher.
+ */
+package update
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func isolateHeartbeat(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("USAGEBAR_STATE_DIR", dir)
+	t.Setenv("USAGEBAR_PANE_HEARTBEAT_PATH", filepath.Join(dir, heartbeatFileName))
+}
+
+func TestPaneHeartbeatFresh_MissingIsStale(t *testing.T) {
+	isolateHeartbeat(t)
+	if PaneHeartbeatFresh(time.UnixMilli(1_700_000_000_000), heartbeatFreshFor) {
+		t.Fatal("missing heartbeat must not look fresh")
+	}
+}
+
+func TestPaneHeartbeatFresh_WithinWindow(t *testing.T) {
+	isolateHeartbeat(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	TouchPaneHeartbeat(now)
+	if !PaneHeartbeatFresh(now.Add(15*time.Second), heartbeatFreshFor) {
+		t.Fatal("15s-old heartbeat must still be fresh")
+	}
+}
+
+func TestPaneHeartbeatFresh_Expired(t *testing.T) {
+	isolateHeartbeat(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	TouchPaneHeartbeat(now)
+	if PaneHeartbeatFresh(now.Add(21*time.Second), heartbeatFreshFor) {
+		t.Fatal("heartbeat older than 20s must be stale")
+	}
+}
+
+func TestShouldSkipWatchTick_FollowsHeartbeat(t *testing.T) {
+	isolateHeartbeat(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	if ShouldSkipWatchTick(now) {
+		t.Fatal("no heartbeat: watcher must collect")
+	}
+	TouchPaneHeartbeat(now)
+	if !ShouldSkipWatchTick(now) {
+		t.Fatal("fresh pane collect: watcher must skip")
+	}
+}

--- a/internal/update/panes.go
+++ b/internal/update/panes.go
@@ -1,0 +1,40 @@
+/**
+ * Builds OpenPaneSnapshot rows from Herdr's open-agent pane list so the
+ * limits pane and the $limit publisher see the same set of panes.
+ */
+package update
+
+import (
+	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+)
+
+// ListOpenPaneSnapshots lists open agent panes. ok=false means the herdr
+// query failed (unknown state), as opposed to a confirmed empty list.
+func ListOpenPaneSnapshots() ([]limits.OpenPaneSnapshot, bool) {
+	open, ok := herdrcli.ListOpenAgentPanesOK()
+	if !ok {
+		return nil, false
+	}
+	snaps := make([]limits.OpenPaneSnapshot, 0, len(open))
+	for _, p := range open {
+		agent := ""
+		if p.Agent != nil {
+			agent = *p.Agent
+		}
+		label := agent
+		if p.RowLabel != nil {
+			label = *p.RowLabel
+		}
+		var sid *string
+		if p.AgentSession != nil {
+			sid = &p.AgentSession.Value
+		}
+		cwd := herdrcli.PaneSessionCwd(p.PaneInfo)
+		snaps = append(snaps, limits.OpenPaneSnapshot{
+			PaneID: p.PaneID, Agent: agent, Label: label,
+			SessionID: sid, Cwd: cwd,
+		})
+	}
+	return snaps, true
+}

--- a/internal/update/publish.go
+++ b/internal/update/publish.go
@@ -1,0 +1,191 @@
+/**
+ * Fans a collected ProviderLimits snapshot out to open panes' $limit tokens.
+ *
+ * $limit is account state, so one collect updates every pane that bills the
+ * same account. $context stays event-driven except the multi-profile limit
+ * prefix that already lives on that row. Empty snapshots never blank a
+ * last-known-good token. Pay-as-you-go burn is pane-session state and is
+ * left to the event path.
+ */
+package update
+
+import (
+	"strings"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
+	"github.com/senna-lang/herdr-agent-usage/internal/providers/opencode"
+)
+
+// LimitPublishPane is one open pane as the publisher sees it.
+// Billing and profile identity are resolved by the caller so this type
+// stays provider-neutral.
+type LimitPublishPane struct {
+	PaneID           string
+	Resolved         bool
+	BillingMode      limits.BillingMode
+	LimitsProviderID string
+	MultiProfile     bool
+	AccountLabel     string
+	Tokens           map[string]string
+}
+
+// LimitPublishTarget is one metadata write. ContextToken is nil when $context
+// must not be touched.
+type LimitPublishTarget struct {
+	PaneID       string
+	LimitToken   string
+	ContextToken *string
+}
+
+// LimitPublishTargets decides $limit (and multi-profile $context prefix)
+// writes from one collected snapshot. It does not I/O.
+func LimitPublishTargets(providers []limits.ProviderLimits, panes []LimitPublishPane, nowMs int64) []LimitPublishTarget {
+	byID := make(map[string]limits.ProviderLimits, len(providers))
+	for _, provider := range providers {
+		byID[provider.ProviderID] = provider
+	}
+	var out []LimitPublishTarget
+	for _, pane := range panes {
+		if !pane.Resolved || pane.BillingMode == limits.BillingPayAsYouGo {
+			continue
+		}
+		provider, ok := byID[pane.LimitsProviderID]
+		if !ok {
+			continue
+		}
+		limitText := limits.FormatSidebarLimit(provider, nowMs)
+		if limitText == "" {
+			continue
+		}
+		target := LimitPublishTarget{PaneID: pane.PaneID, LimitToken: limitText}
+		if pane.MultiProfile && pane.AccountLabel != "" {
+			target.LimitToken = pane.AccountLabel
+			ctx := replaceContextLimitPrefix(tokenValue(pane.Tokens, "context"), limitText)
+			target.ContextToken = &ctx
+		}
+		out = append(out, target)
+	}
+	return out
+}
+
+func tokenValue(tokens map[string]string, name string) string {
+	if tokens == nil {
+		return ""
+	}
+	return tokens[name]
+}
+
+// replaceContextLimitPrefix updates the limit segment parked on $context for
+// multi-profile panes without recomputing the context meter.
+func replaceContextLimitPrefix(current, limitText string) string {
+	if limitText == "" {
+		return current
+	}
+	if current == "" {
+		return limitText
+	}
+	if i := strings.Index(current, " · "); i >= 0 {
+		return limitText + current[i:]
+	}
+	if strings.Contains(current, "⛁") || strings.Contains(current, "compacted") {
+		return limitText + " · " + current
+	}
+	return limitText
+}
+
+func applyLimitPublishTargets(writer metadataTokenWriter, panes []LimitPublishPane, targets []LimitPublishTarget) {
+	tokensByPane := make(map[string]map[string]string, len(panes))
+	for _, pane := range panes {
+		tokensByPane[pane.PaneID] = pane.Tokens
+	}
+	for _, target := range targets {
+		current := tokensByPane[target.PaneID]
+		writeMetadataTokenWith(writer, current, target.PaneID, "limit", target.LimitToken, false)
+		if target.ContextToken != nil {
+			writeMetadataTokenWith(writer, current, target.PaneID, "context", *target.ContextToken, false)
+		}
+	}
+}
+
+func sidebarAccountIdentity(
+	agent, providerID string,
+	claudeProfiles []claude.ClaudeProfile,
+	codexProfiles []codex.CodexProfile,
+	grokProfiles []grok.GrokProfile,
+	openCodeProfiles []opencode.OpenCodeProfile,
+) (multi bool, account string) {
+	multi = (agent == "claude" && len(claudeProfiles) > 1) ||
+		(agent == "codex" && len(codexProfiles) > 1) ||
+		(agent == "grok" && len(grokProfiles) > 1) ||
+		(agent == "opencode" && len(openCodeProfiles) > 1)
+	if !multi {
+		return false, ""
+	}
+	switch agent {
+	case "claude":
+		if profile, ok := findClaudeProfile(claudeProfiles, providerID); ok {
+			return true, resolveSidebarAccountLabel(profile)
+		}
+	case "codex":
+		if profile, ok := findCodexProfile(codexProfiles, providerID); ok {
+			return true, profile.Label
+		}
+	case "grok":
+		if profile, ok := findGrokProfile(grokProfiles, providerID); ok {
+			return true, profile.Label
+		}
+	case "opencode":
+		if profile, ok := findOpenCodeProfile(openCodeProfiles, providerID); ok {
+			return true, profile.Label
+		}
+	}
+	return true, ""
+}
+
+// PublishCollectedLimits writes $limit for every open subscription pane from
+// an already-collected snapshot. A failed pane query is a no-op so a
+// transient herdr error cannot blank rows.
+func PublishCollectedLimits(providers []limits.ProviderLimits, nowMs int64) {
+	PublishCollectedLimitsWith(herdrMetadataTokenWriter, herdrcli.GetPaneInfo, providers, nowMs)
+}
+
+func PublishCollectedLimitsWith(
+	writer metadataTokenWriter,
+	getPane func(string) herdrcli.PaneInfo,
+	providers []limits.ProviderLimits,
+	nowMs int64,
+) {
+	snaps, ok := ListOpenPaneSnapshots()
+	if !ok {
+		return
+	}
+	claudeProfiles := limits.ResolvedClaudeProfiles()
+	codexProfiles := limits.ResolvedCodexProfiles()
+	grokProfiles := limits.ResolvedGrokProfiles()
+	openCodeProfiles := limits.ResolvedOpenCodeProfiles()
+	resolve := limits.BuildHarnessPaneProviderResolver(claudeProfiles, codexProfiles, grokProfiles, openCodeProfiles)
+	billing := limits.DefaultBillingDeps()
+	panes := make([]LimitPublishPane, 0, len(snaps))
+	for _, snap := range snaps {
+		providerID, resolved := resolve(snap)
+		info := getPane(snap.PaneID)
+		pane := LimitPublishPane{
+			PaneID:   snap.PaneID,
+			Resolved: resolved,
+			Tokens:   info.Tokens,
+		}
+		if resolved {
+			pane.BillingMode = limits.PaneBillingMode(providerID, snap, billing)
+			pane.LimitsProviderID = limits.SubscriptionLimitsProviderID(providerID, snap)
+			pane.MultiProfile, pane.AccountLabel = sidebarAccountIdentity(
+				snap.Agent, providerID, claudeProfiles, codexProfiles, grokProfiles, openCodeProfiles,
+			)
+		}
+		panes = append(panes, pane)
+	}
+	applyLimitPublishTargets(writer, panes, LimitPublishTargets(providers, panes, nowMs))
+}

--- a/internal/update/publish_test.go
+++ b/internal/update/publish_test.go
@@ -1,0 +1,245 @@
+/**
+ * Tests for account-snapshot fan-out onto sidebar $limit tokens.
+ */
+package update
+
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+)
+
+func intp(v int) *int { return &v }
+
+func window(used float64, minutes int) *limits.LimitWindow {
+	return &limits.LimitWindow{UsedPercentage: used, WindowMinutes: intp(minutes)}
+}
+
+func TestLimitPublishTargets_SubscriptionPaneGetsMatchingProvider(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	panes := []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+	}}
+	got := LimitPublishTargets(providers, panes, 0)
+	if len(got) != 1 || got[0].PaneID != "w1:p1" || got[0].LimitToken != "5h 72%" {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].ContextToken != nil {
+		t.Fatal("single-profile must not touch $context")
+	}
+}
+
+func TestLimitPublishTargets_TwoPanesSameAccount(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(13, 300),
+	}}
+	panes := []LimitPublishPane{
+		{PaneID: "w1:p1", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
+		{PaneID: "w1:p2", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
+	}
+	got := LimitPublishTargets(providers, panes, 0)
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].LimitToken != "5h 87%" || got[1].LimitToken != "5h 87%" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_RoutesEachPaneToOwnProvider(t *testing.T) {
+	providers := []limits.ProviderLimits{
+		{ProviderID: "claude", Primary: window(28, 300)},
+		{ProviderID: "grok", Primary: window(86, 10080)},
+	}
+	panes := []LimitPublishPane{
+		{PaneID: "p-claude", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
+		{PaneID: "p-grok", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "grok"},
+	}
+	got := LimitPublishTargets(providers, panes, 0)
+	if len(got) != 2 || got[0].LimitToken != "5h 72%" || got[1].LimitToken != "7d 14%" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_SkipsMissingProvider(t *testing.T) {
+	got := LimitPublishTargets(nil, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+	}}, 0)
+	if len(got) != 0 {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_SkipsEmptyLimit(t *testing.T) {
+	providers := []limits.ProviderLimits{{ProviderID: "claude"}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+	}}, 0)
+	if len(got) != 0 {
+		t.Fatalf("empty windows must keep last-known-good, got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_SkipsPayAsYouGo(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingPayAsYouGo,
+		LimitsProviderID: "claude",
+	}}, 0)
+	if len(got) != 0 {
+		t.Fatalf("PAYG must stay on the event path, got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_SkipsUnresolved(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         false,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+	}}, 0)
+	if len(got) != 0 {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_UnknownBillingFailOpen(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "opencode",
+		Primary:    window(20, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingUnknown,
+		LimitsProviderID: "opencode",
+	}}, 0)
+	if len(got) != 1 || got[0].LimitToken != "5h 80%" {
+		t.Fatalf("unknown billing must fail open, got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_MultiProfileMovesPercentToContext(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+		MultiProfile:     true,
+		AccountLabel:     "user@example.com",
+		Tokens:           map[string]string{"context": "5h 99% · ⛁ 14% (136k)"},
+	}}, 0)
+	if len(got) != 1 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].LimitToken != "user@example.com" {
+		t.Fatalf("limit=%q", got[0].LimitToken)
+	}
+	if got[0].ContextToken == nil || *got[0].ContextToken != "5h 72% · ⛁ 14% (136k)" {
+		t.Fatalf("context=%v", got[0].ContextToken)
+	}
+}
+
+func TestLimitPublishTargets_MultiProfileWithoutAccountLabelKeepsLimitRow(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+		MultiProfile:     true,
+	}}, 0)
+	if len(got) != 1 || got[0].LimitToken != "5h 72%" || got[0].ContextToken != nil {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestReplaceContextLimitPrefix(t *testing.T) {
+	tests := []struct {
+		current, limit, want string
+	}{
+		{"", "5h 72%", "5h 72%"},
+		{"5h 99% · ⛁ 14% (136k)", "5h 72%", "5h 72% · ⛁ 14% (136k)"},
+		{"⛁ 14% (136k)", "5h 72%", "5h 72% · ⛁ 14% (136k)"},
+		{"compacted (120k)", "5h 72%", "5h 72% · compacted (120k)"},
+		{"5h 99%", "5h 72%", "5h 72%"},
+		{"5h 99% · 14%", "5h 72%", "5h 72% · 14%"},
+	}
+	for _, tt := range tests {
+		if got := replaceContextLimitPrefix(tt.current, tt.limit); got != tt.want {
+			t.Fatalf("current=%q limit=%q got=%q want=%q", tt.current, tt.limit, got, tt.want)
+		}
+	}
+}
+
+func TestApplyLimitPublishTargets_SkipsUnchangedLimit(t *testing.T) {
+	set := map[string]int{}
+	writer := metadataTokenWriter{
+		set: func(paneID, _, name, _ string) bool {
+			set[paneID+"/"+name]++
+			return true
+		},
+		clear: func(_, _, _ string) bool { return true },
+	}
+	panes := []LimitPublishPane{{
+		PaneID: "w1:p1",
+		Tokens: map[string]string{"limit": "5h 72%"},
+	}}
+	applyLimitPublishTargets(writer, panes, []LimitPublishTarget{
+		{PaneID: "w1:p1", LimitToken: "5h 72%"},
+	})
+	if set["w1:p1/limit"] != 0 {
+		t.Fatalf("unchanged token was written: %v", set)
+	}
+}
+
+func TestApplyLimitPublishTargets_WritesChangedLimitAndContext(t *testing.T) {
+	set := map[string]string{}
+	writer := metadataTokenWriter{
+		set: func(paneID, _, name, value string) bool {
+			set[paneID+"/"+name] = value
+			return true
+		},
+		clear: func(_, _, _ string) bool { return true },
+	}
+	ctx := "5h 72% · ⛁ 14% (136k)"
+	panes := []LimitPublishPane{{
+		PaneID: "w1:p1",
+		Tokens: map[string]string{"limit": "old@example.com", "context": "5h 99% · ⛁ 14% (136k)"},
+	}}
+	applyLimitPublishTargets(writer, panes, []LimitPublishTarget{
+		{PaneID: "w1:p1", LimitToken: "user@example.com", ContextToken: &ctx},
+	})
+	if set["w1:p1/limit"] != "user@example.com" || set["w1:p1/context"] != ctx {
+		t.Fatalf("got %v", set)
+	}
+}

--- a/internal/update/watch.go
+++ b/internal/update/watch.go
@@ -1,0 +1,169 @@
+/**
+ * Idle $limit refresh: one collect every WatchRefreshInterval while the
+ * Agent Usage pane is closed, then fan the snapshot out to open panes.
+ *
+ * A lock file keeps a single watcher. A second start exits immediately.
+ * Ticks are skipped while the pane heartbeat is fresh so the 15s pane
+ * collect remains the only clock when the pane is open. The lock mtime is
+ * refreshed on every tick, including skipped ones, so a live watcher is
+ * never treated as stale.
+ */
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/limits"
+)
+
+const (
+	watchLockName  = "limits-watch.lock"
+	watchLockStale = 2 * time.Minute
+)
+
+func watchLockPath() string {
+	if v := os.Getenv("USAGEBAR_WATCH_LOCK_PATH"); v != "" {
+		return v
+	}
+	return filepath.Join(pluginStateDir(), watchLockName)
+}
+
+// WatchAlreadyRunning is true when a live watcher holds the lock.
+func WatchAlreadyRunning(now time.Time) bool {
+	st, err := os.Stat(watchLockPath())
+	if err != nil {
+		return false
+	}
+	return now.Sub(st.ModTime()) <= watchLockStale
+}
+
+func tryAcquireWatchLock(now time.Time) (*os.File, bool) {
+	path := watchLockPath()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err == nil {
+		touchWatchLock(now)
+		return f, true
+	}
+	st, statErr := os.Stat(path)
+	if statErr != nil {
+		return nil, false
+	}
+	if now.Sub(st.ModTime()) <= watchLockStale {
+		return nil, false
+	}
+	_ = os.Remove(path)
+	f, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, false
+	}
+	touchWatchLock(now)
+	return f, true
+}
+
+func touchWatchLock(now time.Time) {
+	_ = os.Chtimes(watchLockPath(), now, now)
+}
+
+func releaseWatchLock(f *os.File) {
+	if f != nil {
+		_ = f.Close()
+	}
+	_ = os.Remove(watchLockPath())
+}
+
+func collectWatchProviders(cwd *string, nowMs int64) []limits.ProviderLimits {
+	opts := limits.DefaultCollectOptions()
+	snaps, panesOK := ListOpenPaneSnapshots()
+	opts.Only = limits.BillingProviderFilter(snaps, panesOK, limits.DefaultBillingDeps())
+	return limits.CollectAllProviderLimits(cwd, nowMs, opts)
+}
+
+// ShouldSkipWatchTick is true when the Agent Usage pane is already
+// publishing on its 15s loop.
+func ShouldSkipWatchTick(now time.Time) bool {
+	return PaneHeartbeatFresh(now, heartbeatFreshFor)
+}
+
+type watchLoop struct {
+	now     func() time.Time
+	sleep   func(time.Duration)
+	stop    <-chan struct{}
+	skip    func(time.Time) bool
+	tick    func()
+	acquire func(time.Time) (*os.File, bool)
+	release func(*os.File)
+	touch   func(time.Time)
+}
+
+func (w watchLoop) run() {
+	if w.now == nil || w.sleep == nil || w.tick == nil || w.acquire == nil {
+		return
+	}
+	lock, ok := w.acquire(w.now())
+	if !ok {
+		return
+	}
+	if w.release != nil {
+		defer w.release(lock)
+	}
+	runTick := func() {
+		now := w.now()
+		if w.touch != nil {
+			w.touch(now)
+		}
+		if w.skip != nil && w.skip(now) {
+			return
+		}
+		w.tick()
+	}
+	runTick()
+	for {
+		if stopped(w.stop) {
+			return
+		}
+		w.sleep(WatchRefreshInterval)
+		if stopped(w.stop) {
+			return
+		}
+		runTick()
+	}
+}
+
+func stopped(stop <-chan struct{}) bool {
+	if stop == nil {
+		return false
+	}
+	select {
+	case <-stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// RunWatch holds the singleton lock and refreshes idle $limit rows until
+// the process is killed. A second instance exits without collecting.
+func RunWatch(cwd *string, now func() time.Time, sleep func(time.Duration), stop <-chan struct{}) {
+	if now == nil {
+		now = time.Now
+	}
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	watchLoop{
+		now:     now,
+		sleep:   sleep,
+		stop:    stop,
+		skip:    ShouldSkipWatchTick,
+		acquire: tryAcquireWatchLock,
+		release: releaseWatchLock,
+		touch:   touchWatchLock,
+		tick: func() {
+			nowMs := now().UnixMilli()
+			PublishCollectedLimits(collectWatchProviders(cwd, nowMs), nowMs)
+		},
+	}.run()
+}

--- a/internal/update/watch_test.go
+++ b/internal/update/watch_test.go
@@ -1,0 +1,123 @@
+/**
+ * Tests for the idle $limit watcher lock and skip/tick loop.
+ */
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func isolateWatch(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("USAGEBAR_STATE_DIR", dir)
+	t.Setenv("USAGEBAR_WATCH_LOCK_PATH", filepath.Join(dir, watchLockName))
+	t.Setenv("USAGEBAR_PANE_HEARTBEAT_PATH", filepath.Join(dir, heartbeatFileName))
+}
+
+func TestTryAcquireWatchLock_SecondInstanceLoses(t *testing.T) {
+	isolateWatch(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	first, ok := tryAcquireWatchLock(now)
+	if !ok {
+		t.Fatal("first acquire must succeed")
+	}
+	defer releaseWatchLock(first)
+	if _, ok := tryAcquireWatchLock(now.Add(time.Second)); ok {
+		t.Fatal("second live watcher must lose")
+	}
+}
+
+func TestWatchAlreadyRunning(t *testing.T) {
+	isolateWatch(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	if WatchAlreadyRunning(now) {
+		t.Fatal("missing lock is not running")
+	}
+	first, ok := tryAcquireWatchLock(now)
+	if !ok {
+		t.Fatal("acquire")
+	}
+	defer releaseWatchLock(first)
+	if !WatchAlreadyRunning(now.Add(time.Second)) {
+		t.Fatal("live lock must look running")
+	}
+	if WatchAlreadyRunning(now.Add(watchLockStale + time.Second)) {
+		t.Fatal("stale lock must not look running")
+	}
+}
+
+func TestTryAcquireWatchLock_StaleLockIsReclaimed(t *testing.T) {
+	isolateWatch(t)
+	now := time.UnixMilli(1_700_000_000_000)
+	if err := os.WriteFile(watchLockPath(), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := now.Add(-watchLockStale - time.Second)
+	if err := os.Chtimes(watchLockPath(), stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	lock, ok := tryAcquireWatchLock(now)
+	if !ok {
+		t.Fatal("stale lock must be reclaimed")
+	}
+	releaseWatchLock(lock)
+}
+
+func TestWatchLoop_SecondAcquireDoesNotTick(t *testing.T) {
+	ticks := 0
+	watchLoop{
+		now:   func() time.Time { return time.UnixMilli(1) },
+		sleep: func(time.Duration) {},
+		stop:  alreadyStopped(),
+		tick:  func() { ticks++ },
+		acquire: func(time.Time) (*os.File, bool) {
+			return nil, false
+		},
+	}.run()
+	if ticks != 0 {
+		t.Fatalf("ticks=%d", ticks)
+	}
+}
+
+func TestWatchLoop_SkipsThenTicks(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	ticks := 0
+	skips := 0
+	sleeps := 0
+	stop := make(chan struct{})
+	watchLoop{
+		now: func() time.Time { return now },
+		sleep: func(d time.Duration) {
+			if d != WatchRefreshInterval {
+				t.Fatalf("slept %s", d)
+			}
+			sleeps++
+			now = now.Add(d)
+		},
+		stop: stop,
+		skip: func(time.Time) bool {
+			skips++
+			return skips == 1
+		},
+		tick: func() {
+			ticks++
+			close(stop)
+		},
+		acquire: func(time.Time) (*os.File, bool) { return nil, true },
+		release: func(*os.File) {},
+		touch:   func(time.Time) {},
+	}.run()
+	if ticks != 1 || skips != 2 || sleeps != 1 {
+		t.Fatalf("ticks=%d skips=%d sleeps=%d", ticks, skips, sleeps)
+	}
+}
+
+func alreadyStopped() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}


### PR DESCRIPTION
Closes #71

Idle panes kept a stale `$limit` because the Agent Usage pane ticked every 15s while the sidebar only wrote tokens on `pane.focused` / `pane.agent_status_changed`. Both surfaces already format `ProviderLimits`; the missing piece was publishing that snapshot to every open subscription pane.

- Pane collect (15s) fans the same snapshot out to `$limit` on every pane that bills the account.
- A singleton `usagebar watch` process covers the closed-pane gap at 60s and backs off while the pane heartbeat is fresh, so there is still one clock.
- `$context` stays event-driven. Multi-profile panes only refresh the limit prefix already parked on that row.
- Pay-as-you-go burn and empty snapshots are left alone so a timer cannot blank last-known-good.

## Test plan

- [x] `go test ./internal/update/ ./cmd/usagebar/`
- [x] `go test ./...`
- [x] Focus an idle subscription pane after a window reset without clicking it; `$limit` should move within 60s (or 15s if the Agent Usage pane is open)