### PR TITLE
chore(release): prepare v0.5.11

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.10"
+version = "0.5.11"
 # [[startup]] hooks landed in Herdr 0.7.5. Sidebar tokens still require 0.7.4+.
 min_herdr_version = "0.7.5"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok"


### PR DESCRIPTION
## Summary

Bumps `herdr-plugin.toml` to `0.5.11` so `scripts/release.sh v0.5.11` can tag the startup-token restore from #75.

## Related issue

Related issue: N/A

## Testing

- [x] Version string matches the intended tag
- [ ] `scripts/release.sh v0.5.11` after this lands on `main` (CI must pass on that commit)

## User and compatibility impact

Requires Herdr ≥ 0.7.5 (`min_herdr_version` already raised in #75). After install/update, a Herdr restart republishes sidebar tokens without waiting for focus or a completed turn.

## AI assistance

Release metadata prepared with an AI coding agent.

## Checklist

- [x] This PR has one clear purpose and contains no unrelated changes
- [x] I understand the submitted change and have reviewed it for correctness
- [x] Documentation is updated where user-visible behavior changed
- [x] The PR title follows Conventional Commits