### PR TITLE
feat(ui): add limit_percent used presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ herdr plugin action invoke usagebar.setup
 | OMP (Oh My Pi) | Yes | Yes | Session jsonl plus its credential metadata. Subscription routes: OpenCode Go, Grok OAuth, Anthropic OAuth → Claude, and OpenAI Codex OAuth → Codex. API-key backends show backend-scoped session burn |
 | Pi coding agent | Yes | Yes | Session jsonl plus `~/.pi/agent/auth.json`; context windows come from Pi's `models-store.json` / `models.json`, and session trees plus compaction boundaries are respected. Uses the same recognized OAuth/subscription routes and pay-as-you-go rules as OMP |
 
-Percentages in the limits pane are **remaining** (`% left`). Higher is safer.
+Percentages in the limits pane default to **remaining** (`% left`). Higher is safer.
+Set `[ui] limit_percent = "used"` to show consumption instead; the bar fills as
+the window burns, but colour still tracks remaining headroom.
+
 
 ## Agent Usage pane
 
@@ -182,13 +185,19 @@ Created on first `usagebar.setup` (or when missing):
 [notify]
 enabled = true
 remaining_thresholds = [50, 20, 10, 5]
+
+[ui]
+limit_percent = "remaining"  # or "used"
 ```
 
 `enabled = false` suppresses all Agent Usage toasts, including remaining-limit
 warnings and update-available notices; statusLine summaries and cached limits
 continue to refresh. `remaining_thresholds` accepts remaining percentages from
 1 through 100 (for example `[30, 10]`); each threshold can notify once per
-window, from least to most severe.
+window, from least to most severe. `limit_percent = "used"` inverts the displayed
+number (and bar fill) on the pane, sidebar `$limit`, statusLine, and toast body;
+notify firing stays on remaining thresholds.
+
 
 ### Multiple Claude accounts
 

--- a/cmd/usagebar/main.go
+++ b/cmd/usagebar/main.go
@@ -197,7 +197,7 @@ func runStatusLineNotifications(
 	if !config.NotifyEnabled {
 		return
 	}
-	ratelimit.RunRateLimitCheckWithThresholdsIn(profile.StateDir, stdinJSON, nowMs, config.RemainingThresholds, notify)
+	ratelimit.RunRateLimitCheckWithThresholdsIn(profile.StateDir, stdinJSON, nowMs, config.RemainingThresholds, notify, config.LimitPercent)
 }
 
 func resolveCwd() *string {
@@ -294,7 +294,8 @@ func currentLayout() limits.PanelLayout {
 		}
 	}
 	color := term.IsTerminal(int(os.Stdout.Fd())) && os.Getenv("NO_COLOR") == ""
-	return limits.PanelLayout{Columns: cols, Rows: rows, Color: color}
+	cfg := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(environment()))
+	return limits.PanelLayout{Columns: cols, Rows: rows, Color: color, LimitPercent: cfg.LimitPercent}
 }
 
 // paintFrame draws text on the alternate screen.
@@ -461,7 +462,8 @@ func runNotify() {
 	snaps, panesOK := openPaneSnapshots()
 	opts.Only = limits.BillingProviderFilter(snaps, panesOK, limits.DefaultBillingDeps())
 	providers := limits.CollectAllProviderLimits(resolveCwd(), nowMs, opts)
-	limits.NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, config.RemainingThresholds)
+	limits.NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, config.RemainingThresholds, config.LimitPercent)
+
 }
 
 func startIdleWatch() {
@@ -549,7 +551,8 @@ func runStatusLine() {
 }
 
 func printStatusLineSummary(stdinJSON string) {
-	summary := ratelimit.FormatStatusLineSummary(ratelimit.ParseRateLimits(stdinJSON))
+	config := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(environment()))
+	summary := ratelimit.FormatStatusLineSummary(ratelimit.ParseRateLimits(stdinJSON), config.LimitPercent)
 	if summary != "" {
 		fmt.Println(summary)
 	}

--- a/internal/core/limitpercent.go
+++ b/internal/core/limitpercent.go
@@ -1,0 +1,61 @@
+/**
+ * LimitPercent is the presentation direction for quota percentages.
+ *
+ * remaining (default) shows headroom; used shows consumption. Notify
+ * thresholds and UsedPercentage stay remaining-based; only rendered
+ * numbers, words, and bar fill follow this flag. Colour still tracks
+ * remaining headroom in both modes.
+ */
+package core
+
+import (
+	"strconv"
+	"strings"
+)
+
+// LimitPercent is a two-value presentation enum for quota percentages.
+type LimitPercent string
+
+const (
+	// LimitPercentRemaining shows headroom (% left / % remaining). Default.
+	LimitPercentRemaining LimitPercent = "remaining"
+	// LimitPercentUsed shows consumption (% used). Bar fill follows the number.
+	LimitPercentUsed LimitPercent = "used"
+)
+
+// ParseLimitPercent resolves a config value. Unknown or empty input is remaining.
+func ParseLimitPercent(raw string) LimitPercent {
+	if strings.EqualFold(strings.TrimSpace(raw), string(LimitPercentUsed)) {
+		return LimitPercentUsed
+	}
+	return LimitPercentRemaining
+}
+
+// Used reports whether percentages should render as consumption.
+func (m LimitPercent) Used() bool {
+	return m == LimitPercentUsed
+}
+
+// DisplayPercent converts a remaining 0–100 value into the number shown to the user.
+func (m LimitPercent) DisplayPercent(remaining int) int {
+	if m.Used() {
+		return 100 - remaining
+	}
+	return remaining
+}
+
+// BarFill is the 0–100 fraction passed to the gauge. It matches DisplayPercent
+// so the bar and the number always move in the same direction.
+func (m LimitPercent) BarFill(remaining int) float64 {
+	return float64(m.DisplayPercent(remaining))
+}
+
+// InvertRemainingBucket maps a remaining-percent threshold to the displayed
+// number. used mode: 20 remaining → 80. The live window percentage is not used.
+func (m LimitPercent) InvertRemainingBucket(remainingBucket string) int {
+	n, err := strconv.Atoi(remainingBucket)
+	if err != nil {
+		return 0
+	}
+	return m.DisplayPercent(n)
+}

--- a/internal/core/limitpercent_test.go
+++ b/internal/core/limitpercent_test.go
@@ -1,0 +1,54 @@
+/**
+ * Tests for quota-percentage presentation direction.
+ */
+package core
+
+import "testing"
+
+func TestParseLimitPercent(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want LimitPercent
+	}{
+		{"", LimitPercentRemaining},
+		{"remaining", LimitPercentRemaining},
+		{" used ", LimitPercentUsed},
+		{"USED", LimitPercentUsed},
+		{"burned", LimitPercentRemaining},
+	}
+	for _, c := range cases {
+		if got := ParseLimitPercent(c.raw); got != c.want {
+			t.Fatalf("ParseLimitPercent(%q)=%q want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestLimitPercentDisplayAndFill(t *testing.T) {
+	if LimitPercentRemaining.DisplayPercent(72) != 72 {
+		t.Fatal("remaining keeps the headroom number")
+	}
+	if LimitPercentUsed.DisplayPercent(72) != 28 {
+		t.Fatal("used inverts remaining 72 to 28")
+	}
+	if LimitPercentUsed.BarFill(72) != 28 {
+		t.Fatal("bar fill follows the displayed used number")
+	}
+	if LimitPercentRemaining.BarFill(72) != 72 {
+		t.Fatal("remaining bar fill stays on headroom")
+	}
+	if (LimitPercent("")).DisplayPercent(90) != 90 {
+		t.Fatal("zero value is remaining")
+	}
+}
+
+func TestLimitPercentInvertRemainingBucket(t *testing.T) {
+	if got := LimitPercentRemaining.InvertRemainingBucket("20"); got != 20 {
+		t.Fatalf("remaining bucket display=%d", got)
+	}
+	if got := LimitPercentUsed.InvertRemainingBucket("20"); got != 80 {
+		t.Fatalf("used inverts remaining 20 to %d, want 80", got)
+	}
+	if got := LimitPercentUsed.InvertRemainingBucket("50"); got != 50 {
+		t.Fatalf("50 remaining is 50 used, got %d", got)
+	}
+}

--- a/internal/limits/claudeprofiles_io.go
+++ b/internal/limits/claudeprofiles_io.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
@@ -29,6 +30,13 @@ func processEnvMap() map[string]string {
 // the single implicit default when none are configured) from process env.
 func ResolvedClaudeProfiles() []claude.ClaudeProfile {
 	return setup.ResolveClaudeProfiles(processEnvMap())
+}
+
+// ResolvedLimitPercent is the plugin-config presentation direction for quota
+// percentages. Unknown or missing values are remaining.
+func ResolvedLimitPercent() core.LimitPercent {
+	cfg := setup.LoadPluginConfig(setup.ResolvePluginConfigDir(processEnvMap()))
+	return cfg.LimitPercent
 }
 
 // profileByIDIn looks up one profile by provider id within an already-resolved

--- a/internal/limits/formatpanel.go
+++ b/internal/limits/formatpanel.go
@@ -1,13 +1,16 @@
 /**
  * Renders a list of ProviderLimits as text for a plugin pane.
  *
- * The remaining amount is shown as a bar gauge. Herdr's plugin pane clips
- * the top lines when the viewport hugs the bottom, so we render in three
- * tiers based on the pane's rows budget:
+ * Quota percentages default to remaining (headroom). [ui] limit_percent = "used"
+ * inverts the number and bar fill so they track consumption; colour still
+ * follows remaining headroom. Herdr's plugin pane clips the top lines when
+ * the viewport hugs the bottom, so we render in three tiers based on the
+ * pane's rows budget:
  *   1. rich      : header + 2 bars + extras (pane/note)
  *   2. rich-slim : header + 2 bars (no extras)
  *   3. compact   : 1 line per provider (inline mini bar)
  */
+
 package limits
 
 import (
@@ -20,6 +23,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/senna-lang/herdr-agent-usage/internal/bar"
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 // PanelLayout gathers external layout dependencies (color/width/height).
@@ -30,6 +34,8 @@ type PanelLayout struct {
 	// EmptyMessage replaces the default "(no usage data yet)" text when the
 	// provider list is empty (e.g. "(no agent panes open)" for active-only mode).
 	EmptyMessage string
+	// LimitPercent selects remaining (default) vs used presentation.
+	LimitPercent core.LimitPercent
 }
 
 var defaultLayout = PanelLayout{Columns: 44, Rows: 9999, Color: false}
@@ -137,8 +143,12 @@ func windowLine(w *LimitWindow, tag string, layout PanelLayout, nowMs int64) str
 	}
 	rem := remainingOf(w.UsedPercentage)
 	tone := bar.ToneForRemaining(float64(rem))
-	barStr := bar.Colorize(bar.RenderBar(float64(rem), barWidth(layout.Columns)), tone, layout.Color)
-	pct := bar.Colorize(fmt.Sprintf("%3d%% left", rem), tone, layout.Color)
+	barStr := bar.Colorize(bar.RenderBar(layout.LimitPercent.BarFill(rem), barWidth(layout.Columns)), tone, layout.Color)
+	word := "left"
+	if layout.LimitPercent.Used() {
+		word = "used"
+	}
+	pct := bar.Colorize(fmt.Sprintf("%3d%% %s", layout.LimitPercent.DisplayPercent(rem), word), tone, layout.Color)
 	line := "  " + tagCol + "  " + barStr + "   " + pct
 	if w.ResetsAt != nil && *w.ResetsAt > 0 {
 		hint := formatResetIn(*w.ResetsAt*1000 - nowMs)
@@ -181,8 +191,8 @@ func inlineWindow(w *LimitWindow, tag string, layout PanelLayout) string {
 	}
 	rem := remainingOf(w.UsedPercentage)
 	tone := bar.ToneForRemaining(float64(rem))
-	barStr := bar.Colorize(bar.RenderBar(float64(rem), 5), tone, layout.Color)
-	pct := bar.Colorize(fmt.Sprintf("%d%%", rem), tone, layout.Color)
+	barStr := bar.Colorize(bar.RenderBar(layout.LimitPercent.BarFill(rem), 5), tone, layout.Color)
+	pct := bar.Colorize(fmt.Sprintf("%d%%", layout.LimitPercent.DisplayPercent(rem)), tone, layout.Color)
 	warn := ""
 	if w.RunOut != nil && w.RunOut.EmptyBeforeReset {
 		warn = bar.Colorize("⚠", bar.ToneLow, layout.Color)

--- a/internal/limits/formatpanel_test.go
+++ b/internal/limits/formatpanel_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 var wide = PanelLayout{Columns: 60, Rows: 9999, Color: false}
@@ -45,6 +47,31 @@ func TestFormatProviderBlock_HeaderBar(t *testing.T) {
 		t.Fatal("should not contain source")
 	}
 	assertNoANSI(t, text)
+}
+
+func TestFormatProviderBlock_UsedPercentInvertsNumberAndBarNotTone(t *testing.T) {
+	layout := PanelLayout{Columns: 60, Rows: 9999, Color: false, LimitPercent: core.LimitPercentUsed}
+	text := FormatProviderBlock(sampleProvider(), layout, 1_700_000_000_000)
+	for _, want := range []string{"10% used", "40% used"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "left") {
+		t.Fatalf("used mode must not say left:\n%s", text)
+	}
+	colored := FormatProviderBlock(sampleProvider(), PanelLayout{Columns: 60, Rows: 9999, Color: true, LimitPercent: core.LimitPercentUsed}, 0)
+	if !strings.Contains(colored, "\x1b[32m") {
+		t.Fatal("tone must stay remaining-based (green at 90% left / 10% used)")
+	}
+}
+
+func TestFormatLimitsPanel_UsedCompactInvertsInlinePercent(t *testing.T) {
+	layout := PanelLayout{Columns: 60, Rows: 9, Color: false, LimitPercent: core.LimitPercentUsed}
+	compact := FormatLimitsPanel([]ProviderLimits{sampleProvider(), sampleProvider(), sampleProvider()}, 1_700_000_000_000, layout)
+	if !strings.Contains(compact, "10%") || strings.Contains(compact, "90%") {
+		t.Fatalf("compact used mode should show consumed percent:\n%s", compact)
+	}
 }
 
 func TestFormatProviderBlock_EmDash(t *testing.T) {

--- a/internal/limits/formatsidebar.go
+++ b/internal/limits/formatsidebar.go
@@ -9,6 +9,8 @@ package limits
 import (
 	"fmt"
 	"math"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 // FormatSidebarBurn renders a pane's total token consumption (and USD cost,
@@ -69,8 +71,10 @@ func formatCompactTokens(tokens float64) string {
 // recorded reset time has passed: providers may refresh that window shortly
 // after the boundary, and switching to a longer window makes the sidebar
 // unstable. Collection freshness is handled by the provider adapters.
-// Context usage remains in its own $context row.
-func FormatSidebarLimit(provider ProviderLimits, _ int64) string {
+// Context usage remains in its own $context row. percent selects remaining
+// (default) vs used presentation; the tag has no left/used suffix.
+func FormatSidebarLimit(provider ProviderLimits, _ int64, percent core.LimitPercent) string {
+
 	candidates := []struct {
 		window   *LimitWindow
 		fallback string
@@ -109,5 +113,6 @@ func FormatSidebarLimit(provider ProviderLimits, _ int64) string {
 	if shortest == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s %d%%", windowTag(shortest.window, shortest.fallback), remainingOf(shortest.window.UsedPercentage))
+	return fmt.Sprintf("%s %d%%", windowTag(shortest.window, shortest.fallback), percent.DisplayPercent(remainingOf(shortest.window.UsedPercentage)))
+
 }

--- a/internal/limits/formatsidebar_test.go
+++ b/internal/limits/formatsidebar_test.go
@@ -1,6 +1,10 @@
 package limits
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+)
 
 const sidebarNowMs int64 = 1_800_000_000_000
 
@@ -11,7 +15,15 @@ func TestFormatSidebarLimit_PrefersShortestAvailableWindow(t *testing.T) {
 		Primary:   &LimitWindow{UsedPercentage: 28.4, WindowMinutes: &five},
 		Secondary: &LimitWindow{UsedPercentage: 70, WindowMinutes: &seven},
 	}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 72%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "5h 72%" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFormatSidebarLimit_UsedPercentInvertsNumber(t *testing.T) {
+	five := 300
+	p := ProviderLimits{Primary: &LimitWindow{UsedPercentage: 28.4, WindowMinutes: &five}}
+	if got := FormatSidebarLimit(p, sidebarNowMs, core.LimitPercentUsed); got != "5h 28%" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -23,7 +35,7 @@ func TestFormatSidebarLimit_UsesWindowDurationInsteadOfSlotOrder(t *testing.T) {
 		Primary:   &LimitWindow{UsedPercentage: 70, WindowMinutes: &seven},
 		Secondary: &LimitWindow{UsedPercentage: 28.4, WindowMinutes: &five},
 	}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 72%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "5h 72%" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -33,7 +45,7 @@ func TestFormatSidebarLimit_UsesSlotOrderWhenDurationsAreMissing(t *testing.T) {
 		Primary:   &LimitWindow{UsedPercentage: 28.4},
 		Secondary: &LimitWindow{UsedPercentage: 70},
 	}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 72%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "5h 72%" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -41,13 +53,13 @@ func TestFormatSidebarLimit_UsesSlotOrderWhenDurationsAreMissing(t *testing.T) {
 func TestFormatSidebarLimit_FallsBackToNextWindow(t *testing.T) {
 	seven := 10080
 	p := ProviderLimits{Secondary: &LimitWindow{UsedPercentage: 41.6, WindowMinutes: &seven}}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "7d 58%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "7d 58%" {
 		t.Fatalf("got %q", got)
 	}
 }
 
 func TestFormatSidebarLimit_NoWindows(t *testing.T) {
-	if got := FormatSidebarLimit(ProviderLimits{}, sidebarNowMs); got != "" {
+	if got := FormatSidebarLimit(ProviderLimits{}, sidebarNowMs, ""); got != "" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -69,7 +81,7 @@ func TestFormatSidebarLimit_KeepsShortestWindowAcrossResetBoundary(t *testing.T)
 			ResetsAt:       &future,
 		},
 	}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 3%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "5h 3%" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -88,7 +100,7 @@ func TestFormatSidebarLimit_ClaudeKeepsFiveHourAtResetBoundary(t *testing.T) {
 	if provider == nil {
 		t.Fatal("expected Claude limits")
 	}
-	if got := FormatSidebarLimit(*provider, sidebarNowMs); got != "5h 87%" {
+	if got := FormatSidebarLimit(*provider, sidebarNowMs, ""); got != "5h 87%" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -96,7 +108,7 @@ func TestFormatSidebarLimit_ClaudeKeepsFiveHourAtResetBoundary(t *testing.T) {
 func TestFormatSidebarLimit_ReturnsShortestWhenAllWindowsPassedReset(t *testing.T) {
 	expired := sidebarNowMs/1000 - 1
 	p := ProviderLimits{Primary: &LimitWindow{UsedPercentage: 97, ResetsAt: &expired}}
-	if got := FormatSidebarLimit(p, sidebarNowMs); got != "5h 3%" {
+	if got := FormatSidebarLimit(p, sidebarNowMs, ""); got != "5h 3%" {
 		t.Fatalf("got %q", got)
 	}
 }

--- a/internal/limits/notifystate.go
+++ b/internal/limits/notifystate.go
@@ -4,25 +4,26 @@
 package limits
 
 import (
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
 
 // NotifyProviderPrimaryLimits checks non-Claude primary windows with default
 // thresholds under the shared notification-state lock.
 func NotifyProviderPrimaryLimits(providers []ProviderLimits, nowMs int64) {
-	NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, nil)
+	NotifyProviderPrimaryLimitsWithThresholds(providers, nowMs, nil, core.LimitPercentRemaining)
 }
 
 // NotifyProviderPrimaryLimitsWithThresholds applies plugin-configured
 // remaining-percent thresholds under the shared notification-state lock.
-func NotifyProviderPrimaryLimitsWithThresholds(providers []ProviderLimits, nowMs int64, thresholds []int) {
+func NotifyProviderPrimaryLimitsWithThresholds(providers []ProviderLimits, nowMs int64, thresholds []int, percent core.LimitPercent) {
 	claudeProfiles := ResolvedClaudeProfiles()
 	ratelimit.WithLockedProviderState(func(current ratelimit.ProviderNotifyStateMap) ratelimit.ProviderNotifyStateMap {
 		cur := ProviderNotifyState{}
 		for k, v := range current {
 			cur[k] = v
 		}
-		next := CheckProviderPrimaryLimitsWithThresholds(providers, cur, nowMs, thresholds, herdrcliShowNotification, claudeProfiles)
+		next := CheckProviderPrimaryLimitsWithThresholds(providers, cur, nowMs, thresholds, herdrcliShowNotification, claudeProfiles, percent)
 		out := ratelimit.ProviderNotifyStateMap{}
 		for k, v := range next {
 			out[k] = v

--- a/internal/limits/primarynotify.go
+++ b/internal/limits/primarynotify.go
@@ -7,6 +7,7 @@
 package limits
 
 import (
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
@@ -23,6 +24,7 @@ func processProvider(
 	nowMs int64,
 	thresholds []int,
 	notify NotifyFunc,
+	percent core.LimitPercent,
 ) *ratelimit.WindowState {
 	primary := provider.Primary
 	if primary == nil || primary.ResetsAt == nil {
@@ -44,6 +46,7 @@ func processProvider(
 		*decision.BucketToNotify,
 		*primary.ResetsAt,
 		nowMs,
+		percent,
 	)
 	return ratelimit.ApplyNotifyResult(previous, decision.NewState, notify(text.Title, text.Body))
 }
@@ -58,6 +61,7 @@ func CheckProviderPrimaryLimitsWithThresholds(
 	thresholds []int,
 	notify NotifyFunc,
 	claudeProfiles []claude.ClaudeProfile,
+	percent core.LimitPercent,
 ) ProviderNotifyState {
 	next := make(ProviderNotifyState, len(current)+len(providers))
 	for k, v := range current {
@@ -68,7 +72,7 @@ func CheckProviderPrimaryLimitsWithThresholds(
 			continue
 		}
 		prev := current[provider.ProviderID]
-		next[provider.ProviderID] = processProvider(provider, prev, nowMs, thresholds, notify)
+		next[provider.ProviderID] = processProvider(provider, prev, nowMs, thresholds, notify, percent)
 	}
 	return next
 }
@@ -81,5 +85,5 @@ func CheckProviderPrimaryLimits(
 	notify NotifyFunc,
 	claudeProfiles []claude.ClaudeProfile,
 ) ProviderNotifyState {
-	return CheckProviderPrimaryLimitsWithThresholds(providers, current, nowMs, nil, notify, claudeProfiles)
+	return CheckProviderPrimaryLimitsWithThresholds(providers, current, nowMs, nil, notify, claudeProfiles, core.LimitPercentRemaining)
 }

--- a/internal/limits/primarynotify_test.go
+++ b/internal/limits/primarynotify_test.go
@@ -6,6 +6,7 @@ package limits
 import (
 	"testing"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/ratelimit"
 )
@@ -143,6 +144,7 @@ func TestCheckProviderPrimaryLimitsWithThresholds_UsesConfiguredBuckets(t *testi
 			return true
 		},
 		defaultClaudeProfiles,
+		"",
 	)
 	if len(notifications) != 0 {
 		t.Fatalf("45%% remaining must not cross a 30%% threshold: %v", notifications)
@@ -164,11 +166,34 @@ func TestCheckProviderPrimaryLimitsWithThresholds_UsesConfiguredBuckets(t *testi
 			return true
 		},
 		defaultClaudeProfiles,
+		"",
 	)
 	if len(notifications) != 1 || notifications[0] != "Codex limit: 30% remaining · resets in 2h 0m" {
 		t.Fatalf("notifications=%v", notifications)
 	}
 	if next["codex"] == nil || next["codex"].NotifiedBucket == nil || *next["codex"].NotifiedBucket != ratelimit.Bucket("30") {
 		t.Fatalf("next=%+v", next["codex"])
+	}
+}
+
+func TestCheckProviderPrimaryLimitsWithThresholds_UsedInvertsToastBody(t *testing.T) {
+	var notifications []string
+	p := notifyTestProvider(func(pl *ProviderLimits) {
+		pl.Primary.UsedPercentage = 85
+	})
+	CheckProviderPrimaryLimitsWithThresholds(
+		[]ProviderLimits{p},
+		ProviderNotifyState{},
+		notifyNowMs,
+		[]int{20},
+		func(title, body string) bool {
+			notifications = append(notifications, title+": "+body)
+			return true
+		},
+		defaultClaudeProfiles,
+		core.LimitPercentUsed,
+	)
+	if len(notifications) != 1 || notifications[0] != "Codex limit: 80% used · resets in 2h 0m" {
+		t.Fatalf("notifications=%v", notifications)
 	}
 }

--- a/internal/ratelimit/format.go
+++ b/internal/ratelimit/format.go
@@ -6,6 +6,8 @@ package ratelimit
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 // WindowKey is a Claude rate-limit window label key.
@@ -45,17 +47,19 @@ func formatDuration(remainingMs int64) string {
 }
 
 // FormatNotificationBody builds Claude window notification text.
-// remainingBucket is the configured remaining-percent threshold.
+// remainingBucket is the configured remaining-percent threshold. percent
+// only changes the rendered number and word; firing still uses remaining.
 func FormatNotificationBody(
 	windowKey WindowKey,
 	remainingBucket Bucket,
 	resetsAtEpochSeconds int64,
 	nowMs int64,
+	percent core.LimitPercent,
 ) NotificationText {
 	remainingMs := resetsAtEpochSeconds*1000 - nowMs
 	return NotificationText{
 		Title: windowLabel[windowKey],
-		Body:  fmt.Sprintf("%s%% remaining · resets in %s", remainingBucket, formatDuration(remainingMs)),
+		Body:  formatLimitBucketBody(remainingBucket, remainingMs, percent),
 	}
 }
 
@@ -65,10 +69,19 @@ func FormatProviderPrimaryNotification(
 	remainingBucket Bucket,
 	resetsAtEpochSeconds int64,
 	nowMs int64,
+	percent core.LimitPercent,
 ) NotificationText {
 	remainingMs := resetsAtEpochSeconds*1000 - nowMs
 	return NotificationText{
 		Title: providerLabel + " limit",
-		Body:  fmt.Sprintf("%s%% remaining · resets in %s", remainingBucket, formatDuration(remainingMs)),
+		Body:  formatLimitBucketBody(remainingBucket, remainingMs, percent),
 	}
+}
+
+func formatLimitBucketBody(remainingBucket Bucket, remainingMs int64, percent core.LimitPercent) string {
+	word := "remaining"
+	if percent.Used() {
+		word = "used"
+	}
+	return fmt.Sprintf("%d%% %s · resets in %s", percent.InvertRemainingBucket(string(remainingBucket)), word, formatDuration(remainingMs))
 }

--- a/internal/ratelimit/format_test.go
+++ b/internal/ratelimit/format_test.go
@@ -3,12 +3,16 @@
  */
 package ratelimit
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+)
 
 func TestFormatNotificationBody_Session(t *testing.T) {
 	nowMs := int64(1_800_000_000_000)
 	resetsAt := nowMs/1000 + 2*3600 + 15*60
-	result := FormatNotificationBody(WindowFiveHour, Bucket20, resetsAt, nowMs)
+	result := FormatNotificationBody(WindowFiveHour, Bucket20, resetsAt, nowMs, "")
 	if result.Title != "Session limit" {
 		t.Fatalf("title=%q", result.Title)
 	}
@@ -20,7 +24,7 @@ func TestFormatNotificationBody_Session(t *testing.T) {
 func TestFormatNotificationBody_Weekly(t *testing.T) {
 	nowMs := int64(1_800_000_000_000)
 	resetsAt := nowMs/1000 + 3*86400 + 4*3600
-	result := FormatNotificationBody(WindowSevenDay, Bucket10, resetsAt, nowMs)
+	result := FormatNotificationBody(WindowSevenDay, Bucket10, resetsAt, nowMs, "")
 	if result.Title != "Weekly limit" {
 		t.Fatalf("title=%q", result.Title)
 	}
@@ -32,7 +36,7 @@ func TestFormatNotificationBody_Weekly(t *testing.T) {
 func TestFormatNotificationBody_MinutesOnly(t *testing.T) {
 	nowMs := int64(1_800_000_000_000)
 	resetsAt := nowMs/1000 + 30*60
-	result := FormatNotificationBody(WindowFiveHour, Bucket5, resetsAt, nowMs)
+	result := FormatNotificationBody(WindowFiveHour, Bucket5, resetsAt, nowMs, "")
 	if result.Body != "5% remaining · resets in 30m" {
 		t.Fatalf("body=%q", result.Body)
 	}
@@ -41,8 +45,29 @@ func TestFormatNotificationBody_MinutesOnly(t *testing.T) {
 func TestFormatNotificationBody_PastReset(t *testing.T) {
 	nowMs := int64(1_800_000_000_000)
 	resetsAt := nowMs/1000 - 100
-	result := FormatNotificationBody(WindowFiveHour, Bucket5, resetsAt, nowMs)
+	result := FormatNotificationBody(WindowFiveHour, Bucket5, resetsAt, nowMs, "")
 	if result.Body != "5% remaining · resets in 0m" {
+		t.Fatalf("body=%q", result.Body)
+	}
+}
+
+func TestFormatNotificationBody_UsedInvertsFiredBucket(t *testing.T) {
+	nowMs := int64(1_800_000_000_000)
+	resetsAt := nowMs/1000 + 2*3600 + 15*60
+	result := FormatNotificationBody(WindowFiveHour, Bucket20, resetsAt, nowMs, core.LimitPercentUsed)
+	if result.Body != "80% used · resets in 2h 15m" {
+		t.Fatalf("body=%q", result.Body)
+	}
+}
+
+func TestFormatProviderPrimaryNotification_UsedInvertsFiredBucket(t *testing.T) {
+	nowMs := int64(1_800_000_000_000)
+	resetsAt := nowMs/1000 + 2*3600
+	result := FormatProviderPrimaryNotification("Codex", Bucket20, resetsAt, nowMs, core.LimitPercentUsed)
+	if result.Title != "Codex limit" {
+		t.Fatalf("title=%q", result.Title)
+	}
+	if result.Body != "80% used · resets in 2h 0m" {
 		t.Fatalf("body=%q", result.Body)
 	}
 }

--- a/internal/ratelimit/run.go
+++ b/internal/ratelimit/run.go
@@ -1,8 +1,11 @@
 /**
  * Reads rate_limits from the statusLine stdin and sends notifications when
- * a window crosses a bucket threshold (5h and 7d).
+ * a window crosses a bucket threshold (5h and 7d). Toast body presentation
+ * follows LimitPercent; bucket decisions stay remaining-based.
  */
 package ratelimit
+
+import "github.com/senna-lang/herdr-agent-usage/internal/core"
 
 // ShowNotificationFn displays a toast; returns whether it was shown.
 type ShowNotificationFn func(title, body string) bool
@@ -15,6 +18,7 @@ func ProcessWindow(
 	nowMs int64,
 	thresholds []int,
 	notify ShowNotificationFn,
+	percent core.LimitPercent,
 ) *WindowState {
 	if input == nil {
 		return previous
@@ -27,7 +31,7 @@ func ProcessWindow(
 		next := decision.NewState
 		return &next
 	}
-	text := FormatNotificationBody(key, *decision.BucketToNotify, input.ResetsAt, nowMs)
+	text := FormatNotificationBody(key, *decision.BucketToNotify, input.ResetsAt, nowMs, percent)
 	shown := false
 	if notify != nil {
 		shown = notify(text.Title, text.Body)
@@ -44,7 +48,7 @@ func RunRateLimitCheck(stdinJSON string, nowMs int64, notify ShowNotificationFn)
 // RunRateLimitCheckIn is RunRateLimitCheck scoped to an explicit per-profile
 // state dir, so two Claude accounts keep independent notify state.
 func RunRateLimitCheckIn(stateDir string, stdinJSON string, nowMs int64, notify ShowNotificationFn) {
-	RunRateLimitCheckWithThresholdsIn(stateDir, stdinJSON, nowMs, nil, notify)
+	RunRateLimitCheckWithThresholdsIn(stateDir, stdinJSON, nowMs, nil, notify, "")
 }
 
 // RunRateLimitCheckWithThresholdsIn applies the configured remaining-percent
@@ -55,6 +59,7 @@ func RunRateLimitCheckWithThresholdsIn(
 	nowMs int64,
 	thresholds []int,
 	notify ShowNotificationFn,
+	percent core.LimitPercent,
 ) {
 	rateLimits := ParseRateLimits(stdinJSON)
 	if rateLimits == nil {
@@ -65,8 +70,8 @@ func RunRateLimitCheckWithThresholdsIn(
 	}
 	WithLockedStateIn(stateDir, func(current ClaudeNotifyState) ClaudeNotifyState {
 		return ClaudeNotifyState{
-			FiveHour: ProcessWindow(WindowFiveHour, rateLimits.FiveHour, current.FiveHour, nowMs, thresholds, notify),
-			SevenDay: ProcessWindow(WindowSevenDay, rateLimits.SevenDay, current.SevenDay, nowMs, thresholds, notify),
+			FiveHour: ProcessWindow(WindowFiveHour, rateLimits.FiveHour, current.FiveHour, nowMs, thresholds, notify, percent),
+			SevenDay: ProcessWindow(WindowSevenDay, rateLimits.SevenDay, current.SevenDay, nowMs, thresholds, notify, percent),
 		}
 	})
 }

--- a/internal/ratelimit/run_test.go
+++ b/internal/ratelimit/run_test.go
@@ -21,6 +21,7 @@ func TestRunRateLimitCheckWithThresholdsInUsesConfiguredBuckets(t *testing.T) {
 			notifications = append(notifications, title+": "+body)
 			return true
 		},
+		"",
 	)
 
 	if len(notifications) != 1 || notifications[0] != "Session limit: 30% remaining · resets in 1157d 9h" {

--- a/internal/ratelimit/summary.go
+++ b/internal/ratelimit/summary.go
@@ -7,24 +7,27 @@ import (
 	"fmt"
 	"math"
 	"strings"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
-// FormatStatusLineSummary formats remaining % for present windows (e.g. "5h:11% 7d:56%").
-func FormatStatusLineSummary(rateLimits *RateLimitsInput) string {
+// FormatStatusLineSummary formats % for present windows (e.g. "5h:11% 7d:56%").
+// percent selects remaining (default) vs used; the number is inverted in used mode.
+func FormatStatusLineSummary(rateLimits *RateLimitsInput, percent core.LimitPercent) string {
 	if rateLimits == nil {
 		return ""
 	}
 	var parts []string
 	if rateLimits.FiveHour != nil {
-		parts = append(parts, fmt.Sprintf("5h:%s", remainingPercentageLabel(rateLimits.FiveHour.UsedPercentage)))
+		parts = append(parts, fmt.Sprintf("5h:%s", percentageLabel(rateLimits.FiveHour.UsedPercentage, percent)))
 	}
 	if rateLimits.SevenDay != nil {
-		parts = append(parts, fmt.Sprintf("7d:%s", remainingPercentageLabel(rateLimits.SevenDay.UsedPercentage)))
+		parts = append(parts, fmt.Sprintf("7d:%s", percentageLabel(rateLimits.SevenDay.UsedPercentage, percent)))
 	}
 	return strings.Join(parts, " ")
 }
 
-func remainingPercentageLabel(usedPercentage float64) string {
-	remaining := 100 - usedPercentage
-	return fmt.Sprintf("%d%%", int(math.Round(remaining)))
+func percentageLabel(usedPercentage float64, percent core.LimitPercent) string {
+	remaining := int(math.Round(100 - usedPercentage))
+	return fmt.Sprintf("%d%%", percent.DisplayPercent(remaining))
 }

--- a/internal/ratelimit/summary_test.go
+++ b/internal/ratelimit/summary_test.go
@@ -3,39 +3,53 @@
  */
 package ratelimit
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
+)
 
 func TestFormatStatusLineSummary(t *testing.T) {
 	got := FormatStatusLineSummary(&RateLimitsInput{
 		FiveHour: &RateWindowInput{UsedPercentage: 89, ResetsAt: 100},
 		SevenDay: &RateWindowInput{UsedPercentage: 44, ResetsAt: 200},
-	})
+	}, "")
 	if got != "5h:11% 7d:56%" {
 		t.Fatalf("%q", got)
 	}
 
 	got = FormatStatusLineSummary(&RateLimitsInput{
 		SevenDay: &RateWindowInput{UsedPercentage: 43.99999999999999, ResetsAt: 200},
-	})
+	}, "")
 	if got != "7d:56%" {
 		t.Fatalf("%q", got)
 	}
 
 	got = FormatStatusLineSummary(&RateLimitsInput{
 		FiveHour: &RateWindowInput{UsedPercentage: 20.3, ResetsAt: 100},
-	})
+	}, "")
 	if got != "5h:80%" {
 		t.Fatalf("%q", got)
 	}
 
 	got = FormatStatusLineSummary(&RateLimitsInput{
 		FiveHour: &RateWindowInput{UsedPercentage: 10, ResetsAt: 100},
-	})
+	}, "")
 	if got != "5h:90%" {
 		t.Fatalf("%q", got)
 	}
 
-	if FormatStatusLineSummary(nil) != "" {
+	if FormatStatusLineSummary(nil, "") != "" {
 		t.Fatal("expected empty")
+	}
+}
+
+func TestFormatStatusLineSummary_UsedPercent(t *testing.T) {
+	got := FormatStatusLineSummary(&RateLimitsInput{
+		FiveHour: &RateWindowInput{UsedPercentage: 89, ResetsAt: 100},
+		SevenDay: &RateWindowInput{UsedPercentage: 44, ResetsAt: 200},
+	}, core.LimitPercentUsed)
+	if got != "5h:89% 7d:44%" {
+		t.Fatalf("%q", got)
 	}
 }

--- a/internal/setup/pluginconfig.go
+++ b/internal/setup/pluginconfig.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/codex"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/grok"
@@ -29,6 +30,10 @@ type PluginConfig struct {
 	RemainingThresholds []int
 	// NotifyEnabled is the plugin-side intent (separate from host toast delivery).
 	NotifyEnabled bool
+	// LimitPercent is the presentation direction for quota percentages.
+	// remaining (default) shows headroom; used shows consumption. Notify
+	// firing still uses remaining thresholds.
+	LimitPercent core.LimitPercent
 	// ClaudeProfiles are the configured [[claude.profiles]] entries (unresolved).
 	// Empty means the single implicit "claude" profile is synthesized downstream.
 	ClaudeProfiles []claude.ProfileSpec
@@ -43,6 +48,7 @@ type PluginConfig struct {
 var DefaultPluginConfig = PluginConfig{
 	RemainingThresholds: append([]int(nil), DefaultRemainingThresholds...),
 	NotifyEnabled:       true,
+	LimitPercent:        core.LimitPercentRemaining,
 }
 
 // pluginConfigWire mirrors the on-disk TOML shape for decoding.
@@ -51,12 +57,16 @@ type pluginConfigWire struct {
 		Enabled             *bool `toml:"enabled"`
 		RemainingThresholds []int `toml:"remaining_thresholds"`
 	} `toml:"notify"`
+	UI struct {
+		LimitPercent *string `toml:"limit_percent"`
+	} `toml:"ui"`
 	Claude struct {
 		Profiles []profileWire `toml:"profiles"`
 	} `toml:"claude"`
 	Codex struct {
 		Profiles []codexProfileWire `toml:"profiles"`
 	} `toml:"codex"`
+
 	Grok struct {
 		Profiles []grokProfileWire `toml:"profiles"`
 	} `toml:"grok"`
@@ -131,7 +141,12 @@ func DefaultPluginConfigTOML(config PluginConfig) string {
 		"# remaining % thresholds that may fire a toast (once per window/bucket)",
 		"remaining_thresholds = [" + thresholds + "]",
 		"",
+		"[ui]",
+		"# remaining (default): % left / higher is safer. used: fill as you burn.",
+		`limit_percent = "` + string(core.ParseLimitPercent(string(config.LimitPercent))) + `"`,
+		"",
 		"# Multi-account Claude: uncomment and add one block per account.",
+
 		"# Absence of any profile keeps the single default account (fully backward",
 		"# compatible). config_dir must be unique per profile and may use ~.",
 		"#",
@@ -203,7 +218,9 @@ func ParsePluginConfigTOML(raw string) PluginConfig {
 	cfg := PluginConfig{
 		NotifyEnabled:       DefaultPluginConfig.NotifyEnabled,
 		RemainingThresholds: append([]int(nil), DefaultPluginConfig.RemainingThresholds...),
+		LimitPercent:        DefaultPluginConfig.LimitPercent,
 	}
+
 	var wire pluginConfigWire
 	if _, err := toml.Decode(raw, &wire); err != nil {
 		return cfg
@@ -214,6 +231,10 @@ func ParsePluginConfigTOML(raw string) PluginConfig {
 	if thr, ok := validThresholds(wire.Notify.RemainingThresholds); ok {
 		cfg.RemainingThresholds = thr
 	}
+	if wire.UI.LimitPercent != nil {
+		cfg.LimitPercent = core.ParseLimitPercent(*wire.UI.LimitPercent)
+	}
+
 	for _, p := range wire.Claude.Profiles {
 		cfg.ClaudeProfiles = append(cfg.ClaudeProfiles, claude.ProfileSpec{
 			ID:        p.ID,

--- a/internal/setup/pluginconfig_test.go
+++ b/internal/setup/pluginconfig_test.go
@@ -8,12 +8,21 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 )
 
 func TestParsePluginConfigTOML_Defaults(t *testing.T) {
-	cfg := ParsePluginConfigTOML(DefaultPluginConfigTOML(DefaultPluginConfig))
+	raw := DefaultPluginConfigTOML(DefaultPluginConfig)
+	if !contains(raw, "[ui]") || !contains(raw, `limit_percent = "remaining"`) {
+		t.Fatalf("seed missing remaining default:\n%s", raw)
+	}
+	cfg := ParsePluginConfigTOML(raw)
 	if !cfg.NotifyEnabled {
 		t.Fatal("expected enabled")
+	}
+	if cfg.LimitPercent != core.LimitPercentRemaining {
+		t.Fatalf("limit_percent=%q", cfg.LimitPercent)
 	}
 	if !reflect.DeepEqual(cfg.RemainingThresholds, []int{50, 20, 10, 5}) {
 		t.Fatalf("thresholds=%v", cfg.RemainingThresholds)
@@ -29,8 +38,31 @@ remaining_thresholds = [30, 10]
 	if cfg.NotifyEnabled {
 		t.Fatal("expected disabled")
 	}
+	if cfg.LimitPercent != core.LimitPercentRemaining {
+		t.Fatal("missing [ui] must stay remaining")
+	}
 	if !reflect.DeepEqual(cfg.RemainingThresholds, []int{30, 10}) {
 		t.Fatalf("thresholds=%v", cfg.RemainingThresholds)
+	}
+}
+
+func TestParsePluginConfigTOML_LimitPercentUsed(t *testing.T) {
+	cfg := ParsePluginConfigTOML(`
+[ui]
+limit_percent = "used"
+`)
+	if cfg.LimitPercent != core.LimitPercentUsed {
+		t.Fatalf("got %q", cfg.LimitPercent)
+	}
+}
+
+func TestParsePluginConfigTOML_LimitPercentInvalidFallsBack(t *testing.T) {
+	cfg := ParsePluginConfigTOML(`
+[ui]
+limit_percent = "burned"
+`)
+	if cfg.LimitPercent != core.LimitPercentRemaining {
+		t.Fatalf("got %q", cfg.LimitPercent)
 	}
 }
 

--- a/internal/update/contextonly_test.go
+++ b/internal/update/contextonly_test.go
@@ -24,7 +24,7 @@ func TestProviderAndLimitText_ContextOnlyProviderHasEmptyLimit(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			providerText, limitText := formatSidebarBillingTokens(
-				limits.BillingUnknown, "cursor", "cursor", nil, tc.totalTokens, tc.totalCostUSD, 1_000)
+				limits.BillingUnknown, "cursor", "cursor", nil, tc.totalTokens, tc.totalCostUSD, 1_000, "")
 			if limitText != "" {
 				t.Errorf("limitText = %q, want empty", limitText)
 			}

--- a/internal/update/publish.go
+++ b/internal/update/publish.go
@@ -12,6 +12,7 @@ package update
 import (
 	"strings"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/herdrcli"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 	"github.com/senna-lang/herdr-agent-usage/internal/providers/claude"
@@ -43,7 +44,7 @@ type LimitPublishTarget struct {
 
 // LimitPublishTargets decides $limit (and multi-profile $context prefix)
 // writes from one collected snapshot. It does not I/O.
-func LimitPublishTargets(providers []limits.ProviderLimits, panes []LimitPublishPane, nowMs int64) []LimitPublishTarget {
+func LimitPublishTargets(providers []limits.ProviderLimits, panes []LimitPublishPane, nowMs int64, percent core.LimitPercent) []LimitPublishTarget {
 	byID := make(map[string]limits.ProviderLimits, len(providers))
 	for _, provider := range providers {
 		byID[provider.ProviderID] = provider
@@ -57,7 +58,7 @@ func LimitPublishTargets(providers []limits.ProviderLimits, panes []LimitPublish
 		if !ok {
 			continue
 		}
-		limitText := limits.FormatSidebarLimit(provider, nowMs)
+		limitText := limits.FormatSidebarLimit(provider, nowMs, percent)
 		if limitText == "" {
 			continue
 		}
@@ -187,5 +188,6 @@ func PublishCollectedLimitsWith(
 		}
 		panes = append(panes, pane)
 	}
-	applyLimitPublishTargets(writer, panes, LimitPublishTargets(providers, panes, nowMs))
+	applyLimitPublishTargets(writer, panes, LimitPublishTargets(providers, panes, nowMs, limits.ResolvedLimitPercent()))
+
 }

--- a/internal/update/publish_test.go
+++ b/internal/update/publish_test.go
@@ -6,6 +6,7 @@ package update
 import (
 	"testing"
 
+	"github.com/senna-lang/herdr-agent-usage/internal/core"
 	"github.com/senna-lang/herdr-agent-usage/internal/limits"
 )
 
@@ -26,7 +27,7 @@ func TestLimitPublishTargets_SubscriptionPaneGetsMatchingProvider(t *testing.T) 
 		BillingMode:      limits.BillingSubscription,
 		LimitsProviderID: "claude",
 	}}
-	got := LimitPublishTargets(providers, panes, 0)
+	got := LimitPublishTargets(providers, panes, 0, "")
 	if len(got) != 1 || got[0].PaneID != "w1:p1" || got[0].LimitToken != "5h 72%" {
 		t.Fatalf("got %#v", got)
 	}
@@ -44,7 +45,7 @@ func TestLimitPublishTargets_TwoPanesSameAccount(t *testing.T) {
 		{PaneID: "w1:p1", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
 		{PaneID: "w1:p2", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
 	}
-	got := LimitPublishTargets(providers, panes, 0)
+	got := LimitPublishTargets(providers, panes, 0, "")
 	if len(got) != 2 {
 		t.Fatalf("len=%d", len(got))
 	}
@@ -62,7 +63,7 @@ func TestLimitPublishTargets_RoutesEachPaneToOwnProvider(t *testing.T) {
 		{PaneID: "p-claude", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "claude"},
 		{PaneID: "p-grok", Resolved: true, BillingMode: limits.BillingSubscription, LimitsProviderID: "grok"},
 	}
-	got := LimitPublishTargets(providers, panes, 0)
+	got := LimitPublishTargets(providers, panes, 0, "")
 	if len(got) != 2 || got[0].LimitToken != "5h 72%" || got[1].LimitToken != "7d 14%" {
 		t.Fatalf("got %#v", got)
 	}
@@ -74,7 +75,7 @@ func TestLimitPublishTargets_SkipsMissingProvider(t *testing.T) {
 		Resolved:         true,
 		BillingMode:      limits.BillingSubscription,
 		LimitsProviderID: "claude",
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 0 {
 		t.Fatalf("got %#v", got)
 	}
@@ -87,7 +88,7 @@ func TestLimitPublishTargets_SkipsEmptyLimit(t *testing.T) {
 		Resolved:         true,
 		BillingMode:      limits.BillingSubscription,
 		LimitsProviderID: "claude",
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 0 {
 		t.Fatalf("empty windows must keep last-known-good, got %#v", got)
 	}
@@ -103,7 +104,7 @@ func TestLimitPublishTargets_SkipsPayAsYouGo(t *testing.T) {
 		Resolved:         true,
 		BillingMode:      limits.BillingPayAsYouGo,
 		LimitsProviderID: "claude",
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 0 {
 		t.Fatalf("PAYG must stay on the event path, got %#v", got)
 	}
@@ -119,7 +120,7 @@ func TestLimitPublishTargets_SkipsUnresolved(t *testing.T) {
 		Resolved:         false,
 		BillingMode:      limits.BillingSubscription,
 		LimitsProviderID: "claude",
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 0 {
 		t.Fatalf("got %#v", got)
 	}
@@ -135,7 +136,7 @@ func TestLimitPublishTargets_UnknownBillingFailOpen(t *testing.T) {
 		Resolved:         true,
 		BillingMode:      limits.BillingUnknown,
 		LimitsProviderID: "opencode",
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 1 || got[0].LimitToken != "5h 80%" {
 		t.Fatalf("unknown billing must fail open, got %#v", got)
 	}
@@ -154,7 +155,7 @@ func TestLimitPublishTargets_MultiProfileMovesPercentToContext(t *testing.T) {
 		MultiProfile:     true,
 		AccountLabel:     "user@example.com",
 		Tokens:           map[string]string{"context": "5h 99% · ⛁ 14% (136k)"},
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 1 {
 		t.Fatalf("len=%d", len(got))
 	}
@@ -177,8 +178,24 @@ func TestLimitPublishTargets_MultiProfileWithoutAccountLabelKeepsLimitRow(t *tes
 		BillingMode:      limits.BillingSubscription,
 		LimitsProviderID: "claude",
 		MultiProfile:     true,
-	}}, 0)
+	}}, 0, "")
 	if len(got) != 1 || got[0].LimitToken != "5h 72%" || got[0].ContextToken != nil {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestLimitPublishTargets_UsedPercentInvertsSidebarNumber(t *testing.T) {
+	providers := []limits.ProviderLimits{{
+		ProviderID: "claude",
+		Primary:    window(28, 300),
+	}}
+	got := LimitPublishTargets(providers, []LimitPublishPane{{
+		PaneID:           "w1:p1",
+		Resolved:         true,
+		BillingMode:      limits.BillingSubscription,
+		LimitsProviderID: "claude",
+	}}, 0, core.LimitPercentUsed)
+	if len(got) != 1 || got[0].LimitToken != "5h 28%" {
 		t.Fatalf("got %#v", got)
 	}
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -147,6 +147,7 @@ func formatSidebarBillingTokens(
 	providerLimits *limits.ProviderLimits,
 	totalTokens, totalCostUSD float64,
 	nowMs int64,
+	percent core.LimitPercent,
 ) (providerText, limitText string) {
 	providerText = fallbackProviderText
 	if billingMode != limits.BillingPayAsYouGo {
@@ -154,7 +155,7 @@ func formatSidebarBillingTokens(
 			providerText = displayProviderID
 		}
 		if providerLimits != nil {
-			limitText = limits.FormatSidebarLimit(*providerLimits, nowMs)
+			limitText = limits.FormatSidebarLimit(*providerLimits, nowMs, percent)
 		}
 		return providerText, limitText
 	}
@@ -281,7 +282,7 @@ func RunUpdateForPane(paneID string, force bool) {
 	fallbackProviderText := formatSidebarProvider(*pane.Agent, p.AgentID(), snapshot)
 	providerText, limitText := formatSidebarBillingTokens(
 		billingMode, fallbackProviderText, displayProviderID,
-		providerLimits, totalTokens, totalCostUSD, nowMs,
+		providerLimits, totalTokens, totalCostUSD, nowMs, limits.ResolvedLimitPercent(),
 	)
 
 	// With 2+ configured accounts of the same family, the $limit row's job

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -264,7 +264,7 @@ func TestSidebarSecondRowContract(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			providerText, limitText := formatSidebarBillingTokens(
 				tt.mode, tt.fallback, tt.display, tt.providerLimits,
-				tt.tokens, tt.cost, 1_800_000_000_000,
+				tt.tokens, tt.cost, 1_800_000_000_000, "",
 			)
 			if providerText != tt.wantProvider || limitText != tt.wantLim {
 				t.Fatalf("got provider=%q limit=%q, want provider=%q limit=%q", providerText, limitText, tt.wantProvider, tt.wantLim)


### PR DESCRIPTION
Fixes #70

Add `[ui] limit_percent = "remaining" | "used"` (default remaining) so quota percentages can render as consumption.

- Pane, sidebar `$limit`, statusLine, and toast body follow the flag
- Bar fill inverts in used mode; `ToneForRemaining` does not
- `notify.remaining_thresholds` keep remaining semantics; toast inverts the fired bucket (`20` remaining → `80% used`)
- Presentation-only: `UsedPercentage` and notify firing are unchanged

Verified with `gofmt -l .`, `go vet ./...`, `go test ./...`, `go build ./...`, and a live Herdr pane (`7d 70%` remaining ↔ `7d 31%` used).