### PR TITLE
chore(release): v0.5.12

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.11"
+version = "0.5.12"
 # [[startup]] hooks landed in Herdr 0.7.5. Sidebar tokens still require 0.7.4+.
 min_herdr_version = "0.7.5"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok, plus context meters for Cursor"


### PR DESCRIPTION
Bumps the plugin manifest for the v0.5.12 release after Cursor context-provider preflight.