### PR TITLE
chore(release): prepare v0.5.13

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "usagebar"
 name = "Agent Usage"
-version = "0.5.12"
+version = "0.5.13"
 # [[startup]] hooks landed in Herdr 0.7.5. Sidebar tokens still require 0.7.4+.
 min_herdr_version = "0.7.5"
 description = "Sidebar context meters, provider limit windows, and rate-limit toasts for Claude, Codex, OpenCode Go, OMP, Pi coding agent, and Grok, plus context meters for Cursor"


### PR DESCRIPTION
Bump herdr-plugin.toml to v0.5.13 for the reviewed main changes after v0.5.12.