### PR TITLE
feat(plugin): restore sidebar tokens on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/senna-lang/herdr-agent-usage/actions/workflows/ci.yml/badge.svg)](https://github.com/senna-lang/herdr-agent-usage/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go&logoColor=white)
-![herdr 0.7.4+](https://img.shields.io/badge/herdr-0.7.4%2B-6E56CF)
+![herdr 0.7.5+](https://img.shields.io/badge/herdr-0.7.5%2B-6E56CF)
 ![platforms: linux | macOS](https://img.shields.io/badge/platforms-linux%20%7C%20macOS-lightgrey)
 
 Monitor context usage and provider rate limits for agents running in [Herdr](https://herdr.dev).
@@ -18,7 +18,7 @@ Monitor context usage and provider rate limits for agents running in [Herdr](htt
 
 ## Requirements
 
-- **Herdr ≥ 0.7.4**
+- **Herdr ≥ 0.7.5**
 - **macOS or Linux**
 - Agent integrations for reliable session matching (recommended):
 
@@ -61,7 +61,7 @@ The agent can install the plugin and guide you through the remaining setup.
 1. Install the plugin and run **setup** (above).
 2. Open a workspace with at least one agent pane.
 3. Add the sidebar rows printed by `usagebar.setup` to your Herdr config, then run `herdr server reload-config`.
-4. After an agent turn completes (or you focus the pane), the sidebar shows provider limit remaining above context usage. `$limit` also refreshes on its own while the pane sits idle.
+4. After an agent turn completes (or you focus the pane), the sidebar shows provider limit remaining above context usage. `$limit` also refreshes on its own while the pane sits idle. A Herdr restart restores the same tokens via the plugin startup hook.
 5. Open the limits pane:
 
 ```bash
@@ -126,7 +126,7 @@ Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
 
 ## Agent Usage pane
 
-- Auto-refreshes every **15s**, and the same collect updates sidebar `$limit` on every open subscription pane. Press **`r`** to refresh, **`q`** to quit. With the pane closed, `$limit` still moves every **60s**. `$context` stays event-driven.
+- Auto-refreshes every **15s**, and the same collect updates sidebar `$limit` on every open subscription pane. Press **`r`** to refresh, **`q`** to quit. With the pane closed, `$limit` still moves every **60s**. `$context` stays event-driven after the initial restore. After a Herdr restart or live handoff, a `[[startup]]` hook republishes `$title` / `$provider` / `$limit` / `$context` for every open agent pane so the sidebar is not blank until the next focus or turn.
 - OpenCode Go may show three windows (**5h / 7d / 30d**). Other providers show whichever usage windows their data sources make available.
 - Open pane **token share** is local activity share within the shortest window (including a **closed / other** bucket for usage outside open panes). It is not account quota attribution.
 - Sidebar meters update after the agent has **settled** (not while `working`), so they match the last completed turn. If the session cannot be resolved, the `$context` token is cleared rather than showing another session’s numbers.

--- a/bin/run-startup.sh
+++ b/bin/run-startup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Herdr [[startup]] / live-handoff hook: republish sidebar tokens for
+# every open agent pane. Server-owned metadata does not survive a cold
+# restart; the event path only sees one HERDR_PANE_ID.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/run-usagebar.sh" startup "$@"

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -57,6 +57,10 @@ func main() {
 		}
 	case "notify":
 		runNotify()
+	case "startup":
+		// Herdr [[startup]] / live handoff: restore every open pane's tokens.
+		update.RepublishOpenAgentPanes()
+		startIdleWatch()
 	case "watch":
 		update.RunWatch(resolveCwd(), time.Now, time.Sleep, nil)
 	case "check-update":
@@ -82,6 +86,7 @@ func printUsage(w *os.File) {
 
 Usage:
   usagebar status|update [--force]   Update sidebar metadata tokens for HERDR_PANE_ID
+  usagebar startup                   Restore tokens for every open agent pane
   usagebar watch                     Idle $limit refresh while the limits pane is closed
   usagebar limits|panel              Interactive limits panel (q quit, r refresh)
                                      Shows providers with an open agent pane;

--- a/docs/LLM-SETUP.md
+++ b/docs/LLM-SETUP.md
@@ -64,7 +64,7 @@ End state:
 ### 1. Prerequisites
 
 - Confirm `herdr` is on `PATH` and works (`herdr --help` or `herdr plugin list`).  
-- Herdr **≥ 0.7.4** is required.
+- Herdr **≥ 0.7.5** is required.
 - OS: macOS or Linux.  
 - **Go toolchain ≥ 1.25** (`go version`) recommended. `usagebar.setup`
   resolves the binary automatically on first run: it builds with Go when

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,8 +1,8 @@
 id = "usagebar"
 name = "Agent Usage"
 version = "0.5.10"
-# Configurable sidebar rows and metadata tokens landed in Herdr 0.7.4.
-min_herdr_version = "0.7.4"
+# [[startup]] hooks landed in Herdr 0.7.5. Sidebar tokens still require 0.7.4+.
+min_herdr_version = "0.7.5"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"
 platforms = ["macos", "linux"]
 
@@ -16,6 +16,12 @@ platforms = ["macos", "linux"]
 # See https://github.com/senna-lang/herdr-agent-usage/issues/48
 [[build]]
 command = ["bash", "bin/ensure-binary.sh", "--in-tree"]
+
+# Restores $title/$provider/$limit/$context after server start and live
+# handoff. Metadata tokens are ephemeral across a cold restart; event
+# hooks only see the focused pane.
+[[startup]]
+command = ["bash", "bin/run-startup.sh"]
 
 [[events]]
 on = "pane.agent_status_changed"

--- a/internal/update/startup.go
+++ b/internal/update/startup.go
@@ -1,0 +1,35 @@
+/**
+ * Republishes sidebar tokens for every open agent pane after Herdr
+ * restores the session (and again after live handoff).
+ *
+ * Server-owned metadata tokens do not survive a cold restart. The event
+ * path only sees HERDR_PANE_ID for one pane, and PublishCollectedLimits
+ * writes $limit only. Startup therefore reuses RunUpdateForPane so $title,
+ * $provider, $limit, and $context — including the post-compaction label
+ * and pay-as-you-go burn — come back in one pass. force is false so the
+ * live-token dedupe still applies when handoff leaves tokens already set.
+ */
+package update
+
+import "github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
+
+// RepublishOpenAgentPanes restores sidebar tokens for every open agent pane.
+func RepublishOpenAgentPanes() {
+	republishOpenAgentPanesWith(herdrcli.ListOpenAgentPanesOK, RunUpdateForPane)
+}
+
+func republishOpenAgentPanesWith(
+	list func() ([]herdrcli.OpenAgentPane, bool),
+	updatePane func(paneID string, force bool),
+) {
+	panes, ok := list()
+	if !ok {
+		return
+	}
+	for _, pane := range panes {
+		if pane.PaneID == "" {
+			continue
+		}
+		updatePane(pane.PaneID, false)
+	}
+}

--- a/internal/update/startup_test.go
+++ b/internal/update/startup_test.go
@@ -1,0 +1,85 @@
+/**
+ * Tests for the startup republish of sidebar tokens across open agent panes.
+ *
+ * After a Herdr restart the server-side tokens are gone. This path must
+ * visit every listed pane once, never force-write (so live-token dedupe
+ * still applies on handoff), and write nothing when the pane query failed.
+ */
+package update
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
+)
+
+func TestRepublishOpenAgentPanesWith_UpdatesEachListedPane(t *testing.T) {
+	var got []string
+	var forced []bool
+	republishOpenAgentPanesWith(
+		func() ([]herdrcli.OpenAgentPane, bool) {
+			return []herdrcli.OpenAgentPane{
+				{PaneID: "w1:p1"},
+				{PaneID: "w1:p2"},
+			}, true
+		},
+		func(paneID string, force bool) {
+			got = append(got, paneID)
+			forced = append(forced, force)
+		},
+	)
+	want := []string{"w1:p1", "w1:p2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("updated %v, want %v", got, want)
+	}
+	for i, force := range forced {
+		if force {
+			t.Fatalf("pane %s: startup must not force-write tokens", got[i])
+		}
+	}
+}
+
+func TestRepublishOpenAgentPanesWith_FailedListWritesNothing(t *testing.T) {
+	called := false
+	republishOpenAgentPanesWith(
+		func() ([]herdrcli.OpenAgentPane, bool) {
+			return []herdrcli.OpenAgentPane{{PaneID: "w1:p1"}}, false
+		},
+		func(string, bool) { called = true },
+	)
+	if called {
+		t.Fatal("a failed pane query must not republish tokens")
+	}
+}
+
+func TestRepublishOpenAgentPanesWith_EmptyListWritesNothing(t *testing.T) {
+	called := false
+	republishOpenAgentPanesWith(
+		func() ([]herdrcli.OpenAgentPane, bool) {
+			return nil, true
+		},
+		func(string, bool) { called = true },
+	)
+	if called {
+		t.Fatal("no open agent panes must not republish tokens")
+	}
+}
+
+func TestRepublishOpenAgentPanesWith_SkipsEmptyPaneID(t *testing.T) {
+	var got []string
+	republishOpenAgentPanesWith(
+		func() ([]herdrcli.OpenAgentPane, bool) {
+			return []herdrcli.OpenAgentPane{
+				{PaneID: ""},
+				{PaneID: "w1:p3"},
+			}, true
+		},
+		func(paneID string, force bool) {
+			got = append(got, paneID)
+		},
+	)
+	if !reflect.DeepEqual(got, []string{"w1:p3"}) {
+		t.Fatalf("updated %v, want [w1:p3]", got)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -198,7 +198,12 @@ func writeMetadataTokenWith(writer metadataTokenWriter, current map[string]strin
 // RunUpdate resolves usage for HERDR_PANE_ID and refreshes its sidebar tokens,
 // including while the agent is working. force bypasses unchanged-value checks.
 func RunUpdate(force bool) {
-	paneID := os.Getenv("HERDR_PANE_ID")
+	RunUpdateForPane(os.Getenv("HERDR_PANE_ID"), force)
+}
+
+// RunUpdateForPane resolves usage for paneID and refreshes its sidebar tokens.
+// force bypasses unchanged-value checks.
+func RunUpdateForPane(paneID string, force bool) {
 	if paneID == "" {
 		return
 	}


### PR DESCRIPTION
## Summary

Herdr pane metadata tokens are ephemeral across a cold restart (and are restored after live handoff). Event hooks only receive one `HERDR_PANE_ID`, so the sidebar stayed blank until the next focus or completed turn.

This adds a Herdr 0.7.5 `[[startup]]` hook that republishes `$title` / `$provider` / `$limit` / `$context` for every open agent pane by reusing `RunUpdateForPane`. That keeps the recent display contracts on one path:

- **#46** live-token dedupe (`force=false`; handoff that still has tokens does not rewrite them)
- **#52** post-compaction `$context` label
- pay-as-you-go burn (not covered by `PublishCollectedLimits`, which only writes `$limit`)

A failed `pane list` writes nothing rather than clearing last-known-good values.

## Related issue

Related issue: N/A

## Testing

- [x] `gofmt -l .` produces no output
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] Tests were added or updated where appropriate

Live (Herdr 0.8.0, this plugin linked): cleared `usagebar` tokens on idle panes `w6:p48` (omp→codex) and `w7:pC` (claude), then ran `usagebar startup`. All four tokens returned via a fresh collect (not a stale replay). Did not stop the Herdr server, so the hook firing on a real restart is unverified.

## User and compatibility impact

Requires **Herdr ≥ 0.7.5**. `[[startup]]` is a 0.7.5 manifest field; 0.7.4 rejects unknown tables, so `min_herdr_version` is raised from 0.7.4. Users still on 0.7.4 cannot install or update this revision.

After a Herdr restart or live handoff the sidebar meters should reappear without waiting for focus or a completed turn.

## AI assistance

Implemented and verified with an AI coding agent. Live restore was exercised inside a Herdr pane; the server was not restarted.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
- [x] The PR title follows Conventional Commits (e.g. `fix: ...`, `feat(providers): ...`) — see CONTRIBUTING.md for the allowed types